### PR TITLE
fix: handle Decimal in workflow metadata cache

### DIFF
--- a/api/src/core/redis_client.py
+++ b/api/src/core/redis_client.py
@@ -16,6 +16,7 @@ Execution Flow:
 
 import json
 import logging
+from decimal import Decimal
 from datetime import datetime, timezone
 from typing import Any, Awaitable, TypedDict, cast
 
@@ -664,13 +665,15 @@ class RedisClient:
         redis_client = await self._get_redis()
         key = f"{WORKFLOW_METADATA_CACHE_PREFIX}{workflow_id}"
 
+        normalized_value = float(value) if isinstance(value, Decimal) else value
+
         data = {
             "id": workflow_id,
             "name": name,
             "file_path": file_path,
             "timeout_seconds": timeout_seconds,
             "time_saved": time_saved,
-            "value": value,
+            "value": normalized_value,
             "execution_mode": execution_mode,
         }
 

--- a/api/tests/unit/core/test_redis_client.py
+++ b/api/tests/unit/core/test_redis_client.py
@@ -6,6 +6,7 @@ Tests the BLPOP/RPUSH pattern for synchronous workflow execution.
 
 import pytest
 import json
+from decimal import Decimal
 from unittest.mock import AsyncMock
 
 
@@ -19,6 +20,7 @@ class TestRedisClient:
         redis.rpush = AsyncMock()
         redis.expire = AsyncMock()
         redis.blpop = AsyncMock()
+        redis.setex = AsyncMock()
         redis.close = AsyncMock()
         return redis
 
@@ -119,6 +121,29 @@ class TestRedisClient:
 
         mock_redis.close.assert_called_once()
         assert client._redis is None
+
+    async def test_set_workflow_metadata_cache_serializes_decimal(self, mock_redis):
+        """Workflow metadata cache should coerce Decimal values to JSON numbers."""
+        from src.core.redis_client import RedisClient, WORKFLOW_METADATA_CACHE_PREFIX
+
+        client = RedisClient()
+        client._redis = mock_redis
+
+        await client.set_workflow_metadata_cache(
+            workflow_id="wf-123",
+            name="Test Workflow",
+            file_path="features/test/workflows/example.py",
+            timeout_seconds=300,
+            time_saved=15,
+            value=Decimal("42.50"),
+            execution_mode="sync",
+        )
+
+        mock_redis.setex.assert_called_once()
+        call_args = mock_redis.setex.call_args
+        assert call_args[0][0] == f"{WORKFLOW_METADATA_CACHE_PREFIX}wf-123"
+        payload = json.loads(call_args[0][2])
+        assert payload["value"] == 42.5
 
 
 class TestRedisClientSingleton:


### PR DESCRIPTION
## Summary
Handle `Decimal` values when caching workflow metadata to Redis.

## Problem
Workflow metadata caching can fail when a metadata payload contains `Decimal` values. The cache writer serializes the payload with `json.dumps`, which raises `TypeError: Object of type Decimal is not JSON serializable`.

## Change
- coerce `Decimal` instances before JSON serialization in the Redis metadata cache path
- add a unit test covering the serialization path

## Why this is safe
- the change is narrowly scoped to cache serialization
- it does not alter workflow execution behavior
- it only normalizes values that already need to be JSON-compatible for Redis storage

## Validation
- targeted unit coverage added for the Redis cache path
