### PR TITLE
Fix missing OAuth scope on authorization-code and refresh token exchanges

### DIFF
--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -831,6 +831,7 @@ async def oauth_callback(
         client_id=provider.client_id,
         client_secret=client_secret,
         redirect_uri=redirect_uri,
+        scopes=" ".join(provider.scopes) if provider.scopes else None,
         audience=provider.audience,
     )
 

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -125,6 +125,7 @@ class OAuthProviderClient:
         client_id: str,
         client_secret: str | None,
         redirect_uri: str,
+        scopes: str | None = None,
         audience: str | None = None,
     ) -> tuple[bool, dict]:
         """
@@ -159,6 +160,9 @@ class OAuthProviderClient:
         if audience:
             payload["audience"] = audience
 
+        if scopes:
+            payload["scope"] = scopes
+
         return await self._make_token_request(token_url, payload)
 
     async def refresh_access_token(
@@ -167,6 +171,7 @@ class OAuthProviderClient:
         refresh_token: str,
         client_id: str,
         client_secret: str | None,
+        scopes: str | None = None,
         audience: str | None = None,
     ) -> tuple[bool, dict]:
         """
@@ -196,6 +201,9 @@ class OAuthProviderClient:
 
         if audience:
             payload["audience"] = audience
+
+        if scopes:
+            payload["scope"] = scopes
 
         return await self._make_token_request(token_url, payload)
 

--- a/api/tests/unit/routers/test_oauth_refresh.py
+++ b/api/tests/unit/routers/test_oauth_refresh.py
@@ -4,15 +4,6 @@ import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, AsyncMock, patch
 
-import fastmcp.tools as fastmcp_tools
-from fastmcp.tools.tool import ToolResult
-
-
-def _ensure_fastmcp_toolresult_export() -> None:
-    """Bridge fastmcp import shape drift during router package import."""
-    if not hasattr(fastmcp_tools, "ToolResult"):
-        fastmcp_tools.ToolResult = ToolResult
-
 
 class TestOAuthRefreshClientCredentials:
     """Test that /refresh endpoint handles client_credentials flow correctly."""
@@ -100,7 +91,6 @@ class TestOAuthRefreshClientCredentials:
     @pytest.mark.asyncio
     async def test_refresh_endpoint_passes_joined_provider_scopes(self):
         """Authorization-code refresh should forward provider scopes into shared refresh context."""
-        _ensure_fastmcp_toolresult_export()
         from src.routers.oauth_connections import refresh_token
 
         provider = MagicMock()
@@ -177,7 +167,6 @@ class TestOAuthRefreshClientCredentials:
     @pytest.mark.asyncio
     async def test_callback_passes_joined_provider_scopes(self):
         """OAuth callback should forward joined provider scopes into code exchange."""
-        _ensure_fastmcp_toolresult_export()
         from src.models.contracts.oauth import OAuthCallbackRequest
         from src.routers.oauth_connections import oauth_callback
 

--- a/api/tests/unit/routers/test_oauth_refresh.py
+++ b/api/tests/unit/routers/test_oauth_refresh.py
@@ -4,6 +4,15 @@ import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, AsyncMock, patch
 
+import fastmcp.tools as fastmcp_tools
+from fastmcp.tools.tool import ToolResult
+
+
+def _ensure_fastmcp_toolresult_export() -> None:
+    """Bridge fastmcp import shape drift during router package import."""
+    if not hasattr(fastmcp_tools, "ToolResult"):
+        fastmcp_tools.ToolResult = ToolResult
+
 
 class TestOAuthRefreshClientCredentials:
     """Test that /refresh endpoint handles client_credentials flow correctly."""
@@ -87,6 +96,142 @@ class TestOAuthRefreshClientCredentials:
             mock_refresh.assert_called_once()
             assert success is True
             assert result["access_token"] == "refreshed-access-token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_endpoint_passes_joined_provider_scopes(self):
