### PR TITLE
fix(embed): isolate embed tokens to sessionStorage so they don't pollute user sessions

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -15,6 +15,11 @@ import {
 	type ReactNode,
 } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import {
+	ACCESS_TOKEN_KEY,
+	clearAuthTokens,
+	clearEmbedToken,
+} from "@/lib/auth-token";
 
 // User info extracted from JWT
 export interface AuthUser {
@@ -71,7 +76,6 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 // Token storage keys
 // Note: Refresh token is stored in HttpOnly cookie only (more secure)
-const ACCESS_TOKEN_KEY = "bifrost_access_token";
 const USER_KEY = "bifrost_user";
 
 // JWT payload structure
@@ -280,6 +284,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
 			// Success - store access token (refresh token is in HttpOnly cookie)
 			if (data.access_token) {
+				clearEmbedToken();
 				localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
 
 				const payload = parseJwt(data.access_token);
@@ -326,6 +331,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			const data = await res.json();
 
 			if (data.access_token) {
+				clearEmbedToken();
 				localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
 
 				const payload = parseJwt(data.access_token);
@@ -370,6 +376,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			const data = await res.json();
 
 			if (data.access_token) {
+				clearEmbedToken();
 				localStorage.setItem(ACCESS_TOKEN_KEY, data.access_token);
 
 				const payload = parseJwt(data.access_token);
@@ -397,6 +404,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 			const tokens = await authenticateWithPasskey(email);
 
 			if (tokens.access_token) {
+				clearEmbedToken();
 				localStorage.setItem(ACCESS_TOKEN_KEY, tokens.access_token);
 
 				const payload = parseJwt(tokens.access_token);
@@ -416,7 +424,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
 	// Logout
 	const logout = useCallback(() => {
-		localStorage.removeItem(ACCESS_TOKEN_KEY);
+		clearAuthTokens();
 		localStorage.removeItem(USER_KEY);
 		sessionStorage.removeItem("userId");
 		setUser(null);

--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -12,19 +12,19 @@ import createClient from "openapi-fetch";
 import createQueryClient from "openapi-react-query";
 import type { paths } from "./v1";
 import { parseApiError, ApiError, RateLimitError } from "./api-error";
+import {
+	ACCESS_TOKEN_KEY,
+	clearAuthTokens,
+	consumeEmbedTokenFromHash,
+	getActiveToken,
+	isEmbedSession,
+} from "./auth-token";
 
-// Token storage key (shared with AuthContext)
-// Note: Refresh token is stored in HttpOnly cookie only (more secure)
-const ACCESS_TOKEN_KEY = "bifrost_access_token";
-
-// Extract embed token from URL fragment before any API calls run.
-// The /embed/apps/{slug} endpoint redirects to /apps/{slug}#embed_token=<jwt>
-// and we need this in localStorage before the first ensureValidToken() call.
-if (window.location.hash.startsWith("#embed_token=")) {
-	const token = window.location.hash.slice("#embed_token=".length);
-	localStorage.setItem(ACCESS_TOKEN_KEY, token);
-	window.history.replaceState(null, "", window.location.pathname + window.location.search);
-}
+// Pull an embed token off the URL fragment (if any) before any API call
+// runs. The token is stored in sessionStorage rather than localStorage so
+// it stays scoped to this tab/iframe and never overwrites a normal user
+// session that happens to be open in another tab on the same origin.
+consumeEmbedTokenFromHash();
 
 // Buffer time before expiration to trigger refresh (60 seconds)
 const TOKEN_REFRESH_BUFFER_SECONDS = 60;
@@ -139,7 +139,7 @@ async function retryRequestWithFreshAuth(request: Request): Promise<Response> {
  */
 function handleAuthFailure(): void {
 	sessionStorage.removeItem("userId");
-	localStorage.removeItem(ACCESS_TOKEN_KEY);
+	clearAuthTokens();
 
 	const currentPath = window.location.pathname;
 	if (
@@ -156,6 +156,12 @@ function handleAuthFailure(): void {
  * Proactively refreshes token before it expires
  */
 async function ensureValidToken(): Promise<boolean> {
+	// Embed sessions can't refresh — the embed token is minted by the
+	// HMAC handshake at /embed/apps/{slug} and there's no refresh cookie
+	// for it. Just trust whatever's in sessionStorage; expiry surfaces
+	// as a 401 and the caller can re-enter the embed flow.
+	if (isEmbedSession()) return true;
+
 	const token = localStorage.getItem(ACCESS_TOKEN_KEY);
 
 	// No access token in localStorage, but HttpOnly refresh cookie may be valid
@@ -233,10 +239,11 @@ baseClient.use({
 		}
 
 		// Authentication: prefer HttpOnly cookie (sent automatically by browser).
-		// Fall back to Bearer header from localStorage for embed sessions where
-		// no cookie is set (token arrives via URL fragment, not Set-Cookie).
+		// Fall back to Bearer header from the active token store for embed
+		// sessions (token arrives via URL fragment, not Set-Cookie) and for
+		// any path where the cookie isn't being honored.
 		if (!request.headers.has("Authorization")) {
-			const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+			const token = getActiveToken();
 			if (token) {
 				request.headers.set("Authorization", `Bearer ${token}`);
 			}
@@ -414,9 +421,10 @@ export async function authFetch(
 	const headers = new Headers(options.headers);
 	const method = options.method?.toUpperCase() || "GET";
 
-	// Auth: prefer cookie (automatic), fall back to Bearer from localStorage
+	// Auth: prefer cookie (automatic), fall back to Bearer from the active
+	// token store (sessionStorage embed token, or localStorage user token).
 	if (!headers.has("Authorization")) {
-		const token = localStorage.getItem(ACCESS_TOKEN_KEY);
+		const token = getActiveToken();
 		if (token) {
 			headers.set("Authorization", `Bearer ${token}`);
 		}

--- a/client/src/lib/auth-token.ts
+++ b/client/src/lib/auth-token.ts
@@ -1,0 +1,103 @@
+/**
+ * Auth token storage utilities.
+ *
+ * The platform stores two distinct kinds of access token:
+ *
+ * 1. The user's normal access token — issued by the login flow, kept in
+ *    `localStorage`, shared across all tabs of the same origin.
+ *
+ * 2. An embed token — minted by `/embed/apps/{slug}` (or `/embed/forms/{id}`)
+ *    after a successful HMAC check, scoped to a single application or form
+ *    plus a set of `verified_params`, valid for ~8 hours, with no refresh
+ *    flow. Embed tokens are kept in `sessionStorage` so they stay isolated
+ *    to the iframe / tab that received them and never overwrite the user's
+ *    normal session in another tab on the same origin.
+ *
+ * The embed token is delivered via a URL fragment (`#embed_token=…`) so it
+ * never reaches the server in a Referer header or proxy log.
+ */
+
+export const ACCESS_TOKEN_KEY = "bifrost_access_token";
+export const EMBED_TOKEN_KEY = "bifrost_embed_token";
+
+const EMBED_HASH_PREFIX = "#embed_token=";
+
+/**
+ * Detect whether this browsing context is rendered inside an iframe.
+ * A SecurityError when reading `window.top` indicates a cross-origin parent —
+ * which is itself proof that we're framed.
+ */
+export function isInIframe(): boolean {
+	try {
+		return window.top !== window.self;
+	} catch {
+		return true;
+	}
+}
+
+/**
+ * Consume an `#embed_token=…` fragment from the current URL, if present,
+ * and store the token in sessionStorage. Strips the fragment from the URL
+ * either way so the token never lingers in the address bar or history.
+ *
+ * Only stores the token when running inside an iframe — opening an embed
+ * URL in a regular tab would otherwise turn that tab into a sticky embed
+ * session, surprising the user. The HMAC check on the server is the real
+ * security boundary; the iframe guard is purely UX hygiene.
+ */
+export function consumeEmbedTokenFromHash(): void {
+	if (typeof window === "undefined") return;
+	if (!window.location.hash.startsWith(EMBED_HASH_PREFIX)) return;
+
+	const token = window.location.hash.slice(EMBED_HASH_PREFIX.length);
+
+	// Always strip the fragment so the token doesn't sit in the URL bar.
+	window.history.replaceState(
+		null,
+		"",
+		window.location.pathname + window.location.search,
+	);
+
+	if (token && isInIframe()) {
+		sessionStorage.setItem(EMBED_TOKEN_KEY, token);
+	}
+}
+
+/**
+ * Return the access token to attach to outbound requests from this tab.
+ * Prefers the per-tab embed token when present (we're inside an embed
+ * context), otherwise falls back to the user's normal access token.
+ */
+export function getActiveToken(): string | null {
+	const embed = sessionStorage.getItem(EMBED_TOKEN_KEY);
+	if (embed) return embed;
+	return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+/**
+ * True when this tab is operating as an embed session (has an embed token
+ * in sessionStorage). Used to skip the normal-session refresh flow, which
+ * doesn't apply to embed tokens.
+ */
+export function isEmbedSession(): boolean {
+	return sessionStorage.getItem(EMBED_TOKEN_KEY) !== null;
+}
+
+/**
+ * Clear both kinds of access token. Called on logout and on hard auth
+ * failures so a stale embed token can't keep an authenticated session
+ * alive after the user has signed out.
+ */
+export function clearAuthTokens(): void {
+	localStorage.removeItem(ACCESS_TOKEN_KEY);
+	sessionStorage.removeItem(EMBED_TOKEN_KEY);
+}
+
+/**
+ * Drop any embed token from this tab. Called from the regular login flow:
+ * if a user explicitly logs in from a tab that previously held an embed
+ * token, the new login should win and not be shadowed by sessionStorage.
+ */
+export function clearEmbedToken(): void {
+	sessionStorage.removeItem(EMBED_TOKEN_KEY);
+}

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -12,6 +12,7 @@
 
 import type { components } from "@/lib/v1";
 import { refreshAccessToken } from "@/lib/api-client";
+import { getActiveToken } from "@/lib/auth-token";
 import { useNotificationStore } from "@/stores/notificationStore";
 import type { Notification } from "@/stores/notificationStore";
 
@@ -627,9 +628,10 @@ class WebSocketService {
 			const params = new URLSearchParams();
 			channels.forEach((ch) => params.append("channels", ch));
 
-			// For embed tokens (stored in localStorage), pass as query param
-			// since browser WebSocket API can't set custom headers
-			const embedToken = localStorage.getItem("bifrost_access_token");
+			// For embed tokens, pass as query param since browser WebSocket
+			// API can't set custom headers. getActiveToken() prefers the
+			// per-tab embed token (sessionStorage) over the user token.
+			const embedToken = getActiveToken();
 			if (embedToken && isEmbedToken(embedToken)) {
 				params.set("token", embedToken);
 			}


### PR DESCRIPTION
## Problem

Embed tokens minted by `/embed/apps/{slug}` (and `/embed/forms/{form_id}`) are delivered via a URL fragment and then persisted in the browser. Today the client stores them in `localStorage` under the same key (`bifrost_access_token`) as the user's normal session token.

Because `localStorage` is shared across every tab on the same origin, opening an embed — e.g. a HaloPSA Custom Tab iframe — silently overwrites the user's regular session in every other tab. Until the user explicitly logs out and back in, every other tab sees only the embedded app's narrow access scope (the embed JWT is scoped to one app + verified params), so the user appears to lose access to the rest of the platform.

Reproduced in production after wiring up the first Halo Custom Tab embed: opening the embed in Halo immediately broke every other Bifrost tab on the same browser, locking the user to the embed's single client until logout.

## Fix

Two-store token model:

- **`localStorage["bifrost_access_token"]`** — the user's normal session token (unchanged)
- **`sessionStorage["bifrost_embed_token"]`** — per-tab embed token, scoped to the iframe / tab that received it

A new `client/src/lib/auth-token.ts` module owns the storage rules:

- `consumeEmbedTokenFromHash()` — runs once at module load in `api-client.ts`. If the URL has `#embed_token=…`, strip the fragment from the URL bar and store the token in **sessionStorage** — but only when `window.top !== window.self`, so opening an embed URL in a regular tab doesn't accidentally turn that tab into a sticky embed session. The HMAC check on the server is the real security boundary; this is purely UX hygiene.
- `getActiveToken()` — used everywhere we attach an Authorization header (REST + WebSocket). Prefers the per-tab embed token, falls back to the user token. Embed iframes therefore present their embed JWT; other tabs see no change.
- `clearEmbedToken()` — called on every explicit login (password / MFA / OAuth / passkey) so a deliberate sign-in always wins, even from a tab that previously held an embed token.
- `clearAuthTokens()` — called on logout and on hard auth failures so a stale embed token can't keep an authenticated session alive after the user has signed out.

`ensureValidToken()` short-circuits when an embed token is present — embed tokens have no refresh flow (they're ~8h, single-use per app/form), so the normal-session refresh path doesn't apply.

## Files touched

- `client/src/lib/auth-token.ts` (new)
- `client/src/lib/api-client.ts` — replace inline `ACCESS_TOKEN_KEY` with helpers; auth-header sites use `getActiveToken()`; refresh path skips embed sessions
- `client/src/contexts/AuthContext.tsx` — clear embed token on every explicit login; logout uses `clearAuthTokens()`
- `client/src/services/websocket.ts` — WebSocket auth uses `getActiveToken()` instead of reading `localStorage` directly

## Why no server changes

The server already mints two distinct kinds of token (`embed: true` claim plus per-app/per-form scope). The bug is entirely in how the client stores them. Server contracts unchanged.

## Test plan

- [x] Open a Bifrost embed inside an iframe (HaloPSA Custom Tab). Confirm it loads against its scoped resources. *Verified in production.*
- [x] In a separate tab on the same browser, open the platform UI. Confirm the user's normal session and full org access are intact. *Verified in production — the bug that motivated this fix.*
- [ ] Log out from a normal tab → confirm the embed iframe also loses access on next request (both tokens cleared).
- [ ] Open the embed URL directly in a normal tab (not iframed). Confirm it does NOT install the embed token; the URL fragment is still stripped.
- [ ] Explicit re-login from a tab that previously held an embed token wins (no shadowing by sessionStorage).