### PR TITLE
[smoke test] verify ci-noop fires on docs-only PR

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Bifrost is in active development against `main`. Only `main` is supported
 at this time — there are no LTS branches. If you're running a fork or a
-historical commit, please rebase onto current `main` before reporting.
+historical commit, please rebase onto the latest `main` before reporting.
 
 | Version | Supported          |
 | ------- | ------------------ |


### PR DESCRIPTION
Throwaway PR that only modifies SECURITY.md (one-word change). Verifying that:

1. ci-noop.yml fires three stub jobs named 'Lint & Type Check', 'Unit Tests', 'E2E Tests'
2. ci.yml's real lint/unit/e2e do NOT run (paths-ignore correctly skips them)
3. PR shows mergeable

Will be closed without merging once verified.
