### PR TITLE
chore(codeql): batch-fix safe note-level findings

### DIFF
--- a/api/src/core/config_resolver.py
+++ b/api/src/core/config_resolver.py
@@ -141,8 +141,6 @@ class ConfigResolver:
         Raises:
             ValueError: If value cannot be parsed for the specified type
         """
-        import json
-
         try:
             if config_type == ConfigType.INT.value or config_type == "int":
                 return int(value)

--- a/api/src/core/pubsub.py
+++ b/api/src/core/pubsub.py
@@ -660,8 +660,6 @@ async def publish_git_op_completed(
         commit_sha: Commit SHA if created (for sync_execute ops)
         conflicts: List of merge conflict dicts (for sync ops with conflicts)
     """
-    import json
-
     completion_message: dict[str, Any] = {
         "type": "git_op_complete",
         "jobId": job_id,

--- a/api/src/routers/agent_runs.py
+++ b/api/src/routers/agent_runs.py
@@ -682,7 +682,6 @@ async def cancel_agent_run(
         async with get_redis() as r:
             context_raw = await r.get(redis_key)
             if context_raw:
-                import json
                 ctx = json.loads(context_raw)
                 ctx["cancelled"] = True
                 ttl = await r.ttl(redis_key)

--- a/api/src/services/app_bundler/__init__.py
+++ b/api/src/services/app_bundler/__init__.py
@@ -405,7 +405,6 @@ class BundlerService:
 
         # --- 2. Scan user source for names imported from "bifrost" -------
         imported_names: set[str] = set()
-        import re as _re
         bifrost_import_re = _re.compile(
             r'import\s+\{([^}]+)\}\s+from\s+["\']bifrost["\']',
         )

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -38,12 +38,11 @@ def _human_size(num_bytes: int) -> str:
 
 # Import unified log streaming (Redis Stream + PubSub)
 try:
-    from bifrost._logging import log_and_broadcast, flush_logs_to_postgres
+    from bifrost._logging import log_and_broadcast
     STREAM_LOGGING_AVAILABLE = True
 except ImportError:
     STREAM_LOGGING_AVAILABLE = False
     log_and_broadcast = None  # type: ignore
-    flush_logs_to_postgres = None  # type: ignore
 
 # Import bifrost context management for SDK support
 project_root = Path(__file__).parent.parent


### PR DESCRIPTION
## Summary

Triage of the SAFE-TO-BATCH-FIX note-level CodeQL alerts. Most ended up being false positives marked with `# noqa` or intentional patterns; this PR cleans up the genuinely mechanical leftovers.

### Fixed (5 alerts)

- **py/unused-import** (1 of 6): `flush_logs_to_postgres` in `api/src/services/execution/engine.py` was imported but only referenced in a comment. Removed.
- **py/repeated-import** (4 of 4): Removed inline `import json` / `import re as _re` statements that duplicate top-of-file imports.
  - `api/src/core/pubsub.py`
  - `api/src/core/config_resolver.py`
  - `api/src/routers/agent_runs.py`
  - `api/src/services/app_bundler/__init__.py`

### Skipped (28 alerts) — false positives or intentional

- **py/unused-import** (5 of 6): All marked `# noqa: F401` (intentional, for Alembic metadata registration / re-exports) or genuinely used as quoted forward-reference type hints inside `TYPE_CHECKING` blocks.
- **py/test-equals-none** (3 of 3): All three are SQLAlchemy `model.id == None` queries with `# noqa: E711` — replacing with `is None` would BREAK the SQL `IS NULL` semantics. Do not "fix".
- **py/import-and-import-from** (19 of 19): All are intentional dual-import patterns (`import x as mod` for module-level mutation/access alongside `from x import name` for specific names — common in tests that need to reset module-level state).
- **js/unused-local-variable** (1 of 1): In `client/playwright-report/index.html`, a generated build artifact (26K lines, should likely be gitignored — separate concern).

### Recommendation

The skipped alerts are stable false-positives. Consider dismissing them as "won't fix" in CodeQL with reason `false positive` — they will keep re-appearing in triage queues otherwise.

## Test plan

- [x] `ruff check` clean on all 5 modified files
- [x] Python AST parses cleanly on all modified files
- [ ] CI green