### PR TITLE
chore(dependabot): ignore eslint 10 / typescript 6 majors pending upstream

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,21 @@ updates:
     labels:
       - dependencies
       - javascript
+    ignore:
+      # eslint 10 enables react-hooks plugin 7.x's expanded recommended set,
+      # surfacing 60+ real lint errors in the codebase that need a code-fix
+      # sweep before the dep can land. Re-enable after that sweep ships.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-react-hooks"
+        update-types: ["version-update:semver-major"]
+      # TypeScript 6: blocked on openapi-typescript widening its peer to TS 6
+      # (tracked upstream at openapi-ts/openapi-typescript#2774). Re-enable
+      # once openapi-typescript ships TS 6 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # Docker base images — api/
   - package-ecosystem: docker

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,15 +41,21 @@ updates:
       - dependencies
       - javascript
     ignore:
-      # eslint 10 enables react-hooks plugin 7.x's expanded recommended set,
-      # surfacing 60+ real lint errors in the codebase that need a code-fix
-      # sweep before the dep can land. Re-enable after that sweep ships.
+      # eslint 10 + react-hooks 7.1+ both enable the expanded react-hooks
+      # recommended set (set-state-in-effect, refs, immutability,
+      # incompatible-library, error-boundaries) which fires on ~50 real
+      # call sites. We need a code-fix sweep before either can land.
+      # Re-enable after that sweep ships (tracked: TODO issue).
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@eslint/js"
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-plugin-react-hooks"
-        update-types: ["version-update:semver-major"]
+        # 7.1+ ships the expanded recommended set; pin to 7.0.x until sweep.
+        versions: [">=7.1.0"]
+      - dependency-name: "eslint-plugin-react-refresh"
+        # 0.5+ also tightened — pairs with react-hooks 7.1.
+        versions: [">=0.5.0"]
       # TypeScript 6: blocked on openapi-typescript widening its peer to TS 6
       # (tracked upstream at openapi-ts/openapi-typescript#2774). Re-enable
       # once openapi-typescript ships TS 6 support.


### PR DESCRIPTION
## Summary
- eslint 10 + matched plugins: blocked on react-hooks 7.x's expanded recommended preset surfacing ~60 real lint errors. Need a code-fix sweep first.
- typescript 6: blocked on openapi-typescript widening its peer dep to TS 6 ([upstream PR #2774](https://github.com/openapi-ts/openapi-typescript/pull/2774)).

Adds ignore rules so Dependabot stops opening unmergeable PRs for these majors. Closing #61 and #65 in tandem.

## Test plan
- [ ] CI green on this PR (lint/typecheck/tests don't depend on Dependabot config)
- [ ] Verify Dependabot won't re-open the bumps next Monday