### PR TITLE
docs(pr): add attended PR stewardship lane

### DIFF
--- a/docs/runbooks/pr-stewardship.md
+++ b/docs/runbooks/pr-stewardship.md
@@ -1,0 +1,82 @@
+# PR Stewardship Runbook
+
+This runbook defines the attended agent lane for keeping Bifrost pull requests moving. GitHub is the source of truth for PR state, CI, reviews, and merge gates. Codex may fix PRs, update branches, answer review feedback, and enable auto-merge when policy allows it, but it does not merge from an unattended laptop job.
+
+## Operating Model
+
+- Use `scripts/pr-steward.ps1` to produce the queue before touching a PR.
+- Work one PR at a time from an isolated worktree or a fresh branch from current `main`.
+- Treat branch protection, required checks, review decisions, and unresolved review threads as authoritative.
+- Leave final policy exceptions to a human: sensitive paths, major dependencies, Docker base images, workflow changes, auth, execution, secrets, migrations, and multi-tenant boundaries.
+- Prefer GitHub auto-merge over local merge commands. The agent may enable auto-merge only after checks are green and the PR is in an allowed lane.
+
+## Steward Loop
+
+1. Refresh state:
+   ```powershell
+   .\scripts\pr-steward.ps1 -Repo jackmusick/bifrost -Limit 20
+   ```
+2. Pick the first PR with a mechanical next action: behind branch, failing check, stale generated artifact, or unresolved review thread with an obvious code fix.
+3. Create or reuse an isolated worktree for that PR. Do not mutate the shared checkout if it has unrelated local changes.
+4. Inspect the PR diff, comments, checks, and relevant logs before editing.
+5. Make the smallest fix that clears the blocker. If the fix expands scope or touches a sensitive path, stop at a ready-for-review update.
+6. Run the narrowest local verification that proves the fix, then push.
+7. Post or update a PR summary that includes what changed, what was verified, and anything still requiring human review.
+8. Enable auto-merge only when the PR is green, non-draft, policy-eligible, and has no unresolved review threads.
+
+## Policy Lanes
+
+Allowed auto-fix lanes:
+
+- Branch update from `main`.
+- CI failures with a clear mechanical fix.
+- Review feedback that is local, low-risk, and already agreed in the thread.
+- Documentation or test-only fixes that do not change release behavior.
+
+Auto-merge eligible after green checks:
+
+- Dependabot security advisory bumps.
+- Non-major, non-Docker Dependabot patch or minor updates.
+- Documentation-only PRs with no sensitive path changes.
+- Low-risk chores explicitly labeled or approved by a maintainer.
+
+Human approval required:
+
+- Major dependency updates.
+- Docker base images or GitHub workflow changes.
+- Sensitive paths listed in `CONTRIBUTING.md` and `.claude/skills/reviewing-prs/sensitive-paths.md`.
+- Any PR with unclear branch protection, missing checks, unresolved review threads, or external deployment impact.
+
+## Commands
+
+Queue all open PRs:
+
+```powershell
+.\scripts\pr-steward.ps1 -Repo jackmusick/bifrost -Limit 20
+```
+
+Inspect one PR:
+
+```powershell
+.\scripts\pr-steward.ps1 -Repo jackmusick/bifrost -Pr 87
+```
+
+Machine-readable queue:
+
+```powershell
+.\scripts\pr-steward.ps1 -Repo jackmusick/bifrost -Limit 20 -Json
+```
+
+Enable auto-merge only after the runbook says it is eligible:
+
+```powershell
+gh pr merge <number> --repo jackmusick/bifrost --auto --squash
+```
+
+## Failure Behavior
+
+- If branch protection cannot be read, do not merge. Report the inaccessible gate and continue with fix-only work.
+- If a check is flaky, rerun once and record the run URL. If it fails again, treat it as real.
+- If a PR is draft, keep it draft until the author or steward explicitly marks it ready after a clean summary.
+- If the local checkout is dirty or on another task branch, create an isolated worktree before editing.
+- If the steward cannot identify a safe next action, leave a concise status comment instead of improvising.

