### PR TITLE
OSS security & maturity baseline (Tier 0/1/2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS — automatic reviewer assignment
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Right now this is a solo project. As contributors grow, this expands
+# to per-path ownership (e.g. api/ → backend folks, client/ → frontend).
+
+* @jackmusick

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# Dependabot configuration
+# Reference: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Auto-merge policy is enforced by .github/workflows/dependabot-auto-merge.yml
+# (security + patch + minor merge automatically when CI is green; major + Docker
+# stay open for human review).
+
+version: 2
+updates:
+  # Python deps (root requirements.txt)
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - dependencies
+      - python
+
+  # JS/TS deps (client/)
+  - package-ecosystem: npm
+    directory: "/client"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - dependencies
+      - javascript
+
+  # Docker base images — api/
+  - package-ecosystem: docker
+    directory: "/api"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+
+  # Docker base images — client/
+  - package-ecosystem: docker
+    directory: "/client"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+
+  # GitHub Actions — repo root
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,0 +1,50 @@
+# Branch-protection bypass for docs-only PRs.
+#
+# Background: ci.yml uses paths-ignore to skip Lint/Unit/E2E on docs-only
+# changes. But branch protection requires named status checks (e.g.
+# "Lint & Type Check") to report green before merge — and a job that
+# never runs reports nothing, blocking merge forever.
+#
+# This workflow has the INVERSE trigger (paths: matches the same set
+# that ci.yml's paths-ignore: skips) and reports the same status-check
+# names with always-green stub jobs. GitHub branch protection looks up
+# checks by name only, so it accepts these as satisfying the requirement.
+#
+# Keep the `name:` of each job below in EXACT sync with the corresponding
+# job's `name:` in ci.yml.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - ".claude/**"
+      - "docs/**"
+      - "LICENSE"
+      - ".github/CODEOWNERS"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/dependabot.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint & Type Check
+    steps:
+      - run: echo "Skipped — docs/config-only PR."
+
+  test-unit:
+    runs-on: ubuntu-latest
+    name: Unit Tests
+    steps:
+      - run: echo "Skipped — docs/config-only PR."
+
+  test-e2e:
+    runs-on: ubuntu-latest
+    name: E2E Tests
+    steps:
+      - run: echo "Skipped — docs/config-only PR."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     name: Lint & Type Check
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -50,7 +50,7 @@ jobs:
         run: ../.venv/bin/pyright
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: npm
@@ -76,10 +76,10 @@ jobs:
     name: Unit Tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Run unit tests
         run: |
@@ -88,7 +88,7 @@ jobs:
           ./test.sh unit
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           files: ./coverage.xml
           flags: api
@@ -103,10 +103,10 @@ jobs:
     name: E2E Tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Run E2E tests
         run: |
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -140,17 +140,17 @@ jobs:
           echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push API dev image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./api/Dockerfile
@@ -166,7 +166,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push client dev image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: ./client
           file: ./client/Dockerfile
@@ -194,7 +194,7 @@ jobs:
     name: Deploy Dry Run
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -256,7 +256,7 @@ jobs:
 
     steps:
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2.5.2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -314,7 +314,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -325,10 +325,10 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -336,7 +336,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.API_IMAGE }}
           tags: |
@@ -350,7 +350,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
 
       - name: Build and push API image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./api/Dockerfile
@@ -376,7 +376,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -387,10 +387,10 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -398,7 +398,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.CLIENT_IMAGE }}
           tags: |
@@ -412,7 +412,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
 
       - name: Build and push client image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: ./client
           file: ./client/Dockerfile
@@ -438,7 +438,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Get version from tag
         id: get_version
@@ -461,7 +461,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
           name: Release ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,21 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+    # Skip CI for documentation/config-only changes. The companion workflow
+    # ci-noop.yml fires on these same paths and reports the same status-check
+    # names (Lint & Type Check, Unit Tests, E2E Tests) so branch protection
+    # still sees the required checks reported as green.
+    #
+    # IMPORTANT: do NOT add .github/workflows/** to this list — workflow
+    # changes must always run CI so we catch CI-breaking edits before merge.
+    paths-ignore:
+      - "**/*.md"
+      - ".claude/**"
+      - "docs/**"
+      - "LICENSE"
+      - ".github/CODEOWNERS"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/dependabot.yml"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# CodeQL — GitHub-native SAST
+# Findings appear under: Security tab → Code scanning
+# https://docs.github.com/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run catches CVEs in newly-published advisories that match
+    # existing code patterns (CodeQL queries are updated by GitHub).
+    - cron: "0 9 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,58 @@
+# Dependabot auto-merge policy enforcement
+#
+# Policy (also documented in SECURITY.md):
+#   - Security advisory bumps  → auto-merge when CI green (any semver level)
+#   - Patch updates            → auto-merge when CI green
+#   - Minor updates            → auto-merge when CI green
+#   - Major updates            → label needs-review, leave open
+#   - Docker base images       → label needs-review, leave open
+#
+# Mechanism: enable GitHub auto-merge on the eligible PRs. Branch protection
+# requires CI green before merge happens, so this never bypasses CI.
+
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          alert-lookup: true
+
+      - name: Auto-merge security advisory bumps (any semver level)
+        if: steps.metadata.outputs.alert-state == 'OPEN'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge non-major version updates (skip Docker)
+        if: |
+          steps.metadata.outputs.alert-state == '' &&
+          steps.metadata.outputs.package-ecosystem != 'docker' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label majors and Docker for human review
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-major' ||
+          steps.metadata.outputs.package-ecosystem == 'docker'
+        run: gh pr edit "$PR_URL" --add-label needs-review
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,53 @@
+# OpenSSF Scorecard
+# Reference: https://github.com/ossf/scorecard-action
+#
+# Publishes results to:
+#   - GitHub Security tab → Code scanning (under "scorecard")
+#   - https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost
+#
+# The README badge auto-updates from the public API.
+
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 10 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          sarif_file: results.sarif

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Open-source automation platform for Integration Services** - Built to democratize best-in-class tooling before venture capital gets the chance to own something we're all incredibly passionate about.
 
