### PR TITLE
test: stabilize org-scoped sdk execution e2e

### DIFF
--- a/api/tests/e2e/api/test_executions.py
+++ b/api/tests/e2e/api/test_executions.py
@@ -4,6 +4,8 @@ E2E tests for workflow execution.
 Tests sync/async execution, polling, cancellation, and execution history.
 """
 
+import uuid
+
 import pytest
 
 from tests.e2e.conftest import poll_until, write_and_register, execute_workflow_sync
@@ -1365,7 +1367,7 @@ class TestSDKWorkflowExecute:
     @pytest.fixture(scope="class")
     def org_target_workflow(self, e2e_client, platform_admin, org1):
         """Create an org-scoped target workflow that will be called by name."""
-        name = "e2e_sdk_execute_target"
+        name = f"e2e_sdk_execute_target_{uuid.uuid4().hex[:8]}"
         path = f"{name}.py"
         content = f'''"""Target workflow for SDK execute test."""
 from bifrost import workflow
@@ -1396,9 +1398,12 @@ async def {name}(ping: str = "default"):
         )
 
     @pytest.fixture(scope="class")
-    def org_caller_workflow(self, e2e_client, platform_admin, org1):
+    def org_caller_workflow(
+        self, e2e_client, platform_admin, org1, org_target_workflow,
+    ):
         """Create an org-scoped workflow that calls another workflow by name."""
-        name = "e2e_sdk_execute_caller"
+        name = f"e2e_sdk_execute_caller_{uuid.uuid4().hex[:8]}"
+        target_name = org_target_workflow["name"]
         path = f"{name}.py"
         content = f'''"""Caller workflow — uses workflows.execute() by name."""
 import traceback
@@ -1409,7 +1414,7 @@ from bifrost import workflow, workflows
     description="Calls another workflow by name via SDK",
     execution_mode="sync",
 )
-async def {name}(target_name: str = "e2e_sdk_execute_target"):
+async def {name}(target_name: str = "{target_name}"):
     try:
         exec_id = await workflows.execute(
             workflow=target_name,
@@ -1456,6 +1461,9 @@ async def {name}(target_name: str = "e2e_sdk_execute_target"):
             platform_admin.headers,
             org_caller_workflow["id"],
             {"target_name": org_target_workflow["name"]},
+            max_wait=60.0,
+            request_sync=True,
+            request_timeout=120.0,
         )
 
         assert data["status"] == "Success", (

--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -137,6 +137,8 @@ def execute_workflow_sync(
     workflow_id: str,
     input_data: dict | None = None,
     max_wait: float = 30.0,
+    request_sync: bool = False,
+    request_timeout: float | None = None,
 ) -> dict:
     """Execute a workflow and poll until completion.
 
@@ -150,6 +152,8 @@ def execute_workflow_sync(
         workflow_id: UUID of workflow to execute
         input_data: Input parameters for the workflow
         max_wait: Maximum time to wait for completion (seconds)
+        request_sync: If True, ask the API to block until worker completion
+        request_timeout: Optional timeout for the initial execute request
 
     Returns:
         The execution result dict with status, result, error, etc.
@@ -163,7 +167,9 @@ def execute_workflow_sync(
         json={
             "workflow_id": workflow_id,
             "input_data": input_data or {},
+            "sync": request_sync,
         },
+        timeout=request_timeout,
     )
     assert response.status_code == 200, f"Execute failed: {response.text}"
     data = response.json()


### PR DESCRIPTION
## Summary
- give the org-scoped nested SDK execution E2E unique workflow names per run
- allow the helper to request sync execution and override the initial request timeout
- use the sync path for the flaky org-scoped nested execution test

## Why
The org-scoped `workflows.execute()` E2E passed reliably in isolated local runs but timed out intermittently in full GitHub Actions E2E runs. The failures were happening in the test's observation path rather than pointing to a stable product regression.

This keeps the same behavioral assertion while making the test less dependent on suite-wide timing and name collisions.

## Validation
- `./test.sh tests/e2e/api/test_executions.py::TestSDKWorkflowExecute::test_sdk_execute_by_name_org_scoped -v`
