### PR TITLE
chore: narrow CODEOWNERS to human-authored paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,43 @@
 # CODEOWNERS — automatic reviewer assignment
 # https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
-# Right now this is a solo project. As contributors grow, this expands
-# to per-path ownership (e.g. api/ → backend folks, client/ → frontend).
+# Solo project — every path that's authored by a human gets the codeowner.
+# Paths that are mechanically rewritten by Dependabot are deliberately
+# omitted so its auto-PRs don't request review from a codeowner who has
+# no one to delegate to. Branch protection still gates merges on CI; the
+# omission only affects the visual "review requested" signal.
 
-* @jackmusick
+# Source code
+/api/src/                       @jackmusick
+/api/tests/                     @jackmusick
+/api/bifrost/                   @jackmusick
+/api/alembic/                   @jackmusick
+/client/src/                    @jackmusick
+/client/e2e/                    @jackmusick
+/client/public/                 @jackmusick
+
+# Docs and tooling
+/docs/                          @jackmusick
+/.claude/                       @jackmusick
+/scripts/                       @jackmusick
+
+# Repo-level config (Dependabot does NOT touch these)
+/.github/CODEOWNERS             @jackmusick
+/.github/dependabot.yml         @jackmusick
+/.github/SECURITY.md            @jackmusick
+/.github/ISSUE_TEMPLATE/        @jackmusick
+/.github/PULL_REQUEST_TEMPLATE/ @jackmusick
+
+# Top-level
+/CLAUDE.md                      @jackmusick
+/README.md                      @jackmusick
+/LICENSE                        @jackmusick
+/SECURITY.md                    @jackmusick
+/debug.sh                       @jackmusick
+/test.sh                        @jackmusick
+/docker-compose*.yml            @jackmusick
+
+# Intentionally NOT covered (Dependabot owns these on the bump path):
+#   /api/Dockerfile*  /api/requirements.txt  /api/pyproject.toml
+#   /client/package.json  /client/package-lock.json  /client/Dockerfile*
+#   /.github/workflows/*  (action version bumps)


### PR DESCRIPTION
## Summary
- Replace `* @jackmusick` catch-all with per-path ownership.
- Deliberately omit Dependabot-managed paths (Dockerfile*, requirements.txt, package*.json, .github/workflows/*) so Dependabot's auto-PRs stop generating spurious "review requested" badges on mobile.
- Branch protection unchanged: 3 required status checks, 0 required approvals. The visual signal aligns with reality now.

## Test plan
- [ ] CI green
- [ ] Future Dependabot PRs don't list jackmusick as requested reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)