### PR TITLE
fix: checkbox default_value not persisting in form builder

### DIFF
--- a/client/src/components/forms/FormRenderer.tsx
+++ b/client/src/components/forms/FormRenderer.tsx
@@ -765,6 +765,7 @@ function FormRendererInner({
 						<div className="flex items-center space-x-2">
 							<Checkbox
 								id={field.name}
+								checked={watch(field.name) as boolean}
 								onCheckedChange={(checked) =>
 									setValue(field.name, checked, {
 										shouldValidate: true,


### PR DESCRIPTION
## Summary
- Fix `defaultValue || null` in FieldConfigDialog dropping falsy values (false, 0) — now uses type-aware serialization for checkboxes vs other field types
- Render a toggle checkbox for "Default Value" when field type is checkbox, instead of a text input
- Bind `checked={watch(field.name)}` on FormRenderer Checkbox so `default_value` is visually applied on form render

## Test plan
- [ ] Create a checkbox field, set default to checked, save — verify it persists after reopening the field config
- [ ] Create a checkbox field, set default to unchecked, save — verify it persists as unchecked
- [ ] Open a form with a checkbox that has `default_value: true` — verify it renders checked
- [ ] Switch a field type from text to checkbox — verify default value resets to unchecked toggle
- [ ] Switch a field type from checkbox to text — verify default value resets to empty text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)
