### PR TITLE
fix: wire allow_as_query_param through backend

### DIFF
--- a/api/alembic/versions/20260218_add_form_field_allow_as_query_param.py
+++ b/api/alembic/versions/20260218_add_form_field_allow_as_query_param.py
@@ -1,0 +1,28 @@
+"""Add allow_as_query_param boolean column to form_fields table.
+
+Enables per-field control of whether a field's value can be populated
+from URL query parameters.
+
+Revision ID: 20260218_allow_qp
+Revises: 20260218_oauth_audience
+Create Date: 2026-02-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260218_allow_qp"
+down_revision = "20260218_oauth_audience"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "form_fields",
+        sa.Column("allow_as_query_param", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("form_fields", "allow_as_query_param")

--- a/api/alembic/versions/20260218_add_form_field_allow_as_query_param.py
+++ b/api/alembic/versions/20260218_add_form_field_allow_as_query_param.py
@@ -4,7 +4,7 @@ Enables per-field control of whether a field's value can be populated
 from URL query parameters.
 
 Revision ID: 20260218_allow_qp
-Revises: 20260218_oauth_audience
+Revises: 20260220_global_app_slugs
 Create Date: 2026-02-18
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20260218_allow_qp"
-down_revision = "20260218_oauth_audience"
+down_revision = "20260220_global_app_slugs"
 branch_labels = None
 depends_on = None
 

--- a/api/src/models/contracts/forms.py
+++ b/api/src/models/contracts/forms.py
@@ -274,6 +274,7 @@ class FormPublic(BaseModel):
                     multiple=field.multiple,
                     max_size_mb=field.max_size_mb,
                     content=field.content,
+                    allow_as_query_param=field.allow_as_query_param,
                 )
                 form_fields.append(form_field)
 

--- a/api/src/models/orm/forms.py
+++ b/api/src/models/orm/forms.py
@@ -64,6 +64,9 @@ class FormField(Base):
     # For markdown/html fields
     content: Mapped[str | None] = mapped_column(Text, default=None)
 
+    # Allow field value to be populated from URL query parameters
+    allow_as_query_param: Mapped[bool | None] = mapped_column(Boolean, default=None)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), server_default=text("NOW()")
     )

--- a/api/src/routers/forms.py
+++ b/api/src/routers/forms.py
@@ -93,6 +93,7 @@ def _form_schema_to_fields(form_schema: dict, form_id: UUID) -> list[FormFieldOR
             multiple=field.multiple,
             max_size_mb=field.max_size_mb,
             content=field.content,
+            allow_as_query_param=field.allow_as_query_param,
         )
         fields.append(field_orm)
 

--- a/api/src/services/file_storage/indexers/form.py
+++ b/api/src/services/file_storage/indexers/form.py
@@ -258,6 +258,7 @@ class FormIndexer:
                     multiple=form_field.multiple,
                     max_size_mb=form_field.max_size_mb,
                     content=form_field.content,
+                    allow_as_query_param=form_field.allow_as_query_param,
                 )
                 self.db.add(field_orm)
 

--- a/api/tests/e2e/api/test_forms.py
+++ b/api/tests/e2e/api/test_forms.py
@@ -567,8 +567,7 @@ async def e2e_form_test_dp(org_id: str | None = None):
         assert text_field.get("help_text") == "This is help text for the field", "help_text not preserved"
         assert text_field.get("default_value") == "default_text", "default_value not preserved"
         assert text_field.get("required") is True, "required not preserved"
-        # Note: allow_as_query_param is in the contract but not yet in the database schema
-        # This would require a migration to add the column - skipping for now
+        assert text_field.get("allow_as_query_param") is True, "allow_as_query_param not preserved"
 
     def test_form_static_options_preserved(self, comprehensive_form):
         """Verify static options on select/radio fields are preserved."""


### PR DESCRIPTION
## Summary
- The `allow_as_query_param` field was defined in the Pydantic `FormField` contract and the column exists in the database, but was never mapped in the ORM model or passed through the router/serializer
- This caused the form builder's "Allow as query parameter" toggle to silently drop the value on save
- Adds the ORM column mapping, wires it through `_form_schema_to_fields()` and `compute_form_schema()`, and includes an alembic migration for fresh installs

## Test plan
- [ ] Open form builder, toggle "Allow as query parameter" on a field, save the form
- [ ] Reload the form and verify the toggle state persists
- [ ] Create a new form with the toggle enabled and verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)