+        """Authorization-code refresh should forward provider scopes into shared refresh context."""
+        _ensure_fastmcp_toolresult_export()
+        from src.routers.oauth_connections import refresh_token
+
+        provider = MagicMock()
+        provider.oauth_flow_type = "authorization_code"
+        provider.token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+        provider.client_id = "test-client-id"
+        provider.encrypted_client_secret = b"encrypted-secret"
+        provider.scopes = [
+            "openid",
+            "offline_access",
+            "https://graph.microsoft.com/Directory.ReadWrite.All",
+        ]
+        provider.audience = None
+        provider.status = "completed"
+        provider.status_message = None
+
+        token = MagicMock()
+        token.encrypted_refresh_token = b"encrypted-refresh-token"
+
+        ctx = MagicMock()
+        ctx.db = AsyncMock()
+        ctx.org_id = None
+
+        with (
+            patch("src.routers.oauth_connections.OAuthConnectionRepository.get_connection", new=AsyncMock(return_value=provider)),
+            patch("src.routers.oauth_connections.OAuthConnectionRepository.get_token", new=AsyncMock(return_value=token)),
+            patch(
+                "src.routers.oauth_connections.build_token_refresh_context",
+                new=AsyncMock(
+                    return_value={
+                        "token_id": "token-id",
+                        "provider_id": "provider-id",
+                        "provider_name": "Microsoft CSP",
+                        "oauth_flow_type": "authorization_code",
+                        "client_id": provider.client_id,
+                        "encrypted_client_secret": provider.encrypted_client_secret,
+                        "token_url": provider.token_url,
+                        "token_url_defaults": {},
+                        "scopes": provider.scopes,
+                        "audience": provider.audience,
+                        "encrypted_refresh_token": token.encrypted_refresh_token,
+                    }
+                ),
+            ) as mock_build_context,
+            patch(
+                "src.routers.oauth_connections.refresh_oauth_token_http",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "access_token": "refreshed-access-token",
+                        "encrypted_access_token": b"encrypted-access-token",
+                        "encrypted_refresh_token": b"encrypted-refresh-token",
+                        "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+                    }
+                ),
+            ) as mock_refresh_http,
+            patch("src.routers.oauth_connections.CACHE_INVALIDATION_AVAILABLE", False),
+        ):
+            result = await refresh_token(
+                connection_name="Microsoft CSP",
+                ctx=ctx,
+                user=MagicMock(),
+            )
+
+        assert result.success is True
+        mock_build_context.assert_awaited_once()
+        mock_refresh_http.assert_awaited_once()
+        assert mock_refresh_http.await_args.args[0]["scopes"] == [
+            "openid",
+            "offline_access",
+            "https://graph.microsoft.com/Directory.ReadWrite.All",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_callback_passes_joined_provider_scopes(self):
+        """OAuth callback should forward joined provider scopes into code exchange."""
+        _ensure_fastmcp_toolresult_export()
+        from src.models.contracts.oauth import OAuthCallbackRequest
+        from src.routers.oauth_connections import oauth_callback
+
+        provider = MagicMock()
+        provider.token_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+        provider.client_id = "test-client-id"
+        provider.encrypted_client_secret = b"encrypted-secret"
+        provider.scopes = [
+            "openid",
+            "offline_access",
+            "https://api.partnercenter.microsoft.com/user_impersonation",
+        ]
+        provider.audience = None
+
+        ctx = MagicMock()
+        ctx.db = AsyncMock()
+        ctx.org_id = None
+
+        request = OAuthCallbackRequest(
+            code="authorization_code_123",
+            state="state-123",
+            redirect_uri="https://app.example.com/oauth/callback/test",
+            organization_id=None,
+        )
+
+        with (
+            patch("src.routers.oauth_connections.OAuthConnectionRepository.get_connection", new=AsyncMock(return_value=provider)),
+            patch("src.routers.oauth_connections.OAuthConnectionRepository.store_token", new=AsyncMock()),
+            patch("src.routers.oauth_connections.get_url_resolution_defaults", new=AsyncMock(return_value={})),
+            patch("src.routers.oauth_connections.resolve_url_template", return_value=provider.token_url),
+            patch("src.services.oauth_provider.OAuthProviderClient.exchange_code_for_token", new=AsyncMock(return_value=(
+                True,
+                {
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+                    "scope": "openid offline_access https://api.partnercenter.microsoft.com/user_impersonation",
+                },
+            ))) as mock_exchange,
+            patch("src.core.security.decrypt_secret", return_value="decrypted-secret"),
+            patch("src.routers.oauth_connections.CACHE_INVALIDATION_AVAILABLE", False),
+        ):
+            result = await oauth_callback(
+                connection_name="Microsoft CSP",
+                request=request,
+                ctx=ctx,
+                user=MagicMock(),
+            )
+
+        assert result.success is True
+        mock_exchange.assert_awaited_once()
+        assert mock_exchange.await_args.kwargs["scopes"] == (
+            "openid offline_access https://api.partnercenter.microsoft.com/user_impersonation"
+        )
 
     def test_oauth_flow_type_determines_refresh_behavior(self):
         """Flow type should determine which refresh method is used."""

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -151,6 +151,82 @@ class TestOAuthProviderTokenExchange:
             assert result["error"] == "invalid_grant"
             assert "invalid" in result["error_description"].lower()
 
+    @pytest.mark.asyncio
+    async def test_exchange_includes_scope_when_provided(self, oauth_client):
+        """Should include scope in auth code exchange payload when provided."""
+        token_url = "https://oauth.example.com/token"
+
+        with patch('aiohttp.ClientSession') as mock_session_class:
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value={
+                "access_token": "access_token_123",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            })
+
+            mock_post_context = MagicMock()
+            mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session = MagicMock()
+            mock_session.post = MagicMock(return_value=mock_post_context)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session_class.return_value = mock_session
+
+            success, _result = await oauth_client.exchange_code_for_token(
+                token_url=token_url,
+                code="authorization_code_123",
+                client_id="client-id-456",
+                client_secret="client-secret-789",
+                redirect_uri="https://app.example.com/callback",
+                scopes="openid profile offline_access",
+            )
+
+            assert success is True
+            data = mock_session.post.call_args[1]["data"]
+            assert data["scope"] == "openid profile offline_access"
+
+    @pytest.mark.asyncio
+    async def test_exchange_omits_scope_when_not_provided(self, oauth_client):
+        """Should omit scope in auth code exchange payload when not provided."""
+        token_url = "https://oauth.example.com/token"
+
+        with patch('aiohttp.ClientSession') as mock_session_class:
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value={
+                "access_token": "access_token_123",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            })
+
+            mock_post_context = MagicMock()
+            mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session = MagicMock()
+            mock_session.post = MagicMock(return_value=mock_post_context)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session_class.return_value = mock_session
+
+            success, _result = await oauth_client.exchange_code_for_token(
+                token_url=token_url,
+                code="authorization_code_123",
+                client_id="client-id-456",
+                client_secret="client-secret-789",
+                redirect_uri="https://app.example.com/callback",
+                scopes=None,
+            )
+
+            assert success is True
+            data = mock_session.post.call_args[1]["data"]
+            assert "scope" not in data
+
 
 class TestOAuthProviderTokenRefresh:
     """Test access token refresh flow"""