--- a/scripts/pr-steward.ps1
+++ b/scripts/pr-steward.ps1
@@ -1,0 +1,212 @@
+param(
+    [string]$Repo = "jackmusick/bifrost",
+    [int]$Limit = 20,
+    [int]$Pr,
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-GhJson {
+    param([string[]]$Arguments)
+
+    $output = & gh @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "gh $($Arguments -join ' ') failed: $output"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($output)) {
+        return $null
+    }
+
+    return $output | ConvertFrom-Json
+}
+
+function Get-CheckSummary {
+    param([int]$Number)
+
+    $lines = & gh pr checks $Number --repo $Repo --watch=false 2>&1
+    if ($LASTEXITCODE -ne 0 -and ($null -eq $lines -or $lines.Count -eq 0)) {
+        return [pscustomobject]@{
+            failed = 0
+            pending = 0
+            passed = 0
+            unknown = 1
+            failingChecks = @("Unable to read checks.")
+        }
+    }
+
+    $failed = @()
+    $pending = 0
+    $passed = 0
+    $parsed = 0
+    foreach ($line in $lines) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        $parts = $line -split "`t"
+        if ($parts.Count -lt 2) {
+            continue
+        }
+
+        $parsed += 1
+        $name = $parts[0]
+        $state = $parts[1]
+        switch ($state) {
+            "fail" { $failed += $name }
+            "pass" { $passed += 1 }
+            "pending" { $pending += 1 }
+            "queued" { $pending += 1 }
+            "in_progress" { $pending += 1 }
+        }
+    }
+
+    if ($parsed -eq 0 -and $LASTEXITCODE -ne 0) {
+        return [pscustomobject]@{
+            failed = 0
+            pending = 0
+            passed = 0
+            unknown = 1
+            failingChecks = @("Unable to parse checks: $lines")
+        }
+    }
+
+    [pscustomobject]@{
+        failed = $failed.Count
+        pending = $pending
+        passed = $passed
+        unknown = 0
+        failingChecks = $failed
+    }
+}
+
+function Get-ReviewThreadSummary {
+    param([int]$Number)
+
+    $query = @'
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          isResolved
+        }
+      }
+    }
+  }
+}
+'@
+
+    $repoParts = $Repo -split "/", 2
+    try {
+        $result = Invoke-GhJson @(
+            "api", "graphql",
+            "-f", "query=$query",
+            "-F", "owner=$($repoParts[0])",
+            "-F", "name=$($repoParts[1])",
+            "-F", "number=$Number"
+        )
+    }
+    catch {
+        return [pscustomobject]@{
+            unresolved = 0
+            total = 0
+            readable = $false
+        }
+    }
+
+    $threads = @($result.data.repository.pullRequest.reviewThreads.nodes)
+    [pscustomobject]@{
+        unresolved = @($threads | Where-Object { -not $_.isResolved }).Count
+        total = $threads.Count
+        readable = $true
+    }
+}
+
+function Get-NextAction {
+    param(
+        [object]$PullRequest,
+        [object]$Checks,
+        [object]$Threads
+    )
+
+    if ($PullRequest.isDraft) {
+        return "Draft: leave unmerged; fix checks and update PR summary before marking ready."
+    }
+
+    if ($PullRequest.mergeStateStatus -eq "BEHIND") {
+        return "Update branch from main in an isolated worktree, then rerun checks."
+    }
+
+    if ($Checks.failed -gt 0) {
+        return "Fix failing checks: $($Checks.failingChecks -join ', ')."
+    }
+
+    if ($Threads.unresolved -gt 0) {
+        return "Address or reply to $($Threads.unresolved) unresolved review thread(s)."
+    }
+
+    if ($PullRequest.mergeStateStatus -eq "BLOCKED") {
+        return "Blocked with no readable failing check; inspect branch protection and required reviews."
+    }
+
+    if ($PullRequest.mergeStateStatus -eq "CLEAN" -or $PullRequest.mergeStateStatus -eq "HAS_HOOKS") {
+        return "Green candidate: human reviews policy; agent may enable auto-merge only if lane is allowed."
+    }
+
+    return "Inspect manually: merge state is $($PullRequest.mergeStateStatus)."
+}
+
+$fields = "number,title,state,isDraft,mergeStateStatus,reviewDecision,headRefName,baseRefName,author,labels,updatedAt,url"
+if ($Pr -gt 0) {
+    $pullRequests = @(Invoke-GhJson @("pr", "view", "$Pr", "--repo", $Repo, "--json", $fields))
+}
+else {
+    $pullRequests = @(Invoke-GhJson @("pr", "list", "--repo", $Repo, "--limit", "$Limit", "--json", $fields))
+}
+
+$queue = foreach ($pullRequest in $pullRequests) {
+    $checks = Get-CheckSummary -Number $pullRequest.number
+    $threads = Get-ReviewThreadSummary -Number $pullRequest.number
+    $labels = @($pullRequest.labels | ForEach-Object { $_.name })
+
+    [pscustomobject]@{
+        number = $pullRequest.number
+        title = $pullRequest.title
+        url = $pullRequest.url
+        author = $pullRequest.author.login
+        branch = $pullRequest.headRefName
+        draft = [bool]$pullRequest.isDraft
+        mergeState = $pullRequest.mergeStateStatus
+        reviewDecision = $pullRequest.reviewDecision
+        labels = $labels
+        checks = $checks
+        reviewThreads = $threads
+        nextAction = Get-NextAction -PullRequest $pullRequest -Checks $checks -Threads $threads
+    }
+}
+
+if ($Json) {
+    $queue | ConvertTo-Json -Depth 10
+    exit 0
+}
+
+"# PR Steward Queue"
+""
+"Repository: $Repo"
+"Generated: $((Get-Date).ToString("s"))"
+""
+foreach ($item in $queue) {
+    "## #$($item.number) $($item.title)"
+    "- State: merge=$($item.mergeState); draft=$($item.draft); review=$($item.reviewDecision)"
+    "- Branch: $($item.branch)"
+    "- Checks: passed=$($item.checks.passed); failed=$($item.checks.failed); pending=$($item.checks.pending)"
+    if ($item.checks.failingChecks.Count -gt 0) {
+        "- Failing checks: $($item.checks.failingChecks -join ', ')"
+    }
+    "- Review threads: unresolved=$($item.reviewThreads.unresolved); total=$($item.reviewThreads.total)"
+    "- Next action: $($item.nextAction)"
+    "- URL: $($item.url)"
+    ""
+}


### PR DESCRIPTION
## Summary
- add a Windows-native PR steward queue script for attended auto-fix workflows
- document the Bifrost PR stewardship runbook, policy lanes, and failure behavior
- dry-run the steward against the current queue, including PR 87 and the first blocked PRs

## Test Plan
- .\scripts\pr-steward.ps1 -Repo jackmusick/bifrost -Pr 87
- .\scripts\pr-steward.ps1 -Repo jackmusick/bifrost -Limit 5 -Json
- git diff --check