### PR TITLE
Refactor Azure Table Storage to use repository pattern exclusively

### DIFF
--- a/shared/repositories/__init__.py
+++ b/shared/repositories/__init__.py
@@ -3,6 +3,7 @@ Repository pattern for database access
 Centralizes all TableStorage operations and provides type-safe, indexed queries
 """
 
+from .audit import AuditRepository
 from .base import BaseRepository
 from .config import ConfigRepository
 from .executions import ExecutionRepository
@@ -14,6 +15,7 @@ from .scoped_repository import ScopedRepository
 from .users import UserRepository
 
 __all__ = [
+    "AuditRepository",
     "BaseRepository",
     "ScopedRepository",
     "ExecutionRepository",

--- a/shared/repositories/audit.py
+++ b/shared/repositories/audit.py
@@ -1,0 +1,238 @@
+"""
+Audit Repository
+Manages audit log entries with date-based partitioning
+"""
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from .base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class AuditRepository(BaseRepository):
+    """
+    Repository for audit log entries
+
+    Audit logs are stored in AuditLog table with:
+    - PartitionKey: Date in YYYY-MM-DD format (for time-range queries)
+    - RowKey: Reverse timestamp + UUID (for chronological sorting)
+    - EventType: Type of audit event
+    - Event-specific fields
+    """
+
+    def __init__(self):
+        """Initialize audit repository without context (uses GLOBAL table)"""
+        super().__init__("AuditLog", context=None)
+
+    def log_event(self, event_type: str, data: dict[str, Any]) -> None:
+        """
+        Log an audit event to table storage
+
+        Args:
+            event_type: Type of audit event
+            data: Event-specific data fields
+
+        Raises:
+            Exception: If logging fails
+        """
+        now = datetime.now(UTC)
+        entity = self._create_entity(event_type, now, data)
+
+        try:
+            self.insert(entity)
+            logger.info(
+                f"Audit event logged: {event_type}",
+                extra={'event_type': event_type, 'partition_key': entity['PartitionKey']}
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to log audit event {event_type}: {e}",
+                exc_info=True
+            )
+            raise
+
+    def log_function_key_access(
+        self,
+        key_id: str,
+        key_name: str,
+        org_id: str,
+        endpoint: str,
+        method: str,
+        remote_addr: str,
+        user_agent: str,
+        status_code: int,
+        details: dict[str, Any] | None = None
+    ) -> None:
+        """
+        Log function key authentication usage
+
+        Args:
+            key_id: Function key identifier
+            key_name: Friendly key name
+            org_id: Target organization ID
+            endpoint: API endpoint path
+            method: HTTP method
+            remote_addr: Client IP address
+            user_agent: Client user agent string
+            status_code: HTTP response status
+            details: Additional context (JSON-serializable)
+        """
+        self.log_event(
+            event_type="function_key_access",
+            data={
+                "KeyId": key_id,
+                "KeyName": key_name,
+                "OrgId": org_id,
+                "Endpoint": endpoint,
+                "Method": method,
+                "RemoteAddr": remote_addr,
+                "UserAgent": user_agent,
+                "StatusCode": status_code,
+                "Details": json.dumps(details) if details else None
+            }
+        )
+
+    def log_cross_org_access(
+        self,
+        user_id: str,
+        target_org_id: str,
+        endpoint: str,
+        method: str,
+        remote_addr: str,
+        status_code: int,
+        details: dict[str, Any] | None = None
+    ) -> None:
+        """
+        Log PlatformAdmin cross-organization access
+
+        Args:
+            user_id: Admin user ID
+            target_org_id: Organization being accessed
+            endpoint: API endpoint path
+            method: HTTP method
+            remote_addr: Client IP address
+            status_code: HTTP response status
+            details: Additional context (reason, support ticket, etc.)
+        """
+        self.log_event(
+            event_type="cross_org_access",
+            data={
+                "UserId": user_id,
+                "OrgId": target_org_id,
+                "Endpoint": endpoint,
+                "Method": method,
+                "RemoteAddr": remote_addr,
+                "StatusCode": status_code,
+                "Details": json.dumps(details) if details else None
+            }
+        )
+
+    def log_import_violation_attempt(
+        self,
+        blocked_module: str,
+        workspace_file: str,
+        stack_trace: list[str] | None = None
+    ) -> None:
+        """
+        Log attempted workspace→engine import violation
+
+        Args:
+            blocked_module: Module name that was blocked
+            workspace_file: Source file that attempted import
+            stack_trace: Python stack trace (file:line format)
+        """
+        self.log_event(
+            event_type="engine_violation_attempt",
+            data={
+                "BlockedModule": blocked_module,
+                "WorkspaceFile": workspace_file,
+                "Details": json.dumps({
+                    "stack_trace": stack_trace or []
+                })
+            }
+        )
+
+    def query_by_date_range(
+        self,
+        start_date: datetime,
+        end_date: datetime,
+        event_type: str | None = None
+    ) -> list[dict]:
+        """
+        Query audit logs by date range
+
+        Args:
+            start_date: Start date (inclusive)
+            end_date: End date (inclusive)
+            event_type: Optional filter by event type
+
+        Returns:
+            List of audit log entities
+        """
+        # Build list of partition keys (dates) to query
+        current = start_date.date()
+        end = end_date.date()
+
+        results = []
+        while current <= end:
+            partition_key = current.strftime("%Y-%m-%d")
+
+            # Build filter
+            filter_query = f"PartitionKey eq '{partition_key}'"
+            if event_type:
+                filter_query += f" and EventType eq '{event_type}'"
+
+            # Query this partition
+            results.extend(list(self.query(filter_query)))
+
+            # Move to next day
+            from datetime import timedelta
+            current += timedelta(days=1)
+
+        logger.info(
+            f"Found {len(results)} audit log entries from {start_date.date()} to {end_date.date()}"
+        )
+        return results
+
+    def _create_entity(
+        self,
+        event_type: str,
+        timestamp: datetime,
+        data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Create AuditLog table entity
+
+        Args:
+            event_type: Type of audit event
+            timestamp: Event timestamp (UTC)
+            data: Event-specific data
+
+        Returns:
+            Dictionary representing table entity
+        """
+        # PartitionKey: Date in YYYY-MM-DD format
+        partition_key = timestamp.strftime("%Y-%m-%d")
+
+        # RowKey: Reverse timestamp + UUID for chronological sorting
+        # Reverse timestamp ensures newest first when querying partition
+        max_ticks = 9999999999999  # Max value for sorting
+        ticks = int(timestamp.timestamp() * 1000)  # milliseconds
+        reverse_ticks = max_ticks - ticks
+        row_key = f"{reverse_ticks}_{uuid.uuid4().hex}"
+
+        # Build entity
+        entity = {
+            "PartitionKey": partition_key,
+            "RowKey": row_key,
+            "EventType": event_type,
+            "Timestamp": timestamp.isoformat(),
+            **data  # Merge event-specific fields
+        }
+
+        return entity

