### PR TITLE
fix: allow permanent deletion of inactive forms

### DIFF
--- a/client/src/hooks/useForms.ts
+++ b/client/src/hooks/useForms.ts
@@ -224,10 +224,13 @@ export function useDeleteForm() {
 	const queryClient = useQueryClient();
 
 	return $api.useMutation("delete", "/api/forms/{form_id}", {
-		onSuccess: () => {
+		onSuccess: (_data, variables) => {
 			queryClient.invalidateQueries({ queryKey: ["get", "/api/forms"] });
-			toast.success("Form deleted", {
-				description: "The form has been deactivated",
+			const purged = variables?.params?.query?.purge;
+			toast.success(purged ? "Form permanently removed" : "Form deleted", {
+				description: purged
+					? "The form has been permanently removed from the database"
+					: "The form has been deactivated",
 			});
 		},
 		onError: (error) => {

--- a/client/src/pages/Forms.tsx
+++ b/client/src/pages/Forms.tsx
@@ -131,15 +131,20 @@ export function Forms() {
 		navigate(`/forms/${formId}/edit`);
 	};
 
-	const handleDelete = (formId: string, formName: string) => {
-		setSelectedForm({ id: formId, name: formName, isActive: false });
+	const handleDelete = (formId: string, formName: string, isActive: boolean) => {
+		setSelectedForm({ id: formId, name: formName, isActive });
 		setIsDeleteDialogOpen(true);
 	};
 
 	const handleConfirmDelete = async () => {
 		if (!selectedForm) return;
+		// If the form is already inactive, purge it permanently
+		const purge = !selectedForm.isActive;
 		await deleteForm.mutateAsync({
-			params: { path: { form_id: selectedForm.id } },
+			params: {
+				path: { form_id: selectedForm.id },
+				query: { purge },
+			},
 		});
 		setIsDeleteDialogOpen(false);
 		setSelectedForm(null);
@@ -450,6 +455,7 @@ export function Forms() {
 														handleDelete(
 															form.id,
 															form.name,
+															form.is_active,
 														)
 													}
 													title="Delete form"
@@ -629,6 +635,7 @@ export function Forms() {
 																	handleDelete(
 																		form.id,
 																		form.name,
+																		form.is_active,
 																	)
 																}
 																title="Delete form"
@@ -736,10 +743,9 @@ export function Forms() {
 					<AlertDialogHeader>
 						<AlertDialogTitle>Are you sure?</AlertDialogTitle>
 						<AlertDialogDescription>
-							This will permanently delete the form "
-							{selectedForm?.name}". This action cannot be undone.
-							Users will no longer be able to access or execute
-							this form.
+							{selectedForm && !selectedForm.isActive
+								? `This will permanently remove the inactive form "${selectedForm.name}" from the database. This action cannot be undone.`
+								: `This will deactivate the form "${selectedForm?.name}". Users will no longer be able to access or execute this form.`}
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>


### PR DESCRIPTION
## Summary
- Inactive forms were stuck in the database after soft-delete because only `is_active` was set to `false` with no path to fully remove them. This caused duplicate forms (e.g. two "Generate Renewal Quote" entries) where the inactive copy could never be cleaned up.
- Added a `purge` query parameter to `DELETE /forms/{form_id}`. When `purge=true`, the form and its related records (roles, fields) are hard-deleted from the database, and execution references are unlinked (set to NULL).
- Default behavior (`purge=false`) is unchanged — still a soft delete.
- Frontend automatically uses `purge=true` when deleting an already-inactive form, with updated confirmation dialog messaging and toast notifications.

## Changes
- **`api/src/routers/forms.py`** — Added `purge` query param to delete endpoint. When true: unlinks executions, deletes form_roles, hard-deletes the form (form_fields cascade via ORM).
- **`client/src/pages/Forms.tsx`** — `handleDelete` passes form's `is_active` status; `handleConfirmDelete` sets `purge=true` for already-inactive forms; dialog messaging updated for both cases.
- **`client/src/hooks/useForms.ts`** — `useDeleteForm` toast reflects whether form was purged or deactivated.

## Test plan
- [ ] Delete an active form — verify it soft-deletes (sets `is_active=false`, form still in DB)
- [ ] Delete an already-inactive form — verify it's permanently removed from DB
- [ ] Verify executions that referenced the purged form still exist with `form_id=NULL`
- [ ] Verify form_roles and form_fields are cleaned up on purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)