### PR TITLE
draft: propose source-backed integration definitions

### DIFF
--- a/api/bifrost/integration_definition.py
+++ b/api/bifrost/integration_definition.py
@@ -1,0 +1,109 @@
+"""
+Source-backed integration definition helpers.
+
+This is a bridge layer for the fork's `.bifrost/` convergence work. It models a
+portable integration definition file that can live in normal repo source, while
+leaving runtime state (mappings, secrets, tokens, org-specific config) in the
+database.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class SourceIntegrationConfigSchema(BaseModel):
+    """Portable config schema item for a source-backed integration definition."""
+
+    key: str = Field(description="Config key name")
+    type: str = Field(description="string | int | bool | json | secret")
+    required: bool = Field(default=False, description="Whether this config must be set")
+    description: str | None = Field(default=None, description="Human-readable description")
+    options: list[str] | None = Field(default=None, description="Allowed values for string config")
+    position: int = Field(default=0, description="Display order in UI")
+
+
+class SourceOAuthProvider(BaseModel):
+    """Portable OAuth provider definition for a source-backed integration."""
+
+    provider_name: str = Field(description="Provider identifier")
+    display_name: str | None = Field(default=None, description="UI display name")
+    oauth_flow_type: str = Field(default="authorization_code", description="OAuth flow type")
+    client_id: str = Field(
+        default="__NEEDS_SETUP__",
+        description="OAuth client ID sentinel; never store a live secret-bearing client here",
+    )
+    authorization_url: str | None = Field(default=None, description="OAuth authorization endpoint")
+    token_url: str | None = Field(default=None, description="OAuth token endpoint")
+    token_url_defaults: dict | None = Field(default=None, description="Default params for token request")
+    scopes: list[str] = Field(default_factory=list, description="OAuth scopes")
+    redirect_uri: str | None = Field(default=None, description="OAuth redirect URI template")
+
+
+class SourceIntegrationDefinition(BaseModel):
+    """
+    Portable integration definition.
+
+    Deliberately excludes runtime state:
+    - mappings
+    - config values
+    - OAuth tokens
+    - org-specific overrides
+    """
+
+    id: str = Field(description="Integration UUID")
+    name: str = Field(description="Display name")
+    entity_id: str | None = Field(default=None, description="Field name for mapped entity identifier")
+    entity_id_name: str | None = Field(default=None, description="Display label for the entity ID")
+    list_entities_data_provider_id: str | None = Field(
+        default=None,
+        description="Workflow UUID for entity picker",
+    )
+    config_schema: list[SourceIntegrationConfigSchema] = Field(
+        default_factory=list,
+        description="Portable config schema",
+    )
+    oauth_provider: SourceOAuthProvider | None = Field(
+        default=None,
+        description="Portable OAuth provider definition",
+    )
+
+    def to_manifest_dict(self) -> dict:
+        """
+        Convert to the current manifest-shaped integration dict.
+
+        This is an interim bridge for migration work. Runtime-only fields such
+        as mappings are left empty.
+        """
+
+        data = self.model_dump(mode="python", exclude_none=True)
+        data["mappings"] = []
+        return data
+
+
+def load_integration_definition(path: str | Path) -> SourceIntegrationDefinition:
+    """Load one source-backed integration definition file."""
+
+    definition_path = Path(path)
+    data = yaml.safe_load(definition_path.read_text()) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{definition_path} did not contain a mapping")
+    return SourceIntegrationDefinition(**data)
+
+
+def discover_integration_definitions(root: str | Path) -> dict[str, SourceIntegrationDefinition]:
+    """
+    Discover `integrations/*/integration.yaml` files under a repo root.
+
+    Returns a mapping keyed by slug directory name.
+    """
+
+    root_path = Path(root)
+    definitions: dict[str, SourceIntegrationDefinition] = {}
+    for path in sorted(root_path.glob("integrations/*/integration.yaml")):
+        slug = path.parent.name
+        definitions[slug] = load_integration_definition(path)
+    return definitions

--- a/api/tests/unit/sdk/test_integration_definition.py
+++ b/api/tests/unit/sdk/test_integration_definition.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from bifrost.integration_definition import (
+    SourceIntegrationDefinition,
+    discover_integration_definitions,
+    load_integration_definition,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_load_dnsfilter_integration_definition() -> None:
+    definition = load_integration_definition(
+        REPO_ROOT / "integrations" / "dnsfilter" / "integration.yaml"
+    )
+
+    assert isinstance(definition, SourceIntegrationDefinition)
+    assert definition.id == "82252311-d1d6-4d69-b26f-b42989e60d03"
+    assert definition.name == "DNSFilter"
+    assert definition.list_entities_data_provider_id == "41d3fef1-f134-4ca9-a61a-4c9417151647"
+    assert len(definition.config_schema) == 1
+    assert definition.config_schema[0].key == "api_key"
+    assert definition.oauth_provider is None
+
+
+def test_dnsfilter_definition_bridges_to_manifest_shape() -> None:
+    definition = load_integration_definition(
+        REPO_ROOT / "integrations" / "dnsfilter" / "integration.yaml"
+    )
+
+    manifest_dict = definition.to_manifest_dict()
+
+    assert manifest_dict["id"] == definition.id
+    assert manifest_dict["name"] == definition.name
+    assert manifest_dict["mappings"] == []
+    assert manifest_dict["config_schema"][0]["key"] == "api_key"
+
+
+def test_discover_integration_definitions() -> None:
+    definitions = discover_integration_definitions(REPO_ROOT)
+
+    assert "dnsfilter" in definitions
+    assert definitions["dnsfilter"].name == "DNSFilter"

--- a/docs/plans/2026-03-27-manifest-inventory.md
+++ b/docs/plans/2026-03-27-manifest-inventory.md
@@ -1,0 +1,100 @@
+# `.bifrost` Manifest Inventory
+
+**Date:** 2026-03-27
+
+## Purpose
+
+This note records what the fork's tracked `.bifrost` manifests are still
+carrying so the eventual convergence work can be deliberate.
+
+## Current Tracked Files
+
+- `.bifrost/agents.yaml`
+- `.bifrost/apps.yaml`
+- `.bifrost/integrations.yaml`
+- `.bifrost/workflows.yaml`
+
+## Entity Counts
+
+- Workflows: `108`
+- Integrations: `26`
+- Agents: `2`
+- Apps: `1`
+
+## What Is Already Source-Backed
+
+All path-bearing manifest entities currently point at real files:
+
+- Workflows with existing source paths: `108/108`
+- Agents with existing source paths: `2/2`
+- Apps with existing source paths: `1/1`
+
+Workflow path breakdown:
+
+- `features/`: `77`
+- `shared/`: `30`
+- `workflows/`: `1`
+
+The lone legacy-path workflow is:
+
+- `workflows/sample/hello_world.py`
+
+That means the migration risk is not orphaned files. The risk is the metadata
+still living only in the manifest layer.
+
+## Workflow Metadata Still Carried In `.bifrost/workflows.yaml`
+
+Most frequent fields:
+
+- `function_name`: `108`
+- `id`: `108`
+- `name`: `108`
+- `path`: `108`
+- `description`: `106`
+- `type`: `86`
+- `category`: `83`
+- `tags`: `82`
+- `timeout_seconds`: `49`
+- `access_level`: `39`
+- `endpoint_enabled`: `38`
+
+In other words, workflow source files already exist, but the manifest still
+holds the platform registration identity and a large amount of user-facing
+metadata.
+
+## Integration Metadata Still Carried In `.bifrost/integrations.yaml`
+
+Most frequent fields:
+
+- `id`: `26`
+- `mappings`: `26`
+- `name`: `26`
+- `config_schema`: `22`
+- `list_entities_data_provider_id`: `21`
+- `oauth_provider`: `6`
+- `default_entity_id`: `2`
+- `entity_id`: `2`
+- `entity_id_name`: `2`
+
+This is the hardest part of the migration. Unlike workflows, integrations do
+not have a separate entity file today. The manifest is the only place carrying
+most integration registration metadata.
+
+## Migration Implications
+
+The safe migration order is:
+
+1. stop teaching `.bifrost/*.yaml` as authored source-of-truth
+2. inventory and preserve manifest-only metadata
+3. decide where integration metadata should live long-term
+4. only then remove tracked `.bifrost/*.yaml` from the fork's normal authored
+   surface
+
+## Tooling
+
+Use the local audit helper to refresh this inventory:
+
+```bash
+python scripts/audit_manifest_inventory.py
+python scripts/audit_manifest_inventory.py --markdown
+```

--- a/docs/plans/2026-03-27-source-backed-integration-model.md
+++ b/docs/plans/2026-03-27-source-backed-integration-model.md
@@ -1,0 +1,123 @@
+# Source-Backed Integration Definition Model
+
+**Date:** 2026-03-27
+
+## Goal
+
+Converge the fork toward upstream's repo model without inventing a brand-new
+entity system.
+
+The platform already externalizes several entity types into source-backed
+definitions:
+
+- workflows / tools / data providers: Python decorators
+- forms: `.form.yaml`
+- agents: `.agent.yaml`
+- apps: app directory + `app.yaml`
+
+Integrations are the main remaining entity type whose portable definition still
+mostly lives in `.bifrost/integrations.yaml`.
+
+## Recommendation
+
+Add a dedicated source-backed integration definition file and treat
+`.bifrost/integrations.yaml` as generated export only.
+
+Target layout:
+
+```text
+integrations/
+  dnsfilter/
+    integration.yaml
+```
+
+This matches the existing platform pattern better than keeping integrations as a
+special case inside generated manifest YAML.
+
+## What Belongs In `integration.yaml`
+
+Portable definition only:
+
+- `id`
+- `name`
+- `entity_id`
+- `entity_id_name`
+- `list_entities_data_provider_id`
+- `config_schema`
+- `oauth_provider`
+
+The `oauth_provider` block may contain structural defaults such as:
+
+- `provider_name`
+- `display_name`
+- `oauth_flow_type`
+- `authorization_url`
+- `token_url`
+- `token_url_defaults`
+- `scopes`
+- `redirect_uri`
+- `client_id` only as a sentinel like `__NEEDS_SETUP__`
+
+## What Does Not Belong In `integration.yaml`
+
+Runtime or environment-specific state should remain DB-backed:
+
+- mappings
+- config values
+- secrets
+- OAuth tokens
+- org-specific overrides
+
+## Why This Fits Upstream
+
+This follows the model already visible in platform code:
+
+- source/decorator metadata is indexed into DB
+- forms and agents are file-backed and indexed into DB
+- repo sync regenerates `.bifrost/*.yaml` from DB state
+- direct editing of `.bifrost/` is blocked because it is system-generated
+
+So the clean move is not to make `.bifrost/integrations.yaml` more important.
+It is to give integrations a real source-backed home like the other entity
+types already have.
+
+## Pilot Scope
+
+Pilot integration: `DNSFilter`
+
+Why:
+
+- simple config schema
+- no OAuth provider block
+- still exercises `list_entities_data_provider_id`
+
+Pilot file:
+
+- `integrations/dnsfilter/integration.yaml`
+
+Pilot helper code:
+
+- `api/bifrost/integration_definition.py`
+
+Pilot validation:
+
+- `api/tests/unit/sdk/test_integration_definition.py`
+
+## Migration Strategy
+
+1. Define and validate source-backed integration files.
+2. Pilot one low-complexity integration.
+3. Add an integration indexer / serializer path when ready.
+4. Dual-write DB state and integration files during migration.
+5. Only after that, stop treating `.bifrost/integrations.yaml` as authored
+   source.
+
+## Non-Goals For The Pilot
+
+- no runtime import path change yet
+- no manifest import rewrite yet
+- no automatic DB sync from `integrations/*/integration.yaml` yet
+- no deletion of `.bifrost/integrations.yaml` yet
+
+The pilot exists to prove the source-backed file shape before changing platform
+behavior.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,19 @@
+# Source-Backed Integration Definitions
+
+This directory is the pilot home for source-backed integration definitions.
+
+Current status:
+
+- this is a convergence scaffold, not the active runtime import path
+- `.bifrost/integrations.yaml` still exists today
+- these files are intended to become the authored, portable integration
+  definitions once the migration is implemented
+
+Current pilot:
+
+- `dnsfilter/integration.yaml`
+
+See:
+
+- `docs/plans/2026-03-27-source-backed-integration-model.md`
+- `api/bifrost/integration_definition.py`

--- a/integrations/dnsfilter/integration.yaml
+++ b/integrations/dnsfilter/integration.yaml
@@ -1,0 +1,9 @@
+id: 82252311-d1d6-4d69-b26f-b42989e60d03
+name: DNSFilter
+list_entities_data_provider_id: 41d3fef1-f134-4ca9-a61a-4c9417151647
+config_schema:
+  - key: api_key
+    type: secret
+    required: true
+    description: DNSFilter API token from Account Settings
+    position: 0

--- a/scripts/audit_manifest_inventory.py
+++ b/scripts/audit_manifest_inventory.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Audit the tracked .bifrost manifests and summarize how much metadata is still
+carried only in the manifest layer.
+
+Usage:
+    python scripts/audit_manifest_inventory.py
+    python scripts/audit_manifest_inventory.py --markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_DIR = REPO_ROOT / ".bifrost"
+
+
+def load_manifest(name: str, key: str) -> dict[str, dict]:
+    path = MANIFEST_DIR / name
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict) or key not in data or not isinstance(data[key], dict):
+        raise ValueError(f"{path} did not contain a top-level '{key}' mapping")
+    return data[key]
+
+
+def existing_paths(entries: dict[str, dict]) -> tuple[int, list[tuple[str, str, str | None]]]:
+    missing: list[tuple[str, str, str | None]] = []
+    for entry_id, meta in entries.items():
+        path = meta.get("path")
+        if path and not (REPO_ROOT / path).exists():
+            missing.append((entry_id, path, meta.get("name")))
+    return len(entries) - len(missing), missing
+
+
+def workflow_prefix_counts(entries: dict[str, dict]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for meta in entries.values():
+        path = meta.get("path", "")
+        if path.startswith("features/"):
+            counts["features"] += 1
+        elif path.startswith("shared/"):
+            counts["shared"] += 1
+        elif path.startswith("workflows/"):
+            counts["legacy_workflows"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
+def field_counts(entries: dict[str, dict]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for meta in entries.values():
+        for key in meta:
+            counts[key] += 1
+    return counts
+
+
+def format_counter(counter: Counter[str]) -> str:
+    return "\n".join(f"  - {key}: {value}" for key, value in counter.most_common())
+
+
+def render_text() -> str:
+    workflows = load_manifest("workflows.yaml", "workflows")
+    integrations = load_manifest("integrations.yaml", "integrations")
+    agents = load_manifest("agents.yaml", "agents")
+    apps = load_manifest("apps.yaml", "apps")
+
+    workflow_present, workflow_missing = existing_paths(workflows)
+    agent_present, agent_missing = existing_paths(agents)
+    app_present, app_missing = existing_paths(apps)
+
+    lines = [
+        ".bifrost manifest inventory",
+        "",
+        f"repo_root: {REPO_ROOT}",
+        "",
+        "entity counts:",
+        f"  - workflows: {len(workflows)}",
+        f"  - integrations: {len(integrations)}",
+        f"  - agents: {len(agents)}",
+        f"  - apps: {len(apps)}",
+        "",
+        "path-backed entities:",
+        f"  - workflows with existing paths: {workflow_present}/{len(workflows)}",
+        f"  - agents with existing paths: {agent_present}/{len(agents)}",
+        f"  - apps with existing paths: {app_present}/{len(apps)}",
+        "",
+        "workflow path prefixes:",
+        format_counter(workflow_prefix_counts(workflows)),
+        "",
+        "workflow field frequency:",
+        format_counter(field_counts(workflows)),
+        "",
+        "integration field frequency:",
+        format_counter(field_counts(integrations)),
+    ]
+
+    if workflow_missing or agent_missing or app_missing:
+        lines.extend(["", "missing paths:"])
+        for entry_id, path, name in workflow_missing + agent_missing + app_missing:
+            lines.append(f"  - {entry_id}: {path} ({name})")
+
+    return "\n".join(lines)
+
+
+def render_markdown() -> str:
+    workflows = load_manifest("workflows.yaml", "workflows")
+    integrations = load_manifest("integrations.yaml", "integrations")
+    agents = load_manifest("agents.yaml", "agents")
+    apps = load_manifest("apps.yaml", "apps")
+
+    workflow_present, workflow_missing = existing_paths(workflows)
+    agent_present, agent_missing = existing_paths(agents)
+    app_present, app_missing = existing_paths(apps)
+
+    lines = [
+        "# `.bifrost` Inventory",
+        "",
+        f"- Workflows: `{len(workflows)}`",
+        f"- Integrations: `{len(integrations)}`",
+        f"- Agents: `{len(agents)}`",
+        f"- Apps: `{len(apps)}`",
+        "",
+        "## Source-backed Paths",
+        "",
+        f"- Workflows with existing source paths: `{workflow_present}/{len(workflows)}`",
+        f"- Agents with existing source paths: `{agent_present}/{len(agents)}`",
+        f"- Apps with existing source paths: `{app_present}/{len(apps)}`",
+        "",
+        "## Workflow Path Prefixes",
+        "",
+    ]
+
+    for key, value in workflow_prefix_counts(workflows).most_common():
+        lines.append(f"- `{key}`: `{value}`")
+
+    lines.extend(["", "## Workflow Field Frequency", ""])
+    for key, value in field_counts(workflows).most_common():
+        lines.append(f"- `{key}`: `{value}`")
+
+    lines.extend(["", "## Integration Field Frequency", ""])
+    for key, value in field_counts(integrations).most_common():
+        lines.append(f"- `{key}`: `{value}`")
+
+    missing = workflow_missing + agent_missing + app_missing
+    if missing:
+        lines.extend(["", "## Missing Paths", ""])
+        for entry_id, path, name in missing:
+            lines.append(f"- `{entry_id}` -> `{path}` ({name})")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--markdown", action="store_true", help="render markdown instead of plain text")
+    args = parser.parse_args()
+
+    output = render_markdown() if args.markdown else render_text()
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_integration_definitions.py
+++ b/scripts/validate_integration_definitions.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Validate source-backed integration definition files.
+
+Usage:
+    python scripts/validate_integration_definitions.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+API_DIR = REPO_ROOT / "api"
+
+if str(API_DIR) not in sys.path:
+    sys.path.insert(0, str(API_DIR))
+
+from bifrost.integration_definition import discover_integration_definitions  # noqa: E402
+
+
+def main() -> int:
+    definitions = discover_integration_definitions(REPO_ROOT)
+    if not definitions:
+        print("No source-backed integration definitions found.")
+        return 0
+
+    print(f"Validated {len(definitions)} source-backed integration definition(s):")
+    for slug, definition in definitions.items():
+        print(f"  - {slug}: {definition.name} ({definition.id})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

Bifrost already has source-backed models for most portable entities:

- workflows / tools / data providers from Python decorators
- forms from `.form.yaml`
- agents from `.agent.yaml`
- apps from app directories / `app.yaml`

Integrations are the main remaining portable entity type whose definition still mostly lives in manifest-shaped metadata.

At the same time, the platform already treats `.bifrost/` as generated/system-managed state in several places:

- `.bifrost/` edits are blocked in file operations
- `/api/files/manifest` regenerates manifests from DB state
- repo sync regenerates `.bifrost/*.yaml` from DB state

That makes integrations the awkward exception.

## What We Found

From a manifest inventory pass in the fork:

- 108 workflows
- 26 integrations
- 2 agents
- 1 app

All workflow / agent / app manifest entries already point at real source files.

So the migration risk is not orphaned source. The risk is metadata still living only in the manifest layer, especially for integrations:

- config schema
- OAuth provider definition
- entity picker wiring
- stable IDs and display metadata

This PR includes a repeatable inventory script and the resulting inventory note.

## Proposal

Add a source-backed integration definition file:

`integrations/<slug>/integration.yaml`

This file would carry portable integration metadata only:

- `id`
- `name`
- `entity_id`
- `entity_id_name`
- `list_entities_data_provider_id`
- `config_schema`
- `oauth_provider`

Runtime/environment-specific state would remain DB-backed:

- config values
- secrets
- tokens
- mappings
- org-specific overrides

Under this model, `.bifrost/integrations.yaml` becomes generated export, not authored source.

## Why This Fits Existing Architecture

This follows the same pattern already used by other entity types:

- executable entities: source decorators -> DB
- portable config entities: source YAML/files -> DB
- `.bifrost`: generated projection of DB state

This is narrower than a full manifest-system rewrite. It only closes the remaining gap for integrations.

## This PR

This PR is intentionally a pilot only.

Included:

- an inventory script and inventory note
- a portable integration definition contract/loader
- a validation script
- one pilot source-backed integration definition for DNSFilter
- unit coverage for the pilot shape

Not included:

- no runtime import behavior change
- no manifest import/export change
- no deletion of `.bifrost/integrations.yaml`
- no broad migration of existing integrations

## Review Questions

1. Does this target model fit upstream’s intended direction for repo-backed entities?
2. Is `integrations/<slug>/integration.yaml` the right source-backed home?
3. Should integration metadata stay YAML/file-backed, or would maintainers prefer a different source representation?
4. If accepted, is the next step an integration indexer / serializer path similar to forms and agents?
