### PR TITLE
fix: add Cache-Control headers to nginx API proxy

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -22,6 +22,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
     # API proxy - main application endpoints
@@ -36,6 +37,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 300s;
         proxy_connect_timeout 75s;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
     # Auth callback routes - handled client-side by React Router (SSO login callbacks)
@@ -52,6 +54,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
     # WebSocket proxy - real-time updates
@@ -129,8 +132,10 @@ server {
     }
 
     # SPA fallback - serve index.html for client-side routing
+    # index.html must not be cached so new deploys serve fresh JS/CSS references
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
     }
 
     # Static assets caching


### PR DESCRIPTION
## Summary

- Add `Cache-Control: no-store, no-cache, must-revalidate` to `/api`, `/api/auth`, and `/auth` proxy locations in the client nginx config
- Add `Cache-Control: no-cache` to the SPA fallback (`/`) so `index.html` is always revalidated on new deploys

## Problem

Without explicit `Cache-Control` headers on API proxy responses, browsers may apply default caching heuristics to `GET` requests (e.g., `GET /api/forms/{id}`). This can cause stale form definitions, workflow configs, and other API data to be served from browser cache after updates — leading to confusing bugs where the backend has correct data but the UI shows outdated state.

## Test plan

- [ ] Verify API responses include `Cache-Control: no-store, no-cache, must-revalidate` header (check in browser DevTools Network tab)
- [ ] Verify `index.html` includes `Cache-Control: no-cache` header
- [ ] Verify static assets (`.js`, `.css`, etc.) still return `Cache-Control: public, immutable` with 1-year expiry
- [ ] Verify form data providers return fresh data after form edits without requiring a hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)