### PR TITLE
Fix SDK file operations, secret decryption, and minor UI issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,10 @@ Desktop.ini
 # Linux
 *~
 
+# ==================== CLAUDE CODE ====================
+.claude/
+.mcp.json
+
 # ==================== OTHERS ====================
 
 AzuriteConfig

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -369,7 +369,13 @@ async def cli_get_config(
         raw_value = cache_entry.get("value")
         config_type = cache_entry.get("type", "string")
 
-        if config_type == "json" and isinstance(raw_value, str):
+        if config_type == "secret" and raw_value:
+            from src.core.security import decrypt_secret
+            try:
+                raw_value = decrypt_secret(raw_value)
+            except Exception:
+                raw_value = None
+        elif config_type == "json" and isinstance(raw_value, str):
             try:
                 raw_value = json.loads(raw_value)
             except json.JSONDecodeError:

--- a/client/src/pages/settings/Email.tsx
+++ b/client/src/pages/settings/Email.tsx
@@ -283,7 +283,7 @@ export function Email() {
 								</SelectTrigger>
 								<SelectContent>
 									{activeWorkflows.length === 0 ? (
-										<SelectItem value="" disabled>
+										<SelectItem value="__empty" disabled>
 											No workflows available
 										</SelectItem>
 									) : (

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -197,6 +197,15 @@ export default defineConfig({
 				target: process.env.API_URL || "http://localhost:8000",
 				changeOrigin: true,
 			},
+			// Proxy API docs (Swagger UI and ReDoc)
+			"/docs": {
+				target: process.env.API_URL || "http://localhost:8000",
+				changeOrigin: true,
+			},
+			"/redoc": {
+				target: process.env.API_URL || "http://localhost:8000",
+				changeOrigin: true,
+			},
 			// Proxy OpenAPI spec for type generation
 			"/openapi.json": {
 				target: process.env.API_URL || "http://localhost:8000",


### PR DESCRIPTION
  ## Summary

  - **fix: resolve double `_repo/` prefix and binary file write crash in SDK file ops** — `S3Backend` was
  double-prefixing workspace paths with `_repo/`, causing all SDK file operations (`files.read`, `files.write`, etc.) to
   404 during workflow execution. Also fixes binary file writes (PPTX, PNG) crashing on null bytes in PostgreSQL text
  columns.
  - **fix: decrypt secret config values in SDK `config.get()` endpoint** — The `/api/cli/config/get` endpoint returned
  raw Fernet-encrypted blobs for secret-type values instead of decrypting them, breaking workflows that read API keys
  and credentials via the SDK.
  - **fix: use non-empty placeholder value for disabled SelectItem in Email settings** — Radix UI `SelectItem` does not
  allow empty string as value.
  - **feat: proxy /docs and /redoc through Vite dev server** — Makes Swagger UI and ReDoc accessible at `localhost:3000`
   during development.
  - **chore: add `.claude/` and `.mcp.json` to `.gitignore`**

  ## Test plan

  - [x] Verified SDK `files.read()` and `files.write()` work in workflow executions (cloud mode)
  - [x] Verified binary file writes (PPTX) succeed without PostgreSQL encoding errors
  - [x] Verified `config.get()` returns decrypted plaintext for secret-type config values
  - [x] Verified Email settings page renders without SelectItem errors