-[![License: AGPL](https://img.shields.io/badge/License-AGPL-green.svg)](https://opensource.org/licenses/agpl)
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![CodeQL](https://github.com/jackmusick/bifrost/actions/workflows/codeql.yml/badge.svg)](https://github.com/jackmusick/bifrost/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost/badge)](https://securityscorecards.dev/viewer/?uri=github.com/jackmusick/bifrost)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-green.svg)](https://fastapi.tiangolo.com/)
 [![Python](https://img.shields.io/badge/Python-3.11-blue.svg)](https://www.python.org/)
 [![Docker](https://img.shields.io/badge/Docker-Compose-blue.svg)](https://www.docker.com/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+## Supported Versions
+
+Bifrost is in active development against `main`. Only `main` is supported
+at this time — there are no LTS branches. If you're running a fork or a
+historical commit, please rebase onto current `main` before reporting.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `main`  | :white_check_mark: |
+| Older   | :x:                |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security reports.**
+
+Two ways to report privately:
+
+### 1. GitHub private vulnerability reporting (preferred)
+
+Go to https://github.com/jackmusick/bifrost/security/advisories/new
+and submit a draft advisory. This keeps the report confidential and lets
+us discuss + patch + coordinate disclosure inside GitHub's tooling.
+
+### 2. Email
+
+If you can't use GitHub's flow, email **jackmmusick@gmail.com** with:
+
+- A description of the issue and its impact
+- Reproduction steps
+- The affected commit / branch
+- Your contact info for follow-up
+
+### Response SLA
+
+- **Acknowledgment:** within 48 hours of report
+- **Triage + severity assessment:** within 7 days
+- **Patch + advisory disclosure:** depends on severity; we'll communicate
+  expected timelines after triage
+
+We don't currently run a paid bug bounty. If your report leads to a fix,
+we'll credit you in the advisory and the release notes (unless you'd
+rather stay anonymous).
+
+## Supply-Chain Practices
+
+The repo runs:
+
+- **Dependabot alerts + security updates** for `pip`, `npm`, `docker`,
+  `github-actions` (see `.github/dependabot.yml`)
+- **CodeQL** SAST on push, PR, and weekly schedule
+  (see `.github/workflows/codeql.yml`)
+- **Secret scanning + push protection** at the repo level
+- **OpenSSF Scorecard** weekly, results published to
+  https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost
+
+### Auto-Merge Policy for Dependency Updates
+
+To keep patch SLAs short, Dependabot PRs auto-merge under these conditions:
+
+| Update type | Auto-merge |
+|---|---|
+| Security advisory bumps | Yes if CI green |
+| Patch (`x.y.Z`) | Yes if CI green |
+| Minor (`x.Y.z`) | Yes if CI green |
+| Major (`X.y.z`) | No — human review |
+| Docker base image | No — human review |
+| GitHub Actions (pinned to SHA) | Yes if CI green |
+
+Auto-merged PRs still go through the full CI suite (lint, typecheck,
+unit, e2e). If a green-CI auto-merge later breaks something, the
+behavior is by definition uncovered by tests — the response is to add
+the test and fix forward, not to gate the auto-merge harder.
+
+## What's Out of Scope
+
+- Issues in dependencies — report those upstream.
+- Issues in self-hosted deployments where the operator misconfigured
+  the deployment (open ports, weak passwords, etc.) — these are
+  operator concerns, not Bifrost vulnerabilities.
+- DoS via deliberate resource exhaustion of a single-tenant deploy.

--- a/docs/superpowers/plans/2026-04-25-oss-security-maturity.md
+++ b/docs/superpowers/plans/2026-04-25-oss-security-maturity.md
@@ -1,0 +1,985 @@
+# OSS Security & Maturity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the standard OSS supply-chain + security + community-health baseline (LICENSE, Dependabot, CodeQL, secret scanning, OpenSSF Scorecard, SECURITY.md, branch protection) to the Bifrost repo in a single PR.
+
+**Architecture:** All work is config files at the repo root and under `.github/`. No application code changes. The PR adds 8 new files, edits 2, and is followed by a checklist of repo Settings clicks the user performs after merge. A separate plan written after the Security tab populates will cover the Tier 4 skills + watch-loop work.
+
+**Tech Stack:** GitHub Actions (YAML), Dependabot, CodeQL, OpenSSF Scorecard Action, GNU AGPL-3.0 license text.
+
+**Out of scope (deferred to follow-up plan):**
+- `.claude/skills/bifrost-secupdate/` and `.claude/skills/bifrost-secaudit/` — written after Security tab populates so skills can reference real alert structure
+- The one-time `/loop` invocation — runs after the PR merges
+- SonarCloud / Snyk / Socket.dev (Tier 3) — explicitly skipped, revisit in 2-3 months
+
+**Spec:** See `docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md` for context, decision rationale, and verification criteria.
+
+---
+
+## File Structure
+
+| Path | Action | Tier |
+|---|---|---|
+| `LICENSE` | Create — full AGPL-3.0 text | 0 |
+| `.github/dependabot.yml` | Create | 1 |
+| `.github/workflows/codeql.yml` | Create | 1 |
+| `.github/workflows/dependabot-auto-merge.yml` | Create | 1 |
+| `.github/workflows/scorecard.yml` | Create | 2 |
+| `.github/workflows/ci.yml` | Edit — pin all `uses:` lines to commit SHAs | 2 |
+| `.github/CODEOWNERS` | Create | 2 |
+| `SECURITY.md` | Create | 2 |
+| `README.md` | Edit — fix license badge link, add Scorecard + CodeQL badges | 2 |
+
+Each file has one focused responsibility. Workflows live in `.github/workflows/`. Top-level governance files (`LICENSE`, `SECURITY.md`, `CODEOWNERS`) live where GitHub expects to auto-discover them.
+
+---
+
+## Task 1: Add LICENSE file (Tier 0)
+
+**Files:**
+- Create: `LICENSE`
+
+**Why:** README claims AGPL but no `LICENSE` file exists. GitHub's license API returns 404, the repo sidebar shows no license, and the AGPL claim has no enforceable text behind it. This blocks Tier 2 (the README license badge needs a real file to link to) so it goes first.
+
+- [ ] **Step 1: Download the canonical AGPL-3.0 text**
+
+The SPDX-canonical AGPL-3.0 text is hosted by the FSF. Use `curl` to fetch it directly into the repo so we don't introduce typos.
+
+```bash
+curl -sSfL https://www.gnu.org/licenses/agpl-3.0.txt -o LICENSE
+```
+
+- [ ] **Step 2: Verify it downloaded correctly**
+
+```bash
+head -5 LICENSE
+wc -l LICENSE
+```
+
+Expected:
+- First line: `                    GNU AFFERO GENERAL PUBLIC LICENSE`
+- Line count: ~660 lines (varies slightly with whitespace; should be in the 600-700 range)
+
+- [ ] **Step 3: Confirm SPDX detection**
+
+GitHub uses the `licensee` Ruby gem to detect license. The canonical FSF text matches the `AGPL-3.0` SPDX identifier. There's nothing to run locally — we'll verify after the PR merges via `gh api repos/jackmusick/bifrost/license`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add LICENSE
+git commit -m "$(cat <<'EOF'
+chore: add AGPL-3.0 LICENSE file
+
+README has badged AGPL since project inception but the LICENSE file was
+missing — the AGPL claim was unenforceable until this lands. Pulls the
+canonical FSF text so GitHub's licensee detection identifies it as AGPL-3.0.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add Dependabot config (Tier 1)
+
+**Files:**
+- Create: `.github/dependabot.yml`
+
+**Why:** This config tells Dependabot which ecosystems to scan, how often, and how to group PRs. Without it, only security-update PRs flow (after the user enables them in Settings); routine version updates need this YAML.
+
+- [ ] **Step 1: Verify the manifest paths Dependabot will watch**
+
+```bash
+ls requirements.txt client/package.json api/Dockerfile api/Dockerfile.dev client/Dockerfile client/Dockerfile.dev client/Dockerfile.playwright
+```
+
+Expected: all 7 files exist (1 pip manifest, 1 npm manifest, 5 Dockerfiles).
+
+- [ ] **Step 2: Write `.github/dependabot.yml`**
+
+```yaml
+# Dependabot configuration
+# Reference: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Auto-merge policy is enforced by .github/workflows/dependabot-auto-merge.yml
+# (security + patch + minor merge automatically when CI is green; major + Docker
+# stay open for human review).
+
+version: 2
+updates:
+  # Python deps (root requirements.txt)
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - dependencies
+      - python
+
+  # JS/TS deps (client/)
+  - package-ecosystem: npm
+    directory: "/client"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - dependencies
+      - javascript
+
+  # Docker base images — api/
+  - package-ecosystem: docker
+    directory: "/api"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+
+  # Docker base images — client/
+  - package-ecosystem: docker
+    directory: "/client"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+
+  # GitHub Actions — repo root
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels:
+      - dependencies
+      - github-actions
+```
+
+Notes encoded in the config:
+- `groups` blocks for `pip`, `npm`, `github-actions` keep weekly version-update noise to ~1 PR per ecosystem (minor+patch grouped); majors stay individual.
+- Docker is intentionally **not** grouped — base-image bumps deserve individual PRs (they require human review per the auto-merge policy).
+- Security updates are not configured here; they're enabled at the repo Settings level (Task 9 manual checklist) and don't honor `groups`.
+
+- [ ] **Step 3: Validate YAML syntax**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"
+```
+
+Expected: no output (parse succeeds). Any error means a typo to fix.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/dependabot.yml
+git commit -m "$(cat <<'EOF'
+chore(deps): add Dependabot config for pip, npm, docker, actions
+
+Weekly version-update sweep with minor+patch grouped per ecosystem to
+keep PR noise manageable. Majors stay individual for human review. Docker
+intentionally ungrouped — base-image changes warrant per-PR review.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add CodeQL workflow (Tier 1)
+
+**Files:**
+- Create: `.github/workflows/codeql.yml`
+
+**Why:** CodeQL is GitHub's free SAST. Catches injection, deserialization, and other code-level vulnerabilities. Findings land in the Security tab; PR-level alerts surface inline.
+
+- [ ] **Step 1: Write `.github/workflows/codeql.yml`**
+
+```yaml
+# CodeQL — GitHub-native SAST
+# Findings appear under: Security tab → Code scanning
+# https://docs.github.com/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run catches CVEs in newly-published advisories that match
+    # existing code patterns (CodeQL queries are updated by GitHub).
+    - cron: "0 9 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.0
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.0
+        with:
+          category: "/language:${{ matrix.language }}"
+```
+
+Notes:
+- All `uses:` are pinned to commit SHAs with the version as a comment — Scorecard's Pinned-Dependencies check requires this.
+- `security-and-quality` query suite is broader than `security-extended` — catches code-quality issues alongside vulns.
+- Matrix split lets one language fail without blocking the other.
+
+- [ ] **Step 2: Validate YAML syntax**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/codeql.yml
+git commit -m "$(cat <<'EOF'
+ci: add CodeQL workflow for python and javascript-typescript
+
+Runs SAST on push/PR and weekly. Findings flow to Security tab → Code scanning.
+Actions are pinned to commit SHAs for Scorecard's Pinned-Dependencies check.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add Dependabot auto-merge workflow (Tier 1)
+
+**Files:**
+- Create: `.github/workflows/dependabot-auto-merge.yml`
+
+**Why:** Encodes the auto-merge policy (security + patch + minor merge auto when CI green; major + Docker need human review) so Dependabot PRs don't pile up.
+
+- [ ] **Step 1: Write `.github/workflows/dependabot-auto-merge.yml`**
+
+```yaml
+# Dependabot auto-merge policy enforcement
+#
+# Policy (also documented in SECURITY.md):
+#   - Security updates  → auto-merge when CI green
+#   - Patch updates     → auto-merge when CI green
+#   - Minor updates     → auto-merge when CI green
+#   - Major updates     → label needs-review, leave open
+#   - Docker updates    → label needs-review, leave open
+#
+# Mechanism: enable GitHub auto-merge on the eligible PRs. Branch protection
+# requires CI green before merge happens, so this never bypasses CI.
+
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for safe updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.dependency-type == 'direct:production' && contains(steps.metadata.outputs.dependency-names, 'security')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Always-merge security advisory bumps
+        # Dependabot exposes alert-driven security updates via the
+        # `dependency-group` not being set AND the alert metadata being present.
+        # Simpler heuristic: PRs with the `security` label that Dependabot adds
+        # automatically when the bump resolves a GHSA advisory.
+        if: contains(github.event.pull_request.labels.*.name, 'security')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label majors and Docker for human review
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-major' ||
+          steps.metadata.outputs.package-ecosystem == 'docker'
+        run: gh pr edit "$PR_URL" --add-label needs-review
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Notes:
+- `pull_request_target` is required so the workflow runs with the base-branch token (Dependabot PRs from forks get a read-only token otherwise).
+- `if: github.actor == 'dependabot[bot]'` gates the entire job — humans opening PRs are unaffected.
+- `gh pr merge --auto` *enables* auto-merge; the actual merge happens when branch protection's required checks pass.
+- The "security" detection has two paths because Dependabot's metadata around security advisories has changed historically — the label-based check is the reliable one; the dependency-name match is belt-and-suspenders.
+
+- [ ] **Step 2: Validate YAML syntax**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/dependabot-auto-merge.yml'))"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/dependabot-auto-merge.yml
+git commit -m "$(cat <<'EOF'
+ci: add Dependabot auto-merge workflow
+
+Enforces auto-merge policy:
+- security/patch/minor: enable auto-merge (waits for CI green via branch
+  protection, then squashes)
+- major/docker: label needs-review and leave open
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Add OpenSSF Scorecard workflow (Tier 2)
+
+**Files:**
+- Create: `.github/workflows/scorecard.yml`
+
+**Why:** Runs the scorecard scan weekly, publishes results to GitHub's Security tab and the public `securityscorecards.dev` API. Source of the badge in the README.
+
+- [ ] **Step 1: Write `.github/workflows/scorecard.yml`**
+
+```yaml
+# OpenSSF Scorecard
+# Reference: https://github.com/ossf/scorecard-action
+#
+# Publishes results to:
+#   - GitHub Security tab → Code scanning (under "scorecard")
+#   - https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost
+#
+# The README badge auto-updates from the public API.
+
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 10 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@4e828ff8d448a8a6e532957b1811f387a63867e8 # v3.29.0
+        with:
+          sarif_file: results.sarif
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/scorecard.yml
+git commit -m "$(cat <<'EOF'
+ci: add OpenSSF Scorecard workflow
+
+Weekly scorecard scan publishing to Security tab + securityscorecards.dev.
+README badge added in a later commit consumes the public API.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Pin GitHub Actions in ci.yml to commit SHAs (Tier 2)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Why:** Scorecard's Pinned-Dependencies check requires SHAs (mutable tags like `@v4` can be repointed by a compromised maintainer). This is a mechanical edit: replace every `uses: foo@vN` with `uses: foo@<sha> # vN`.
+
+The ci.yml currently uses these actions:
+- `actions/checkout@v4` and `@v5` (mixed — fix to single version)
+- `actions/setup-python@v6`
+- `actions/setup-node@v5`
+- `codecov/codecov-action@v4`
+- `digitalocean/action-doctl@v2`
+- `docker/build-push-action@v5`
+- `docker/login-action@v3`
+- `docker/metadata-action@v5`
+- `docker/setup-buildx-action@v3`
+- `softprops/action-gh-release@v1`
+
+- [ ] **Step 1: Resolve current SHAs for each action**
+
+For each action, fetch the SHA of its latest matching tag:
+
+```bash
+gh api repos/actions/checkout/git/refs/tags/v4.2.2 --jq '.object.sha'
+gh api repos/actions/checkout/git/refs/tags/v5.0.0 --jq '.object.sha'
+gh api repos/actions/setup-python/git/refs/tags/v6.0.0 --jq '.object.sha'
+gh api repos/actions/setup-node/git/refs/tags/v5.0.0 --jq '.object.sha'
+gh api repos/codecov/codecov-action/git/refs/tags/v4.6.0 --jq '.object.sha'
+gh api repos/digitalocean/action-doctl/git/refs/tags/v2.5.1 --jq '.object.sha'
+gh api repos/docker/build-push-action/git/refs/tags/v5.4.0 --jq '.object.sha'
+gh api repos/docker/login-action/git/refs/tags/v3.3.0 --jq '.object.sha'
+gh api repos/docker/metadata-action/git/refs/tags/v5.6.1 --jq '.object.sha'
+gh api repos/docker/setup-buildx-action/git/refs/tags/v3.7.1 --jq '.object.sha'
+gh api repos/softprops/action-gh-release/git/refs/tags/v1.0.0 --jq '.object.sha'
+```
+
+Some of these tag names may be wrong (e.g. `v4.2.2` vs latest `v4.x` could be different). For each, if the tag returns a 404, run `gh api repos/<owner>/<repo>/releases/latest --jq '.tag_name'` first to discover the actual latest tag name. Capture every (action, version, SHA) triple before editing the file.
+
+Example: `actions/checkout v4.2.2` → SHA `11bd71901bbe5b1630ceea73d27597364c9af683`.
+
+- [ ] **Step 2: Replace every `uses: foo@vN` line in ci.yml**
+
+For each action found in step 1, edit ci.yml replacing:
+
+```yaml
+        uses: actions/checkout@v4
+```
+
+with:
+
+```yaml
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+```
+
+There's a mix of `actions/checkout@v4` and `@v5` in the file — use the highest version (`v5.x`) consistently for both, with the resolved SHA. The version comment (`# v5.0.0`) is what Dependabot's `github-actions` ecosystem reads when proposing future bumps, so keep it accurate.
+
+- [ ] **Step 3: Verify no unpinned uses remain in the changed file**
+
+```bash
+grep -nE 'uses:.*@v[0-9]+([.]|$|\s)' .github/workflows/ci.yml
+```
+
+Expected: empty output (every `uses:` is now an SHA followed by `# vN.N.N`).
+
+- [ ] **Step 4: Validate YAML syntax**
+
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "$(cat <<'EOF'
+ci: pin all GitHub Actions in ci.yml to commit SHAs
+
+Required for OpenSSF Scorecard's Pinned-Dependencies check. Mutable tags
+like @v4 can be silently repointed by a compromised maintainer; SHAs
+cannot. Version comments (# v4.2.2) preserve Dependabot's ability to
+detect newer releases.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Add CODEOWNERS (Tier 2)
+
+**Files:**
+- Create: `.github/CODEOWNERS`
+
+**Why:** GitHub uses this for automatic PR reviewer assignment. Scorecard's Code-Review check looks for it. Solo project, so the rule is simple — but the file's existence matters.
+
+- [ ] **Step 1: Write `.github/CODEOWNERS`**
+
+```text
+# CODEOWNERS — automatic reviewer assignment
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Right now this is a solo project. As contributors grow, this expands
+# to per-path ownership (e.g. api/ → backend folks, client/ → frontend).
+
+* @jackmusick
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/CODEOWNERS
+git commit -m "$(cat <<'EOF'
+chore: add CODEOWNERS
+
+Solo-project ownership rule for now (* @jackmusick). Lets GitHub
+auto-request review from the maintainer on every PR and satisfies
+Scorecard's Code-Review check.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Add SECURITY.md (Tier 2)
+
+**Files:**
+- Create: `SECURITY.md`
+
+**Why:** GitHub auto-discovers this file and exposes it as the project's "Security policy" link. Tells researchers how to report vulnerabilities. Required by Scorecard's Security-Policy check.
+
+- [ ] **Step 1: Write `SECURITY.md`**
+
+```markdown
+# Security Policy
+
+## Supported Versions
+
+Bifrost is in active development against `main`. Only `main` is supported
+at this time — there are no LTS branches. If you're running a fork or a
+historical commit, please rebase onto current `main` before reporting.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| `main`  | :white_check_mark: |
+| Older   | :x:                |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security reports.**
+
+Two ways to report privately:
+
+### 1. GitHub private vulnerability reporting (preferred)
+
+Go to https://github.com/jackmusick/bifrost/security/advisories/new
+and submit a draft advisory. This keeps the report confidential and lets
+us discuss + patch + coordinate disclosure inside GitHub's tooling.
+
+### 2. Email
+
+If you can't use GitHub's flow, email **jackmmusick@gmail.com** with:
+
+- A description of the issue and its impact
+- Reproduction steps
+- The affected commit / branch
+- Your contact info for follow-up
+
+### Response SLA
+
+- **Acknowledgment:** within 48 hours of report
+- **Triage + severity assessment:** within 7 days
+- **Patch + advisory disclosure:** depends on severity; we'll communicate
+  expected timelines after triage
+
+We don't currently run a paid bug bounty. If your report leads to a fix,
+we'll credit you in the advisory and the release notes (unless you'd
+rather stay anonymous).
+
+## Supply-Chain Practices
+
+The repo runs:
+
+- **Dependabot alerts + security updates** for `pip`, `npm`, `docker`,
+  `github-actions` (see `.github/dependabot.yml`)
+- **CodeQL** SAST on push, PR, and weekly schedule
+  (see `.github/workflows/codeql.yml`)
+- **Secret scanning + push protection** at the repo level
+- **OpenSSF Scorecard** weekly, results published to
+  https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost
+
+### Auto-Merge Policy for Dependency Updates
+
+To keep patch SLAs short, Dependabot PRs auto-merge under these conditions:
+
+| Update type | Auto-merge |
+|---|---|
+| Security advisory bumps | Yes if CI green |
+| Patch (`x.y.Z`) | Yes if CI green |
+| Minor (`x.Y.z`) | Yes if CI green |
+| Major (`X.y.z`) | No — human review |
+| Docker base image | No — human review |
+| GitHub Actions (pinned to SHA) | Yes if CI green |
+
+Auto-merged PRs still go through the full CI suite (lint, typecheck,
+unit, e2e). If a green-CI auto-merge later breaks something, the
+behavior is by definition uncovered by tests — the response is to add
+the test and fix forward, not to gate the auto-merge harder.
+
+## What's Out of Scope
+
+- Issues in dependencies — report those upstream.
+- Issues in self-hosted deployments where the operator misconfigured
+  the deployment (open ports, weak passwords, etc.) — these are
+  operator concerns, not Bifrost vulnerabilities.
+- DoS via deliberate resource exhaustion of a single-tenant deploy.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add SECURITY.md
+git commit -m "$(cat <<'EOF'
+docs: add SECURITY.md
+
+Vulnerability disclosure policy: GitHub private advisories preferred,
+email fallback at jackmmusick@gmail.com. Documents the auto-merge policy
+so contributors know what lands without human review and why.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Update README.md (Tier 2)
+
+**Files:**
+- Modify: `README.md` (lines 5-9, 232-236)
+
+**Why:** Two issues to fix:
+1. License badge links to `https://opensource.org/licenses/agpl` (404 — that page doesn't exist) and shows "License: AGPL" instead of standard SPDX text "AGPL-3.0".
+2. No Scorecard or CodeQL badges yet — both are standard for OSS projects taking security seriously.
+
+- [ ] **Step 1: Read current badge block and license section**
+
+```bash
+sed -n '5,9p' README.md
+sed -n '232,236p' README.md
+```
+
+Confirm contents match what's in the spec (5 badges starting with License at line 5; License section at line 232).
+
+- [ ] **Step 2: Edit the badge block**
+
+Replace lines 5-9 with the corrected license badge + new Scorecard + CodeQL badges. The full new block:
+
+```markdown
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![CodeQL](https://github.com/jackmusick/bifrost/actions/workflows/codeql.yml/badge.svg)](https://github.com/jackmusick/bifrost/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost/badge)](https://securityscorecards.dev/viewer/?uri=github.com/jackmusick/bifrost)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-green.svg)](https://fastapi.tiangolo.com/)
+[![Python](https://img.shields.io/badge/Python-3.11-blue.svg)](https://www.python.org/)
+[![Docker](https://img.shields.io/badge/Docker-Compose-blue.svg)](https://www.docker.com/)
+[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-blue.svg)](https://www.postgresql.org/)
+```
+
+Changes:
+- License badge: `License-AGPL` → `License-AGPL--3.0` (the `--` renders as a single `-` in shields.io URL encoding); link target `https://opensource.org/licenses/agpl` → `LICENSE` (relative link to the in-repo file).
+- Added CodeQL badge (links to the workflow runs page).
+- Added Scorecard badge (auto-updates from the public API once the workflow has run at least once after merge).
+
+Use Edit tool with old_string being the existing 5 lines (5-9) and new_string being the 7 lines above.
+
+- [ ] **Step 3: No change needed to the License section text (lines 232-236)**
+
+The existing text:
+```markdown
+This project is licensed under the AGPL License - see the [LICENSE](LICENSE) file for details.
+```
+
+…already links to `LICENSE` correctly. The "Why AGPL?" paragraph below it stays as-is. No edit needed.
+
+- [ ] **Step 4: Verify badge URLs render**
+
+The Scorecard badge will show "no data" until the workflow runs post-merge (~5 min after merge). The other badges should render immediately. Check by opening the markdown in any rendered view (GitHub's PR diff preview works) — but don't block on this; it'll be obvious when the PR is up.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs: fix license badge link, add CodeQL + Scorecard badges
+
+- License badge was linking to a 404 page on opensource.org and labeled
+  generically as "AGPL"; now links to the in-repo LICENSE file and shows
+  the SPDX identifier "AGPL-3.0".
+- New CodeQL badge links to the workflow runs page.
+- New Scorecard badge auto-updates from securityscorecards.dev once the
+  scorecard workflow has its first post-merge run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Open the PR
+
+**Files:** none (operates on the branch)
+
+**Why:** All Tier 0/1/2 file work is done. The PR description carries the manual checklist the user must follow after merge.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin oss-hardening
+```
+
+- [ ] **Step 2: Open the PR with the manual checklist in the body**
+
+```bash
+gh pr create --title "OSS security & maturity baseline (Tier 0/1/2)" --body "$(cat <<'EOF'
+Adds the supply-chain + security + community-health baseline. See
+`docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md` for
+context and `docs/superpowers/plans/2026-04-25-oss-security-maturity.md`
+for the per-task plan.
+
+## What this PR adds
+
+- **`LICENSE`** — full AGPL-3.0 text (README has badged AGPL since day 1
+  but the file was missing — GitHub's license API returned 404).
+- **`.github/dependabot.yml`** — pip + npm + docker + github-actions,
+  weekly, minor+patch grouped per ecosystem.
+- **`.github/workflows/codeql.yml`** — SAST on push/PR + weekly.
+- **`.github/workflows/dependabot-auto-merge.yml`** — security/patch/minor
+  auto-merge when CI green; major + Docker labeled `needs-review`.
+- **`.github/workflows/scorecard.yml`** — OpenSSF Scorecard, weekly + on
+  branch-protection-rule changes.
+- **`.github/CODEOWNERS`** — `* @jackmusick` (solo project for now).
+- **`SECURITY.md`** — vulnerability disclosure policy + auto-merge policy
+  documentation.
+- **`README.md`** — fixed broken license badge link, added CodeQL +
+  Scorecard badges.
+- **`.github/workflows/ci.yml`** — pinned all `uses:` to commit SHAs
+  (Scorecard Pinned-Dependencies check).
+
+## Manual steps after merge
+
+1. **Settings → Code security**, toggle ON:
+   - Dependabot alerts
+   - Dependabot security updates
+   - Dependabot version updates
+   - Secret scanning
+   - Push protection
+   - Confirm CodeQL is detected (should auto-light-up once the workflow
+     runs).
+
+2. **Configure branch protection on `main`** by running this command
+   locally (after replacing the contexts list with the actual job names
+   from the latest CI run):
+
+   ```bash
+   gh api -X PUT repos/jackmusick/bifrost/branches/main/protection \
+     --input - <<'JSON'
+   {
+     "required_status_checks": {
+       "strict": true,
+       "contexts": [
+         "Lint & Type Check",
+         "Unit Tests",
+         "Analyze (python)",
+         "Analyze (javascript-typescript)"
+       ]
+     },
+     "enforce_admins": false,
+     "required_pull_request_reviews": {
+       "required_approving_review_count": 1,
+       "dismiss_stale_reviews": true,
+       "require_code_owner_reviews": false
+     },
+     "restrictions": null,
+     "allow_force_pushes": false,
+     "allow_deletions": false,
+     "required_linear_history": true,
+     "required_conversation_resolution": true
+   }
+   JSON
+   ```
+
+   Note: `required_approving_review_count: 1` on a solo project means you'd
+   need to either have a co-maintainer review, use admin bypass, or set
+   this to `0`. Scorecard's Code-Review check accepts `0` as long as
+   the protection rule itself exists.
+
+3. **Wait ~30 minutes** for the Security tab to populate with Dependabot
+   alerts + first CodeQL scan.
+
+4. **Reply with `/loop`** (or just "go") in the conversation that opened
+   this PR — kicks off the one-time watch loop that drains the security
+   queue. The `/loop` is a one-shot — no recurring schedule is set up
+   here.
+
+## Verification after merge
+
+- `gh api repos/jackmusick/bifrost/license --jq '.license.spdx_id'` →
+  `"AGPL-3.0"` (was 404)
+- `gh api repos/jackmusick/bifrost/vulnerability-alerts -i` → HTTP 204
+- Security tab populates within 30 min
+- `curl -s https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost | jq .score`
+  → ≥7 (after first scorecard.yml run, ~5 min post-merge)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify CI is running on the PR**
+
+```bash
+gh pr checks
+```
+
+Expected: `Lint & Type Check`, `Unit Tests`, the new `Analyze (python)` and `Analyze (javascript-typescript)` jobs all in `pending` or `in_progress`.
+
+- [ ] **Step 4: Wait for CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all checks pass. The new CodeQL job may report warnings (it's the first scan) but should succeed. If it fails:
+- For workflow YAML errors: read the failure, fix, push.
+- For genuine CodeQL findings: leave them — they get triaged in the post-merge loop, not this PR.
+
+---
+
+## Verification (after PR merges + manual checklist)
+
+These are checked manually by the user (or by Claude in the follow-up `/loop` session); they're listed here so the spec's verification criteria are explicit at the plan level.
+
+**Tier 0:**
+- `gh api repos/jackmusick/bifrost/license --jq '.license.spdx_id'` returns `"AGPL-3.0"` (currently 404)
+- GitHub repo sidebar shows "AGPL-3.0 license"
+
+**Tier 1:**
+- `gh api repos/jackmusick/bifrost/vulnerability-alerts -i` returns HTTP 204
+- Security tab → Dependabot alerts: ≥1 alert (high probability for a project with this many transitive deps)
+- Within ~hours: first patch-update PR opens and gets auto-merged without human action
+- CodeQL: Actions tab → CodeQL workflow ran successfully on the PR
+
+**Tier 2:**
+- `curl -s https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost | jq .score` returns ≥7
+- README Scorecard badge renders the score (~5 min after first scorecard.yml run)
+- `https://github.com/jackmusick/bifrost/security/policy` shows SECURITY.md
+- `grep -nE 'uses:.*@v[0-9]+([.]|$|\s)' .github/workflows/*.yml` returns empty
+
+---
+
+## Self-Review Notes
+
+Coverage check against spec (`docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md`):
+- Tier 0 (LICENSE) → Task 1 ✓
+- Tier 1 dependabot.yml → Task 2 ✓
+- Tier 1 CodeQL workflow → Task 3 ✓
+- Tier 1 auto-merge workflow → Task 4 ✓
+- Tier 2 Scorecard workflow → Task 5 ✓
+- Tier 2 pin actions → Task 6 ✓
+- Tier 2 CODEOWNERS → Task 7 ✓
+- Tier 2 SECURITY.md → Task 8 ✓
+- Tier 2 README updates → Task 9 ✓
+- Manual checklist (Settings, branch protection) → Task 10 (in PR body) ✓
+- Tier 4 (skills + watch loop) → **explicitly out of scope; deferred to follow-up plan after merge** ✓
+- Tier 3 (Sonar/Snyk/etc.) → **explicitly skipped** ✓
+
+No placeholders, no TBDs, all code complete in each step. The Task 6 SHA-resolution step requires the engineer to actually run `gh api` calls and capture the SHAs — they're not pre-baked because action versions move; the example SHA in Task 3 (`11bd71901bbe5b1630ceea73d27597364c9af683` for `actions/checkout@v4.2.2`) is real and current as of plan-write time.

--- a/docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md
+++ b/docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md
@@ -1,0 +1,196 @@
+# Bifrost OSS Security & Maturity Setup
+
+## Context
+
+Bifrost is a public OSS project (jackmusick/bifrost) at the "engineering hygiene basics work, but no OSS-maturity layer yet" stage. CI runs lint/typecheck/unit/e2e tests, but there is no dependency scanning, no SAST, no security disclosure policy, no scorecard, and the README claims AGPL while the `LICENSE` file is missing entirely (GitHub's license API returns 404 — the AGPL claim is unenforceable until the file ships).
+
+This work establishes the standard supply-chain + security + community-health baseline that public OSS projects are expected to have. The intended outcome:
+
+- A populated GitHub **Security tab** that functions as a live TODO list (Dependabot CVEs, CodeQL findings, secret-scan hits)
+- **Auto-PRs** for CVE patches and routine dependency staleness, grouped to avoid noise
+- **Auto-merge** on the safe categories (security, patch, minor) so toil drops to ~zero for low-risk updates
+- **OpenSSF Scorecard** publicly visible, scored ≥7/10, badge in README
+- Two skills: `bifrost-secupdate` codifies the alert/PR resolution loop; `bifrost-secaudit` produces a current-state snapshot of the Security tab
+- A **one-time `/loop`** kicked off after the Tier 1+2 PR merges that polls the Security tab until it populates, then drains the backlog, then exits. (A recurring schedule is intentionally out of scope for v1 — separate conversation later.)
+
+User has granted full permission to execute commands autonomously where the tool allows it. A small list of clicks-only Settings toggles will be handed back to the user as a numbered checklist.
+
+## Approach
+
+Four tiers, executed in one PR (or two if Tier 1+2 grow large), then a second pass once GitHub has populated the Security tab.
+
+### Tier 0 — License hygiene (blocker for everything else)
+
+- **Add `LICENSE` file at repo root** with full GNU AGPL-3.0 text (verbatim from gnu.org / SPDX). README already badges and references AGPL — the file just isn't there.
+- **Verify** with `gh api repos/jackmusick/bifrost/license` returning 200 (currently 404).
+
+### Tier 1 — GitHub-native security & dependency tooling
+
+All free, all built-in. Done as repo Settings toggles + workflow files.
+
+**Dependabot — `.github/dependabot.yml`:**
+- Ecosystems:
+  - `pip` — directory `/` (root `requirements.txt`)
+  - `npm` — directory `/client`
+  - `docker` — directories `/api` and `/client` (covers 5 Dockerfiles total: `api/Dockerfile`, `api/Dockerfile.dev`, `client/Dockerfile`, `client/Dockerfile.dev`, `client/Dockerfile.playwright`)
+  - `github-actions` — directory `/`
+- Schedule: `weekly` for version updates (Monday morning)
+- Grouping: minor + patch grouped per ecosystem; majors stay individual so they get human review
+- Open-PR-limit: 10 per ecosystem (default 5 is too tight with grouping disabled for majors)
+- Allow security updates always (separate from version-update grouping)
+
+**CodeQL — `.github/workflows/codeql.yml`:**
+- Use GitHub's "default setup" template via Actions
+- Languages: `python`, `javascript-typescript`
+- Triggers: `push: [main]`, `pull_request: [main]`, `schedule: weekly`
+
+**Repo Settings (manual — user clicks):**
+- Settings → Code security:
+  - Dependabot alerts: ON
+  - Dependabot security updates: ON
+  - Dependabot version updates: ON (reads the YAML we commit)
+  - Secret scanning: ON
+  - Push protection: ON
+  - CodeQL: confirm "Default" setup is active after the workflow lands
+
+**Branch protection on `main`:**
+- Require PR before merging
+- Require ≥1 approving review (solo project — but this enforces the "you don't push directly to main" hygiene that Scorecard's Branch-Protection check looks for)
+- Require status checks: `lint`, `test-unit`, the CodeQL job
+- Require branches up to date before merging
+- Configured via `gh api -X PUT repos/jackmusick/bifrost/branches/main/protection ...` — Claude provides the exact JSON payload, user runs it (faster than debugging API permission scopes against the user's token)
+
+**Auto-merge policy:**
+
+| PR type | Auto-merge |
+|---|---|
+| Security updates (any severity, any semver bump) | Yes if CI green |
+| Version-update — patch (`x.y.Z`) | Yes if CI green |
+| Version-update — minor (`x.Y.z`) | Yes if CI green |
+| Version-update — major (`X.y.z`) | **No** — human review required |
+| GitHub Actions updates (pinned to SHA) | Yes if CI green |
+| Docker base image updates | **No** — human review required |
+
+Rationale (codified in `SECURITY.md` so contributors know the policy): when CI passes and an auto-merge later breaks something, the broken behavior is itself an untested code path — the resolution is "write the test, fix the regression, ship." Faster patch SLA + clearer test coverage is worth more than the rare auto-merge regression.
+
+**Mechanism:** `.github/workflows/dependabot-auto-merge.yml` — listens on Dependabot PRs, parses the metadata action's `update-type` output, calls `gh pr merge --auto --squash` only for the categories above. Major/Docker PRs get a label (`needs-review`) and stay open.
+
+### Tier 2 — OSS community signals
+
+- **`SECURITY.md`** at repo root — vuln disclosure email `jackmmusick@gmail.com`, response SLA (48 hrs ack), supported versions ("`main` only"), the auto-merge policy summarized so external contributors understand it.
+- **`CODEOWNERS`** at `.github/CODEOWNERS` — `* @jackmusick` for now (solo project; adding a real reviewer matrix later is trivial).
+- **Pin all GitHub Actions to commit SHAs.** Currently `ci.yml` uses `actions/checkout@v5`, `actions/setup-python@v6`, etc. Scorecard's Pinned-Dependencies check requires SHAs. Tooling: `pinact run` or `ratchet pin` — both auto-pin and leave a comment with the version. Manual pinning also fine for ~5 actions. Done across `ci.yml` and any new workflows in this PR.
+- **OpenSSF Scorecard Action — `.github/workflows/scorecard.yml`:**
+  - Use the official `ossf/scorecard-action` template
+  - Triggers: `schedule: weekly`, `push: [main]`, `branch_protection_rule`
+  - Publish results to GitHub Security tab + `securityscorecards.dev`
+- **README updates:**
+  - Add Scorecard badge (auto-updates)
+  - Verify license badge URL/text matches the actual `LICENSE` file (currently links to a generic opensource.org page — should link to the in-repo `LICENSE`)
+  - Add CodeQL badge (optional but standard)
+
+### Tier 3 — Skipped for v1
+
+**SonarCloud / Snyk / Socket.dev / Semgrep Cloud are not in scope.** Rationale: CodeQL covers ~80% of what these find for free, the marginal value at this project's size is small, and the marginal toil (triaging a second tool's alerts) is real. Revisit in 2–3 months — if CodeQL has missed real bugs that one of these would have caught, layer it in then with data justifying it.
+
+This is documented in the plan but not implemented now.
+
+### Tier 4 — Skills + one-time watch loop (after Security tab populates)
+
+After the Tier 1+2 PR merges and the Security tab populates with real alerts (~30 min later), drain the backlog in the same session — driven by a one-time `/loop` — and codify the resolution loop as a skill.
+
+**Skill: `bifrost-secupdate`** (reactive — invoked when alerts/PRs exist)
+- Inputs: nothing (queries the repo state)
+- Loop:
+  1. `gh pr list --label dependencies` — find open Dependabot PRs
+  2. For each: `gh pr checks <num>` — check CI status
+  3. If CI green + auto-merge eligible: confirm it's set to auto-merge or call `gh pr merge --auto --squash`
+  4. If CI failing: check out the branch in a worktree, read the failure, fix, push, re-run CI
+  5. If failure-fix needs a code change beyond the bump: write the test that demonstrates the issue, then the fix
+  6. For Dependabot alerts without a PR (no upstream fix yet): summarize and surface to user — do not auto-act
+  7. For CodeQL alerts: triage real-vs-FP; for real ones, write fix + test + PR; for FPs, dismiss with reason via `gh api`
+- Halt conditions: a PR fails CI 3 times in a row → stop and ask. A major bump or dep swap → stop and ask. A code-scanning alert that isn't clearly real or FP → stop and ask.
+
+**Skill: `bifrost-secaudit`** (snapshot of current state — invoked manually or by the watch loop's "is it populated yet?" check)
+- Inputs: nothing
+- Output: a brief markdown summary
+  - Open Dependabot alerts: count, severity breakdown
+  - Open Dependabot PRs: count by category, oldest age
+  - Open CodeQL alerts: count, severity breakdown
+  - Secret-scanning alerts: count
+  - Scorecard: current score, top-3 lowest-scoring checks
+- Used both as the "queue is populated, time to drain" trigger inside the watch loop, and as a standalone "where do I stand?" command later.
+
+**One-time watch loop (this session only):**
+- Kicked off via `/loop` (self-paced) immediately after the user merges the Tier 1+2 PR and clicks the Settings checkboxes
+- Each tick:
+  1. Run `bifrost-secaudit`
+  2. If queue is empty (no Dependabot alerts/PRs, no CodeQL alerts) AND <30 min have passed since the PR merged → wait, loop again
+  3. If queue is populated → invoke `bifrost-secupdate`, drain everything possible, surface anything that needs human input, **exit the loop**
+  4. If 60 min have passed with an empty queue → assume the repo is genuinely clean (no CVEs in current deps), report that, exit
+- This is a one-shot — when it exits, no further automation runs. A recurring schedule is a separate decision for a later conversation.
+
+## Files To Modify / Create
+
+| Path | Action | Tier |
+|---|---|---|
+| `LICENSE` | **Create** — full AGPL-3.0 text from SPDX | 0 |
+| `.github/dependabot.yml` | Create | 1 |
+| `.github/workflows/codeql.yml` | Create | 1 |
+| `.github/workflows/dependabot-auto-merge.yml` | Create | 1 |
+| `.github/workflows/ci.yml` | **Edit** — pin all `uses:` to commit SHAs | 2 |
+| `.github/workflows/scorecard.yml` | Create | 2 |
+| `.github/CODEOWNERS` | Create | 2 |
+| `SECURITY.md` | Create | 2 |
+| `README.md` | **Edit** — fix license badge link, add Scorecard + CodeQL badges | 2 |
+| `.claude/skills/bifrost-secupdate/SKILL.md` | Create | 4 |
+| `.claude/skills/bifrost-secaudit/SKILL.md` | Create | 4 |
+| `docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md` | Create — committed spec, copy of this plan | execution |
+
+## Manual Steps (consolidated checklist for user)
+
+These cannot be done via the API reliably from this tool. Plan provides exact text to click / commands to paste.
+
+1. **Settings → Code security** — toggle ON: Dependabot alerts, Dependabot security updates, Dependabot version updates, Secret scanning, Push protection. Confirm CodeQL "Default" setup activates after `codeql.yml` lands.
+2. **Run the branch protection command** — Claude pastes the exact `gh api -X PUT ... /branches/main/protection` invocation in the PR description.
+3. **Merge the PR.**
+4. **Wait ~30 minutes** for Security tab to populate.
+5. **Reply with `/loop`** (or just "go") — kicks off the one-time watch loop. Loop polls `bifrost-secaudit` until the Security tab populates, drains via `bifrost-secupdate`, exits. No recurring schedule is set up in this plan.
+
+## Reusing Existing Patterns
+
+- `.github/workflows/ci.yml` — extend with consistent `permissions:` blocks (already partly present). Pinned-action edits live here.
+- `.claude/skills/bifrost-issues/SKILL.md` and `.claude/skills/reviewing-prs/` — skill structure model for the two new skills (frontmatter, sections, naming).
+- `CONTRIBUTING.md` — already documents the test/lint/typecheck bar; new auto-merge policy referenced from `SECURITY.md` rather than duplicated.
+
+## Verification
+
+End-to-end check after each tier merges:
+
+**Tier 0:**
+- `gh api repos/jackmusick/bifrost/license` returns 200 with `license.spdx_id == "AGPL-3.0"`
+- GitHub repo sidebar shows "AGPL-3.0 license"
+
+**Tier 1:**
+- `gh api repos/jackmusick/bifrost/vulnerability-alerts -i` returns HTTP 204 ("alerts enabled"; was 404 = disabled)
+- Within 30 min: Security tab → Dependabot shows ≥1 alert (assuming any CVEs exist in current deps — almost certain on a project this size)
+- Test the auto-merge workflow by waiting for the first patch-update PR and confirming it lands without manual action
+- CodeQL: Actions tab shows the workflow ran successfully; Security tab → Code scanning has results (alerts or "no issues")
+
+**Tier 2:**
+- `curl -s https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost | jq .score` returns ≥7
+- README Scorecard badge renders the score
+- `SECURITY.md` is discoverable at `https://github.com/jackmusick/bifrost/security/policy`
+- All `uses:` in workflows resolve to 40-char commit SHAs (`grep -E 'uses:.*@v[0-9]' .github/workflows/*.yml` returns empty)
+
+**Tier 4:**
+- `bifrost-secupdate` invoked manually: drives at least one Dependabot PR to merge end-to-end
+- `bifrost-secaudit` invoked manually: produces a markdown report with current state
+- One-time `/loop` runs to completion: polls until Security tab populates, drains the queue, exits cleanly with a summary
+
+## Open Risks / Things To Watch
+
+- **Auto-merge + green CI ≠ "safe."** If a patch-version bump silently changes behavior in a way our tests don't cover, it'll land. Mitigation: when a regression is found post-merge, the response is "add the test, fix forward" rather than "disable auto-merge." User has explicitly accepted this tradeoff.
+- **Branch protection requiring 1 review on a solo project.** Workaround: GitHub allows admins to bypass; or set required reviewers to 0 if it gets in the way. Scorecard's Code-Review check accepts either as long as the protection rule itself is in place.
+- **Pinned actions create maintenance overhead** — updating GitHub Actions now requires SHA bumps. Dependabot's `github-actions` ecosystem handles this automatically (it'll open PRs to bump the SHA when the action publishes a new version), so net toil is zero.
+- **Scorecard score depends on activity.** The "Maintained" check expects recent commits. Going dark for a few months drops the score. Not a concern given current development pace.


### PR DESCRIPTION
Adds the supply-chain + security + community-health baseline. See [docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md](docs/superpowers/specs/2026-04-25-oss-security-maturity-design.md) for context and [docs/superpowers/plans/2026-04-25-oss-security-maturity.md](docs/superpowers/plans/2026-04-25-oss-security-maturity.md) for the per-task plan.

## What this PR adds

- **`LICENSE`** — full AGPL-3.0 text (README has badged AGPL since day 1 but the file was missing; GitHub's license API returned 404).
- **`.github/dependabot.yml`** — pip + npm + docker + github-actions, weekly, minor+patch grouped per ecosystem.
- **`.github/workflows/codeql.yml`** — SAST on push/PR + weekly.
- **`.github/workflows/dependabot-auto-merge.yml`** — security/patch/minor auto-merge when CI green; major + Docker labeled `needs-review`.
- **`.github/workflows/scorecard.yml`** — OpenSSF Scorecard, weekly + on branch-protection-rule changes.
- **`.github/workflows/ci.yml`** — pinned all `uses:` to commit SHAs (Scorecard Pinned-Dependencies check); added `paths-ignore` so docs/config-only PRs skip Lint/Unit/E2E.
- **`.github/workflows/ci-noop.yml`** — companion workflow with inverse `paths:` filter and stub jobs (`Lint & Type Check`, `Unit Tests`, `E2E Tests`) so branch protection's required checks still report green on docs-only PRs.
- **`.github/CODEOWNERS`** — `* @jackmusick` (solo project for now).
- **`SECURITY.md`** — vulnerability disclosure policy + auto-merge policy documentation.
- **`README.md`** — fixed broken license badge link, added CodeQL + Scorecard badges.
- **Spec + plan** in `docs/superpowers/{specs,plans}/`.

## Manual steps after merge

1. **Settings → Code security**, toggle ON:
   - Dependabot alerts
   - Dependabot security updates
   - Dependabot version updates
   - Secret scanning
   - Push protection
   - Confirm CodeQL is detected (should auto-light-up once the workflow runs).

2. **Smoke-test the ci-noop bypass before turning on branch protection.** Open a throwaway PR that only modifies `README.md` (a typo fix is fine). Confirm:
   - `ci-noop.yml`'s stub jobs report green with names `Lint & Type Check`, `Unit Tests`, `E2E Tests`.
   - `ci.yml`'s real Lint/Unit/E2E do NOT run (correctly skipped by `paths-ignore`).
   - The PR shows as mergeable.

   Close the test PR. If the noop doesn't fire correctly, fix the trigger filters before step 3 — otherwise step 3 will lock you out of merging your own docs PRs.

3. **Configure branch protection on `main`** by running this command locally:

   ```bash
   gh api -X PUT repos/jackmusick/bifrost/branches/main/protection \
     --input - <<'JSON'
   {
     "required_status_checks": {
       "strict": true,
       "contexts": [
         "Lint & Type Check",
         "Unit Tests",
         "E2E Tests"
       ]
     },
     "enforce_admins": false,
     "required_pull_request_reviews": {
       "required_approving_review_count": 1,
       "dismiss_stale_reviews": true,
       "require_code_owner_reviews": false
     },
     "restrictions": null,
     "allow_force_pushes": false,
     "allow_deletions": false,
     "required_linear_history": true,
     "required_conversation_resolution": true
   }
   JSON
   ```

   Notes:
   - The required-contexts list contains only the three names that can come from EITHER `ci.yml` (real run) OR `ci-noop.yml` (docs-only stub). Both files use the exact same job names so branch protection is satisfied either way.
   - CodeQL (`Analyze (python)`, `Analyze (javascript-typescript)`) is intentionally not required — it stays a non-blocking security signal that surfaces in the Security tab.
   - `required_approving_review_count: 1` on a solo project means you'd either have a co-maintainer review, use admin bypass, or set this to `0`. Scorecard's Code-Review check accepts `0` as long as the protection rule itself exists.

4. **Wait ~30 minutes** for the Security tab to populate with Dependabot alerts + first CodeQL scan.

5. **Reply with `/loop`** (or just "go") in the conversation that opened this PR — kicks off the one-time watch loop that drains the security queue. The `/loop` is a one-shot — no recurring schedule is set up here.

## Verification after merge

- `gh api repos/jackmusick/bifrost/license --jq '.license.spdx_id'` → `"AGPL-3.0"` (was 404)
- `gh api repos/jackmusick/bifrost/vulnerability-alerts -i` → HTTP 204
- Security tab populates within 30 min
- `curl -s https://api.securityscorecards.dev/projects/github.com/jackmusick/bifrost | jq .score` → ≥7 (after first scorecard.yml run, ~5 min post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
