### PR TITLE
fix: align shared path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ docker compose logs -f api
 docker compose logs -f client
 ```
 
-Changes to files in `api/src/`, `api/shared/`, and `client/src/` automatically reload.
+Changes to files in `api/src/`, `shared/`, and `client/src/` automatically reload.
 
 **VS Code Debugging:**
 
@@ -202,6 +202,26 @@ npm run dev
 # Run E2E tests
 ./test.sh --e2e
 ```
+
+### CLI Authentication Storage
+
+The `bifrost` CLI now prefers the Unix `pass` password store for cached device
+flow credentials and only falls back to `~/.bifrost/credentials.json` when
+`pass` is unavailable.
+
+```bash
+# Default behavior on Unix: prefer pass, fallback to file
+bifrost login
+
+# Force pass-backed storage
+export BIFROST_CREDENTIALS_BACKEND=pass
+
+# Override the pass entry name (default: bifrost/credentials)
+export BIFROST_PASS_ENTRY=bifrost/credentials
+```
+
+If an older plaintext credentials file exists and `pass` is available, the CLI
+will migrate the stored credentials into `pass` automatically on the next read.
 
 ---
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Copy application code (paths relative to root context)
 COPY api/src/ /app/src/
-COPY api/shared/ /app/shared/
+COPY shared/ /app/shared/
 COPY api/alembic/ /app/alembic/
 COPY api/alembic.ini /app/
 COPY api/bifrost/ /app/bifrost/

--- a/api/pyrightconfig.json
+++ b/api/pyrightconfig.json
@@ -1,7 +1,7 @@
 {
     "include": [
         "src/**/*.py",
-        "shared/**/*.py",
+        "../shared/**/*.py",
         "bifrost/**/*.py",
         "tests/**/*.py"
     ],

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
     volumes:
       - ./api/src:/app/src:ro
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/scripts:/app/scripts:ro
       - ./api/alembic:/app/alembic:ro
       - ./api/alembic.ini:/app/alembic.ini:ro
@@ -84,7 +84,7 @@ services:
     volumes:
       - ./api/src:/app/src:ro
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/bifrost:/app/bifrost:ro
       - ./api/alembic:/app/alembic:ro
       - ./api/alembic.ini:/app/alembic.ini:ro
@@ -112,7 +112,7 @@ services:
     volumes:
       - ./api/src:/app/src:ro
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/bifrost:/app/bifrost:ro
     command: >
       watchmedo auto-restart --directory=/app/src --directory=/app/shared --pattern="*.py" --recursive -- python -m src.scheduler.main
@@ -138,7 +138,7 @@ services:
     volumes:
       - ./api/src:/app/src:ro
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/bifrost:/app/bifrost:ro
     command: >
       watchmedo auto-restart --directory=/app/src --directory=/app/shared --pattern="*.py" --recursive -- python -m src.worker.main

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -140,7 +140,7 @@ services:
       BIFROST_ENVIRONMENT: testing
     volumes:
       - ./api/src:/app/src:ro
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/alembic:/app/alembic:ro
       - ./api/alembic.ini:/app/alembic.ini:ro
       - ./api/scripts:/app/scripts:ro
@@ -177,7 +177,7 @@ services:
     volumes:
       - ./api/src:/app/src
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/bifrost:/app/bifrost:ro
       - ./api/alembic:/app/alembic:ro
       - ./api/alembic.ini:/app/alembic.ini:ro
@@ -232,7 +232,7 @@ services:
     volumes:
       - ./api/src:/app/src
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/bifrost:/app/bifrost:ro
     depends_on:
       pgbouncer:
@@ -276,7 +276,7 @@ services:
     volumes:
       - ./api/src:/app/src
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/bifrost:/app/bifrost:ro
       - test-mounts:/mounts
     depends_on:
@@ -338,7 +338,7 @@ services:
     volumes:
       - ./api/src:/app/src
       - /app/src/services/app_compiler/node_modules  # preserve npm deps from image
-      - ./api/shared:/app/shared:ro
+      - ./shared:/app/shared:ro
       - ./api/bifrost:/app/bifrost:ro
       - ./api/scripts:/app/scripts:ro  # Scripts for migration utilities
       - ./api/tests:/app/tests:ro


### PR DESCRIPTION
## Summary
Align shared-path references with the current repo layout.

## Problem
Several development and test references still assume an `api/shared` path that no longer matches the repo layout. That causes avoidable friction in local builds, compose-based workflows, and type-checking configuration.

## Change
- update Docker, compose, and related references to the current shared path layout
- align developer-facing documentation with the actual repo structure

## Why this is safe
- this is path/reference cleanup only
- it does not change application runtime logic
- it reduces mismatch between tooling and the checked-in repo structure