--- a/shared/repositories/config.py
+++ b/shared/repositories/config.py
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _MockGlobalContext:
+    """Mock context for GLOBAL-only operations (workflow keys)"""
+    def __init__(self):
+        self.org_id = "GLOBAL"
+        self.scope = "GLOBAL"
+        self.caller = None
+
+
 class ConfigRepository(ScopedRepository):
     """
     Repository for configuration key-value pairs
@@ -287,3 +295,182 @@ class ConfigRepository(ScopedRepository):
             updatedAt=updated_at,
             updatedBy=cast(str, entity.get("UpdatedBy", "")),
         )
+
+    # Workflow Key Methods
+
+    def create_workflow_key(self, entity: dict) -> dict:
+        """
+        Create a workflow API key in Config table
+
+        Args:
+            entity: Workflow key entity with all required fields
+
+        Returns:
+            Created entity
+        """
+        # Ensure PartitionKey is GLOBAL for workflow keys
+        entity["PartitionKey"] = "GLOBAL"
+        return self.insert(entity)
+
+    def get_workflow_key_by_id(self, key_id: str) -> dict | None:
+        """
+        Get workflow key by ID, checking both possible prefixes
+
+        Args:
+            key_id: Workflow key ID
+
+        Returns:
+            Entity dictionary or None if not found
+        """
+        # Try workflow-specific prefix first
+        entity = self.get_by_id("GLOBAL", f"workflowkey:{key_id}")
+        if entity:
+            return entity
+
+        # Try global key prefix
+        return self.get_by_id("GLOBAL", f"systemconfig:globalkey:{key_id}")
+
+    def list_workflow_keys(
+        self,
+        created_by: str,
+        workflow_id: str | None = None,
+        include_revoked: bool = False
+    ) -> list[dict]:
+        """
+        List workflow API keys for a user
+
+        Args:
+            created_by: User email/ID that created the keys
+            workflow_id: Optional filter by workflow ID
+            include_revoked: Include revoked keys
+
+        Returns:
+            List of workflow key entities
+        """
+        results = []
+
+        # Build base filter for created_by
+        base_filter = f"CreatedBy eq '{created_by}'"
+        if not include_revoked:
+            base_filter += " and Revoked eq false"
+        if workflow_id:
+            base_filter += f" and WorkflowId eq '{workflow_id}'"
+
+        # Query workflow-specific keys
+        workflow_filter = f"PartitionKey eq 'GLOBAL' and RowKey ge 'workflowkey:' and RowKey lt 'workflowkey;' and {base_filter}"
+        results.extend(list(self.query(workflow_filter)))
+
+        # Query global keys (only if no workflow_id filter)
+        if not workflow_id:
+            global_filter = f"PartitionKey eq 'GLOBAL' and RowKey ge 'systemconfig:globalkey:' and RowKey lt 'systemconfig:globalkey;' and {base_filter}"
+            results.extend(list(self.query(global_filter)))
+
+        logger.info(f"Found {len(results)} workflow keys for {created_by}")
+        return results
+
+    def revoke_workflow_key(self, key_id: str, revoked_by: str) -> bool:
+        """
+        Revoke a workflow API key
+
+        Args:
+            key_id: Workflow key ID
+            revoked_by: User email/ID revoking the key
+
+        Returns:
+            True if revoked, False if not found
+        """
+        entity = self.get_workflow_key_by_id(key_id)
+        if not entity:
+            return False
+
+        # Update revocation fields
+        entity["Revoked"] = True
+        entity["RevokedAt"] = datetime.utcnow().isoformat()
+        entity["RevokedBy"] = revoked_by
+
+        self.update(entity, mode="merge")
+
+        logger.info(f"Revoked workflow key {key_id} by {revoked_by}")
+        return True
+
+    def validate_workflow_key(
+        self,
+        hashed_key: str,
+        workflow_id: str | None = None
+    ) -> tuple[bool, str | None]:
+        """
+        Validate workflow API key and update last used timestamp
+
+        Args:
+            hashed_key: SHA256 hash of the API key
+            workflow_id: Optional workflow ID for scoped validation
+
+        Returns:
+            Tuple of (is_valid, key_id)
+        """
+        # Step 1: Try workflow-specific key if workflow_id provided
+        if workflow_id:
+            workflow_filter = (
+                f"PartitionKey eq 'GLOBAL' and RowKey ge 'workflowkey:' and RowKey lt 'workflowkey;' "
+                f"and HashedKey eq '{hashed_key}' and WorkflowId eq '{workflow_id}' and Revoked eq false"
+            )
+            workflow_results = list(self.query(workflow_filter))
+
+            if workflow_results:
+                key_entity = workflow_results[0]
+
+                # Check if revoked (extra safety)
+                if key_entity.get("Revoked", False):
+                    return (False, None)
+
+                # Check DisableGlobalKey flag
+                disable_global = key_entity.get("DisableGlobalKey", False)
+
+                # Update last used
+                key_entity["LastUsedAt"] = datetime.utcnow().isoformat()
+                self.update(key_entity, mode="merge")
+
+                key_id = key_entity.get("KeyId", key_entity["RowKey"].split(":", 1)[1])
+
+                if disable_global:
+                    # This key disables global key fallback
+                    return (True, key_id)
+                else:
+                    # Accept this key
+                    return (True, key_id)
+
+        # Step 2: Try global keys
+        global_filter = (
+            f"PartitionKey eq 'GLOBAL' and RowKey ge 'systemconfig:globalkey:' and RowKey lt 'systemconfig:globalkey;' "
+            f"and HashedKey eq '{hashed_key}' and Revoked eq false"
+        )
+        global_results = list(self.query(global_filter))
+
+        if not global_results:
+            return (False, None)
+
+        key_entity = global_results[0]
+
+        # Check if revoked
+        if key_entity.get("Revoked", False):
+            return (False, None)
+
+        # Update last used
+        key_entity["LastUsedAt"] = datetime.utcnow().isoformat()
+        self.update(key_entity, mode="merge")
+
+        key_id = key_entity.get("KeyId", key_entity["RowKey"].split(":", 2)[2])
+
+        return (True, key_id)
+
+
+def get_global_config_repository() -> ConfigRepository:
+    """
+    Get a ConfigRepository instance for GLOBAL-scoped operations
+
+    Use this for workflow key operations that don't have a user context.
+
+    Returns:
+        ConfigRepository with GLOBAL scope
+    """
+    return ConfigRepository(_MockGlobalContext())  # type: ignore[arg-type]


### PR DESCRIPTION
All Azure Table client usage now goes through repository pattern, removing direct TableClient/TableServiceClient usage outside of the storage layer.

Changes:
- Add workflow key methods to ConfigRepository (create, get, list, revoke, validate)
- Create AuditRepository for structured audit logging
- Add _MockGlobalContext and get_global_config_repository() helper for GLOBAL-scoped operations
- Refactor shared/workflow_keys.py to use ConfigRepository instead of direct table clients
- Refactor shared/handlers/workflow_keys_handlers.py to use repository methods
- Refactor shared/audit.py to use AuditRepository instead of direct table client
- Export AuditRepository in shared/repositories/__init__.py

Benefits:
- Single abstraction layer for all table storage operations
- Easier to swap storage backends in future (e.g., Cosmos DB)
- Consistent error handling and logging
- Better separation of concerns

All Azure Table Storage usage now properly isolated to:
- shared/storage.py (TableStorageService - base abstraction)
- shared/repositories/* (Repository pattern implementations)
- Utility scripts (seed_data.py, clear_data.py, init_tables.py)
- Test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)