### PR TITLE
fix: resolve OAuth refresh {entity_id} from integration settings

### DIFF
--- a/api/src/jobs/schedulers/oauth_token_refresh.py
+++ b/api/src/jobs/schedulers/oauth_token_refresh.py
@@ -124,8 +124,10 @@ async def run_refresh_job(
                         select(Integration).where(Integration.id == provider.integration_id)
                     )
                     integration = result_int.scalar_one_or_none()
-                    if integration and integration.default_entity_id:
-                        integration_entity_id = integration.default_entity_id
+                    if integration:
+                        integration_entity_id = (
+                            integration.default_entity_id or integration.entity_id
+                        )
 
                 token_refresh_data.append({
                     "token_id": token.id,

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -1112,10 +1112,10 @@ async def sdk_integrations_refresh_token(
             if mapping:
                 entity_id = mapping.entity_id
             else:
-                # Fall back to integration's default_entity_id
+                # Fall back to the integration's configured entity identifier
                 integration = await repo.get_by_id(provider.integration_id)
                 if integration:
-                    entity_id = integration.default_entity_id
+                    entity_id = integration.default_entity_id or integration.entity_id
 
         # Decrypt client secret
         client_secret = None

--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -58,7 +58,7 @@ async def get_url_resolution_defaults(
     OAuth URLs may contain {entity_id} placeholders that need to be resolved
     before making HTTP requests. This function gathers the default values
     from the provider's token_url_defaults and the linked integration's
-    default_entity_id.
+    resolved entity identifier.
     """
     defaults: dict[str, str] = dict(provider.token_url_defaults) if provider.token_url_defaults else {}
 
@@ -68,8 +68,10 @@ async def get_url_resolution_defaults(
             select(Integration).where(Integration.id == provider.integration_id)
         )
         integration = result.scalar_one_or_none()
-        if integration and integration.default_entity_id:
-            defaults["entity_id"] = integration.default_entity_id
+        if integration:
+            integration_entity_id = integration.default_entity_id or integration.entity_id
+            if integration_entity_id:
+                defaults["entity_id"] = integration_entity_id
 
     return defaults
 

--- a/api/tests/unit/routers/test_cli_refresh_token.py
+++ b/api/tests/unit/routers/test_cli_refresh_token.py
@@ -147,6 +147,81 @@ class TestRefreshTokenClientCredentials:
         mock_db.add.assert_not_called()
         assert mock_existing_token.expires_at == expires_at
 
+    @pytest.mark.asyncio
+    async def test_falls_back_to_integration_entity_id_when_default_missing(self):
+        """Should resolve {entity_id} from integration.entity_id if needed."""
+        from src.routers.cli import sdk_integrations_refresh_token
+        from src.models.contracts.cli import SDKIntegrationsRefreshTokenRequest
+
+        request = SDKIntegrationsRefreshTokenRequest(connection_name="Microsoft Graph")
+
+        mock_user = MagicMock()
+        mock_user.user_id = uuid4()
+        mock_user.email = "test@example.com"
+        mock_db = AsyncMock()
+
+        provider_id = uuid4()
+        integration_id = uuid4()
+
+        mock_provider = MagicMock()
+        mock_provider.id = provider_id
+        mock_provider.provider_name = "Microsoft Graph"
+        mock_provider.client_id = "ms-client-id"
+        mock_provider.encrypted_client_secret = "encrypted-secret"
+        mock_provider.token_url = "https://login.microsoftonline.com/{entity_id}/oauth2/v2.0/token"
+        mock_provider.token_url_defaults = {}
+        mock_provider.oauth_flow_type = "client_credentials"
+        mock_provider.scopes = ["https://graph.microsoft.com/.default"]
+        mock_provider.integration_id = integration_id
+        mock_provider.organization_id = None
+        mock_provider.audience = None
+
+        provider_result = MagicMock()
+        provider_result.scalars.return_value.first.return_value = mock_provider
+        token_result = MagicMock()
+        token_result.scalars.return_value.first.return_value = None
+
+        mock_db.execute = AsyncMock(side_effect=[provider_result, token_result])
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        mock_token_response = {
+            "access_token": "fresh-ms-token",
+            "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        }
+
+        with (
+            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=str(uuid4())),
+            patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
+            patch("src.core.security.decrypt_secret", return_value="decrypted-secret"),
+            patch("src.core.security.encrypt_secret", return_value="encrypted-new-token"),
+            patch("src.repositories.integrations.IntegrationsRepository") as mock_repo_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_mapping_by_org = AsyncMock(return_value=None)
+            integration = MagicMock()
+            integration.default_entity_id = None
+            integration.entity_id = "tenant-123"
+            mock_repo.get_by_id = AsyncMock(return_value=integration)
+            mock_repo_class.return_value = mock_repo
+
+            mock_instance = MagicMock()
+            mock_instance.get_client_credentials_token = AsyncMock(
+                return_value=(True, mock_token_response)
+            )
+            mock_client_class.return_value = mock_instance
+
+            result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
+
+        assert result.access_token == "fresh-ms-token"
+        mock_instance.get_client_credentials_token.assert_called_once_with(
+            token_url="https://login.microsoftonline.com/tenant-123/oauth2/v2.0/token",
+            client_id="ms-client-id",
+            client_secret="decrypted-secret",
+            scopes="https://graph.microsoft.com/.default",
+            audience=None,
+        )
+
 
 class TestRefreshTokenAuthorizationCode:
     """Test refresh_token endpoint for authorization_code flows."""

--- a/api/tests/unit/routers/test_oauth_refresh.py
+++ b/api/tests/unit/routers/test_oauth_refresh.py
@@ -132,3 +132,30 @@ class TestOAuthRefreshEndpointLogic:
         provider.encrypted_client_secret = b"some-secret"
         has_client_secret = provider.encrypted_client_secret is not None
         assert has_client_secret is True
+
+
+class TestUrlResolutionDefaults:
+    """Test entity_id resolution for OAuth URL templates."""
+
+    @pytest.mark.asyncio
+    async def test_uses_integration_entity_id_when_default_missing(self):
+        """Refresh routes should fall back to integration.entity_id."""
+        from src.routers.oauth_connections import get_url_resolution_defaults
+
+        provider = MagicMock()
+        provider.token_url_defaults = {}
+        provider.integration_id = "integration-123"
+
+        integration = MagicMock()
+        integration.default_entity_id = None
+        integration.entity_id = "tenant-123"
+
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = integration
+
+        db = AsyncMock()
+        db.execute.return_value = result
+
+        defaults = await get_url_resolution_defaults(db, provider)
+
+        assert defaults == {"entity_id": "tenant-123"}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -549,9 +549,9 @@
 			}
 		},
 		"node_modules/@azure/static-web-apps-cli": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@azure/static-web-apps-cli/-/static-web-apps-cli-2.0.7.tgz",
-			"integrity": "sha512-bF9sFrC9Ew1jF8VlMUWJbkIvj6tkPUdhYgwV9g4mKcH0Atwgg65G+ye1CMogkDWqw32a/Cfuv9IrO+xxt3UwjQ==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@azure/static-web-apps-cli/-/static-web-apps-cli-2.0.8.tgz",
+			"integrity": "sha512-C3P5I+4oHZ0ns3uEdYZPZHfQu29os8nxfdWRvvgm9bTLfn3m3+eIzTKch6gIRUSGk1Mk8uKegvsQxZfJ1nic7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -631,7 +631,6 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -1494,7 +1493,6 @@
 			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
 			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@floating-ui/core": "^1.7.3",
 				"@floating-ui/utils": "^0.2.10"
@@ -3433,9 +3431,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-			"integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+			"integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
 			"cpu": [
 				"arm"
 			],
@@ -3446,9 +3444,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-			"integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+			"integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3459,9 +3457,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-			"integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+			"integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3472,9 +3470,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-			"integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+			"integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
 			"cpu": [
 				"x64"
 			],
@@ -3485,9 +3483,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-			"integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+			"integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3498,9 +3496,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-			"integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+			"integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
 			"cpu": [
 				"x64"
 			],
@@ -3511,9 +3509,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-			"integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+			"integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
 			"cpu": [
 				"arm"
 			],
@@ -3524,9 +3522,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-			"integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+			"integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
 			"cpu": [
 				"arm"
 			],
@@ -3537,9 +3535,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-			"integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+			"integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3550,9 +3548,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-			"integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+			"integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3563,9 +3561,22 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-			"integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+			"integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-musl": {
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+			"integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
 			"cpu": [
 				"loong64"
 			],
@@ -3576,9 +3587,22 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-			"integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+			"integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-musl": {
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+			"integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3589,9 +3613,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-			"integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+			"integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3602,9 +3626,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-			"integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+			"integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3615,9 +3639,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-			"integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+			"integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -3628,9 +3652,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-			"integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+			"integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
 			"cpu": [
 				"x64"
 			],
@@ -3641,9 +3665,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-			"integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+			"integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
 			"cpu": [
 				"x64"
 			],
@@ -3653,10 +3677,23 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-openbsd-x64": {
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+			"integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-			"integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+			"integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3667,9 +3704,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-			"integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+			"integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -3680,9 +3717,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-			"integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+			"integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
 			"cpu": [
 				"ia32"
 			],
@@ -3693,9 +3730,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-			"integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+			"integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
 			"cpu": [
 				"x64"
 			],
@@ -3706,9 +3743,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-			"integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+			"integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4076,7 +4113,6 @@
 			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
 			"integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@tanstack/query-core": "5.90.12"
 			},
@@ -4093,7 +4129,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.19.0.tgz",
 			"integrity": "sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -4316,7 +4351,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.19.0.tgz",
 			"integrity": "sha512-N6nKbFB2VwMsPlCw67RlAtYSK48TAsAUgjnD+vd3ieSlIufdQnLXDFUP6hFKx9mwoUVUgZGz02RA6bkxOdYyTw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -4435,7 +4469,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.19.0.tgz",
 			"integrity": "sha512-ZmGUhLbMWaGqnJh2Bry+6V4M6gMpUDYo4D1xNux5Gng/E/eYtc+PMxMZ/6F7tNTAuujLBOQKj6D+4SsSm457jw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/ueberdosis"
@@ -4479,7 +4512,6 @@
 			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.19.0.tgz",
 			"integrity": "sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prosemirror-changeset": "^2.3.0",
 				"prosemirror-collab": "^1.3.1",
@@ -4906,7 +4938,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
 			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -4916,7 +4947,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -5012,7 +5042,6 @@
 			"integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.49.0",
 				"@typescript-eslint/types": "8.49.0",
@@ -5345,7 +5374,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5750,7 +5778,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -6432,7 +6459,6 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -6859,9 +6885,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-			"integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+			"integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -7166,7 +7192,6 @@
 			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -8332,7 +8357,6 @@
 			"resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
 			"integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/immer"
@@ -9316,9 +9340,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.includes": {
@@ -9447,9 +9471,9 @@
 			}
 		},
 		"node_modules/markdown-it": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1",
@@ -10503,7 +10527,6 @@
 			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
 			"integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"dompurify": "3.2.7",
 				"marked": "14.0.0"
@@ -10782,7 +10805,6 @@
 			"resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.15.0.tgz",
 			"integrity": "sha512-OjQUdi61WO4HYhr9+byCPMj0+bgste/LtSBEcV6FzDdONTs7x0fWn8/ndoYwzqCsKWIxEZwo4FN/TG1c1rI8IQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"openapi-typescript-helpers": "^0.0.15"
 			}
@@ -11196,11 +11218,10 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -11278,7 +11299,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -11506,7 +11526,6 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
 			"integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"orderedmap": "^2.0.0"
 			}
@@ -11536,7 +11555,6 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
 			"integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.0.0",
 				"prosemirror-transform": "^1.0.0",
@@ -11585,7 +11603,6 @@
 			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.5.tgz",
 			"integrity": "sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"prosemirror-model": "^1.20.0",
 				"prosemirror-state": "^1.0.0",
@@ -11864,7 +11881,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
 			"integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11895,7 +11911,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
 			"integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -11908,7 +11923,6 @@
 			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
 			"integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			},
@@ -11959,7 +11973,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -12036,9 +12049,9 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.10.1.tgz",
-			"integrity": "sha512-gHL89dRa3kwlUYtRQ+m8NmxGI6CgqN+k4XyGjwcFoQwwCWF6xXpOCUlDovkXClS0d0XJN/5q7kc5W3kiFEd0Yw==",
+			"version": "7.13.2",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
+			"integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
 			"license": "MIT",
 			"dependencies": {
 				"cookie": "^1.0.1",
@@ -12058,12 +12071,12 @@
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.10.1.tgz",
-			"integrity": "sha512-JNBANI6ChGVjA5bwsUIwJk7LHKmqB4JYnYfzFwyp2t12Izva11elds2jx7Yfoup2zssedntwU0oZ5DEmk5Sdaw==",
+			"version": "7.13.2",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
+			"integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
 			"license": "MIT",
 			"dependencies": {
-				"react-router": "7.10.1"
+				"react-router": "7.13.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -12183,8 +12196,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -12457,9 +12469,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.53.3",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-			"integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+			"version": "4.60.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+			"integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "1.0.8"
@@ -12472,28 +12484,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.53.3",
-				"@rollup/rollup-android-arm64": "4.53.3",
-				"@rollup/rollup-darwin-arm64": "4.53.3",
-				"@rollup/rollup-darwin-x64": "4.53.3",
-				"@rollup/rollup-freebsd-arm64": "4.53.3",
-				"@rollup/rollup-freebsd-x64": "4.53.3",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-				"@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-				"@rollup/rollup-linux-arm64-gnu": "4.53.3",
-				"@rollup/rollup-linux-arm64-musl": "4.53.3",
-				"@rollup/rollup-linux-loong64-gnu": "4.53.3",
-				"@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-				"@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-				"@rollup/rollup-linux-riscv64-musl": "4.53.3",
-				"@rollup/rollup-linux-s390x-gnu": "4.53.3",
-				"@rollup/rollup-linux-x64-gnu": "4.53.3",
-				"@rollup/rollup-linux-x64-musl": "4.53.3",
-				"@rollup/rollup-openharmony-arm64": "4.53.3",
-				"@rollup/rollup-win32-arm64-msvc": "4.53.3",
-				"@rollup/rollup-win32-ia32-msvc": "4.53.3",
-				"@rollup/rollup-win32-x64-gnu": "4.53.3",
-				"@rollup/rollup-win32-x64-msvc": "4.53.3",
+				"@rollup/rollup-android-arm-eabi": "4.60.1",
+				"@rollup/rollup-android-arm64": "4.60.1",
+				"@rollup/rollup-darwin-arm64": "4.60.1",
+				"@rollup/rollup-darwin-x64": "4.60.1",
+				"@rollup/rollup-freebsd-arm64": "4.60.1",
+				"@rollup/rollup-freebsd-x64": "4.60.1",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+				"@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+				"@rollup/rollup-linux-arm64-gnu": "4.60.1",
+				"@rollup/rollup-linux-arm64-musl": "4.60.1",
+				"@rollup/rollup-linux-loong64-gnu": "4.60.1",
+				"@rollup/rollup-linux-loong64-musl": "4.60.1",
+				"@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+				"@rollup/rollup-linux-ppc64-musl": "4.60.1",
+				"@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+				"@rollup/rollup-linux-riscv64-musl": "4.60.1",
+				"@rollup/rollup-linux-s390x-gnu": "4.60.1",
+				"@rollup/rollup-linux-x64-gnu": "4.60.1",
+				"@rollup/rollup-linux-x64-musl": "4.60.1",
+				"@rollup/rollup-openbsd-x64": "4.60.1",
+				"@rollup/rollup-openharmony-arm64": "4.60.1",
+				"@rollup/rollup-win32-arm64-msvc": "4.60.1",
+				"@rollup/rollup-win32-ia32-msvc": "4.60.1",
+				"@rollup/rollup-win32-x64-gnu": "4.60.1",
+				"@rollup/rollup-win32-x64-msvc": "4.60.1",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -13008,8 +13023,7 @@
 			"version": "4.1.17",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
 			"integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -13209,7 +13223,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -13587,7 +13600,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
 			"integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -14018,9 +14030,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
 			"devOptional": true,
 			"license": "ISC",
 			"bin": {
@@ -14087,7 +14099,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
 			"integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}


### PR DESCRIPTION
## Summary
- resolve OAuth URL templates from `integration.default_entity_id` or `integration.entity_id`
- apply the same fallback in the OAuth connections router, CLI refresh path, and scheduler refresh job
- add regression coverage for connection refresh and CLI token refresh

## Problem
The platform stores tenant-specific integration state in `entity_id`, but the OAuth refresh path only looked at `default_entity_id` when resolving `{entity_id}` in token URLs.

That meant a configured connection like Microsoft Graph could look valid in the integration API while `POST /api/oauth/connections/{connection_name}/refresh` still sent requests to a literal URL containing `{entity_id}` and failed with tenant-resolution errors.

## Verification
- `pytest -q tests/unit/routers/test_oauth_refresh.py tests/unit/routers/test_cli_refresh_token.py`
- `python3 -m py_compile src/routers/oauth_connections.py src/routers/cli.py src/jobs/schedulers/oauth_token_refresh.py`

## Notes
This was reproduced against a client-credentials Microsoft Graph connection whose integration had `entity_id` set and `default_entity_id` unset.