### PR TITLE
fix: retry client requests with refreshed auth

### DIFF
--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -114,6 +114,27 @@ async function refreshAccessToken(): Promise<boolean> {
 }
 
 /**
+ * Retry a request after token refresh using current auth state.
+ */
+async function retryRequestWithFreshAuth(request: Request): Promise<Response> {
+	const headers = new Headers(request.headers);
+	const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+
+	if (token) {
+		headers.set("Authorization", `Bearer ${token}`);
+	} else {
+		headers.delete("Authorization");
+	}
+
+	return fetch(
+		new Request(request, {
+			headers,
+			credentials: "same-origin",
+		}),
+	);
+}
+
+/**
  * Handle authentication failure - clear session and redirect to login
  */
 function handleAuthFailure(): void {
@@ -245,8 +266,8 @@ baseClient.use({
 			// Attempt token refresh via cookie
 			const refreshed = await refreshAccessToken();
 			if (refreshed) {
-				// Retry original request with fresh credentials
-				return fetch(request.clone());
+				// Retry original request with current credentials
+				return retryRequestWithFreshAuth(request);
 			}
 
 			// Refresh failed - redirect to login
@@ -308,8 +329,8 @@ async function handleAuthResponse(
 		if (!AUTH_ENDPOINTS.some((ep) => url.includes(ep))) {
 			const refreshed = await refreshAccessToken();
 			if (refreshed) {
-				// Retry original request with fresh credentials
-				return fetch(request.clone());
+				// Retry original request with current credentials
+				return retryRequestWithFreshAuth(request);
 			}
 		}
 		handleAuthFailure();


### PR DESCRIPTION
Closes #16

## Summary
Retry client requests after token refresh using the current auth state instead of replaying the stale original `Authorization` header.

## Problem
On `401`, the client refreshes successfully but then retries with `fetch(request.clone())`. If the original request already had a bearer token, the retry can reuse the stale token instead of the freshly refreshed one.

## Change
- add a small helper that rebuilds request headers from current token state
- retry the request with a refreshed `Authorization` header after refresh succeeds

## Validation
- change is isolated to `client/src/lib/api-client.ts`
- local TypeScript validation in this checkout is blocked because `tsc` is not installed in the current client toolchain