@@ -231,6 +307,80 @@ class TestOAuthProviderTokenRefresh:
 
             assert success is False
             assert "invalid_grant" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_includes_scope_when_provided(self, oauth_client):
+        """Should include scope in refresh payload when provided."""
+        token_url = "https://oauth.example.com/token"
+
+        with patch('aiohttp.ClientSession') as mock_session_class:
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value={
+                "access_token": "new_access_token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            })
+
+            mock_post_context = MagicMock()
+            mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session = MagicMock()
+            mock_session.post = MagicMock(return_value=mock_post_context)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session_class.return_value = mock_session
+
+            success, _result = await oauth_client.refresh_access_token(
+                token_url=token_url,
+                refresh_token="refresh_token_123",
+                client_id="client-id",
+                client_secret="client-secret",
+                scopes="openid profile offline_access",
+            )
+
+            assert success is True
+            data = mock_session.post.call_args[1]["data"]
+            assert data["scope"] == "openid profile offline_access"
+
+    @pytest.mark.asyncio
+    async def test_refresh_omits_scope_when_not_provided(self, oauth_client):
+        """Should omit scope in refresh payload when not provided."""
+        token_url = "https://oauth.example.com/token"
+
+        with patch('aiohttp.ClientSession') as mock_session_class:
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value={
+                "access_token": "new_access_token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            })
+
+            mock_post_context = MagicMock()
+            mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_post_context.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session = MagicMock()
+            mock_session.post = MagicMock(return_value=mock_post_context)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session_class.return_value = mock_session
+
+            success, _result = await oauth_client.refresh_access_token(
+                token_url=token_url,
+                refresh_token="refresh_token_123",
+                client_id="client-id",
+                client_secret="client-secret",
+                scopes=None,
+            )
+
+            assert success is True
+            data = mock_session.post.call_args[1]["data"]
+            assert "scope" not in data
 
 
 class TestOAuthProviderScopes:


### PR DESCRIPTION
## Summary
This fixes delegated OAuth connections against Azure / Entra v2 token endpoints by forwarding configured scopes during authorization-code and refresh-token exchanges.

Today, Bifrost sends `scope` when building authorization URLs and for client-credentials token requests, but not when exchanging an auth code or refreshing an access token. For Azure v2 endpoints, that can fail with:

`AADSTS900144: The request body must contain the following parameter: 'scope'.`

## What changed
- Added optional `scopes` support to `OAuthProviderClient.exchange_code_for_token()`
- Added optional `scopes` support to `OAuthProviderClient.refresh_access_token()`
- Passed configured provider scopes from the OAuth callback path into the auth-code token exchange
- Passed configured provider scopes from the authorization-code refresh path into the shared refresh path
- Added regression coverage for scope forwarding in these flows

## Why this belongs upstream
This is a platform OAuth bug, not a workspace-specific integration quirk. Upstream already supports configured scopes for:
- authorization URL generation
- client-credentials token acquisition

This patch makes the authorization-code and refresh-token paths consistent with that model.

## Behavior notes
- `scope` is only included when scopes are configured
- client-credentials behavior is unchanged
- token storage and OAuth connection schemas are unchanged

## Test coverage
- unit tests for token exchange payload construction
- unit tests for refresh payload construction
- router-level verification that configured provider scopes are forwarded in the authorization-code refresh path
- router-level verification that configured provider scopes are forwarded in the OAuth callback path

## Validation
- `/home/thomas/mtg-bifrost/bifrost/.venv/bin/pytest tests/unit/services/test_oauth_provider.py tests/unit/routers/test_oauth_refresh.py -q -s`
- `24 passed in 3.43s`

## Follow-up note
A possible follow-up refinement is to have the authorization-code refresh path prefer stored token scopes over provider scopes if stricter grant preservation is desired.
