### PR TITLE
docs(plans): post-drain checklist for OSS hardening session

### DIFF
--- a/docs/superpowers/plans/2026-04-26-oss-hardening-followups.md
+++ b/docs/superpowers/plans/2026-04-26-oss-hardening-followups.md
@@ -1,0 +1,290 @@
+# OSS Hardening — Final State (2026-04-26)
+
+> **Status:** Most of the original follow-up plan was executed in the same session via parallel subagents. This doc is now mostly a record of what landed + what's still in flight, not a TODO list.
+
+## ⚠️ POST-DRAIN CHECKLIST — DO THIS WHEN THE QUEUE IS EMPTY
+
+**When all my fix PRs (#27, #41-#85 range) have landed**, run this audit. It catches anything that slipped through the cracks of session-by-session work.
+
+### 0. Run `bifrost-secaudit` for a holistic snapshot
+
+This skill (added in #75 during this session) gives a one-shot read of the entire Security tab — Dependabot, CodeQL, secret-scanning, Scorecard, branch protection, auto-merge workflow health, stale PRs. Best first step for "did everything land where I expected?"
+
+```
+/bifrost-secaudit
+```
+
+(Or in a fresh Claude Code session, just say "run bifrost-secaudit" — the skill self-loads.)
+
+If the audit shows anything red — secret-scanning alerts, branch protection regressions, Scorecard score drops — pause and triage before continuing the rest of this checklist.
+
+### 1. Confirm queue is actually drained
+
+```bash
+# Should show only Thomas's PRs (#28, #37, #87) plus any new Dependabot weekly batch
+gh pr list --repo jackmusick/bifrost --state open --json number,title,author --jq '.[] | "  #\(.number) @\(.author.login): \(.title)"'
+```
+
+If anything is still open with auto-merge: drive it through (rebase / resolve conflicts / wait for CI).
+
+### 2. Re-snapshot CodeQL — did it re-scan?
+
+```bash
+# Should be much lower than 506 (the count when this session ended)
+total=$(for page in {1..15}; do gh api "repos/jackmusick/bifrost/code-scanning/alerts?state=open&per_page=100&page=$page" --jq '.[] | .number' 2>/dev/null; done | wc -l)
+echo "CodeQL alerts open: $total"
+
+# Top remaining rules
+for page in {1..15}; do
+  gh api "repos/jackmusick/bifrost/code-scanning/alerts?state=open&per_page=100&page=$page" --jq '.[] | "\(.rule.severity) | \(.rule.id)"' 2>/dev/null
+done | sort | uniq -c | sort -rn | head -15
+```
+
+**Expected:** ~50-100 alerts. If it's still ~500+, **CodeQL hasn't re-scanned yet**. CodeQL re-runs weekly on schedule + on every push to main. Force a re-scan by triggering the workflow:
+
+```bash
+gh workflow run codeql.yml --repo jackmusick/bifrost --ref main
+```
+
+Wait ~10 min, re-check the count.
+
+### 3. Triage anything that survived the drain
+
+If after re-scan you still have alerts open:
+
+- **Errors** — read each, fix or dismiss with rationale. The patterns this session uncovered: see Section E1 below.
+- **Warnings** — same.
+- **Notes** — bulk-action only after sampling at least one. The "code was generated, smells weren't intended" lens applies — lean fix over dismiss.
+
+### 4. Confirm Dependabot alerts dropped too
+
+```bash
+gh api "repos/jackmusick/bifrost/dependabot/alerts?state=open" --jq 'length'
+# Was 11 at session start. Should be 0-3 now (transitive fixes flow with each merge).
+```
+
+If any remain: cross-reference against open Dependabot PRs. If a PR exists, wait. If not, decide fix path (workaround / swap dep / accept).
+
+### 5. Verify Scorecard auto-resolved what it should
+
+```bash
+gh run list --repo jackmusick/bifrost --workflow scorecard.yml --limit 3 --json conclusion,createdAt
+# Latest run should be POST-merge of #78 (Docker SHA pin) + #88 (CODEOWNERS)
+```
+
+After Scorecard re-runs, check the `*ID` rules in CodeQL:
+- `PinnedDependenciesID` should drop from ~18 to ~9 (just the pip/npm-in-Dockerfile ones we accepted)
+- `TokenPermissionsID` should drop
+- `BranchProtectionID` should drop (we enabled `enforce_admins`)
+
+### 6. Tracking issues — close or update
+
+Open issues filed during this session:
+
+- **#74** — eslint sweep tracker. **Close when #86 merges** (the sweep PR). It already fixes all 60 errors; the issue's acceptance criteria are met.
+- **#83** — OpenSSF Best Practices Badge form. **Stays open until you fill out the form** at https://www.bestpractices.dev/. Manual user task.
+- **#92** — `./test.sh` E2E flake (race condition between "Stack is up" and "stack not running"). **Stays open** as a real bug. Caused several hours of CI confusion this session. Worth fixing for repo health.
+
+```bash
+# Quick check — are these all still open?
+for n in 74 83 92; do
+  gh issue view $n --repo jackmusick/bifrost --json state,title --jq '"  #\(.title) [\(.state)]"' | sed "s/^/  #$n /"
+done
+```
+
+### 7. Bonus: lift the eslint dependabot ignore rules
+
+Once #86 (eslint sweep) has landed, the `eslint`, `@eslint/js`, `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh` ignore rules in `.github/dependabot.yml` are no longer needed. Open a small PR to remove them. Dependabot will then re-open the eslint 10 + plugin bumps next Monday and they'll land cleanly.
+
+```yaml
+# Remove these blocks from .github/dependabot.yml under the npm-minor-and-patch group:
+- dependency-name: "eslint"
+  update-types: ["version-update:semver-major"]
+- dependency-name: "@eslint/js"
+  update-types: ["version-update:semver-major"]
+- dependency-name: "eslint-plugin-react-hooks"
+  versions: [">=7.1.0"]
+- dependency-name: "eslint-plugin-react-refresh"
+  versions: [">=0.5.0"]
+```
+
+Keep the typescript ignore (still blocked on openapi-typescript upstream).
+
+### 8. Bonus: re-enable enforce_admins behavior check
+
+`enforce_admins` was turned ON during this session as part of #78. That means even you (admin) need branch protection to be satisfied. If that's surprising in normal use:
+
+```bash
+# Check current state
+gh api repos/jackmusick/bifrost/branches/main/protection --jq '.enforce_admins.enabled'
+
+# To turn off (only if you actively want to bypass branch protection as admin):
+gh api -X DELETE repos/jackmusick/bifrost/branches/main/protection/enforce_admins
+
+# To turn back on:
+gh api -X POST repos/jackmusick/bifrost/branches/main/protection/enforce_admins
+```
+
+Best practice is to leave it ON. Just be aware of why merges might say "base branch policy prohibits the merge" — see the conversation-resolution issue from this session.
+
+### 9. Bonus: review Thomas's PRs
+
+**#27** Thomas timeout fix — I pushed the fix on his behalf during this session; should auto-merge with the queue.
+
+**#28** vuln deps draft — comment posted asking if Dependabot covered. If author hasn't responded in another 7 days, close with thank-you.
+
+**#37** health probes draft (360 LOC) — too soon for ping when this session ended. Revisit if untouched 14 days from creation.
+
+**#87** add OSS security baseline (Semgrep, Gitleaks, OSV, Trivy) — opened during this session. **Genuine review needed.** Read the diff, decide if you want all 4 scanners (likely yes — they're complementary to CodeQL) or a subset.
+
+
+
+## Final state when the session ended
+
+### CodeQL: 1033 → 506 open
+
+That's 527 alerts cleared (51% drop). Will continue dropping as the queued PRs land + CodeQL re-scans. Remaining clusters are mostly:
+
+- **267 `py/log-injection`** — PR #82 wraps ~100 with `log_safe()`. Once it lands and re-scans, count drops further. Residual ~150 are lower-priority files.
+- **134 `py/empty-except`** — PR #84 fixes ALL 134 (110 debug logs added, 16 narrowed except classes, 2 real bug fixes). Auto-resolves on merge.
+- **19 `js/superfluous-trailing-arguments`** — auto-resolves via #77 (paths-ignore on playwright-report).
+- **15 `js/trivial-conditional`** — auto-resolves via #77.
+- **9 `PinnedDependenciesID`** — auto-resolves via #78 (Docker SHA pinning).
+- **8 `js/unneeded-defensive-code`** — auto-resolves via #77.
+- **7 `py/polynomial-redos`** — fixed in PR #85.
+- **7 `js/useless-assignment-to-local`** — 6 in playwright-report (auto-resolves via #77), 1 fixed in #79.
+
+**Realistic post-merge target: ~100 open alerts**, almost all FPs that are already dismissed but show as open in the immediate snapshot before re-scan.
+
+## PRs that landed during the session (already on main)
+
+- **#23** — pre-session feat(embed)
+- **#40** — pre-session OSS hardening baseline (Tier 0/1/2)
+- **#52** — webauthn 2.0→2.7
+- **#54-#58** — patch/minor JS deps
+- **#67-#71** — dompurify, lodash, minimatch, node-forge
+- **#75** — bifrost-secaudit + bifrost-secupdate skills
+- **#76** — CodeQL safe-note batch fixes
+- **#53** — fastmcp
+
+## PRs queued for auto-merge (CI in progress)
+
+| # | What | Auto-merge | Reviewer-eyeball needed? |
+|---|---|---|---|
+| #72 | npm minor-and-patch group (43 deps) | ✅ | gated on #73 + recreate |
+| #73 | dependabot ignore rules for eslint 10 / TS 6 / react-hooks 7.1 | ✅ | no |
+| #77 | CodeQL paths-ignore + delete playwright-report | ✅ | no |
+| #78 | Docker SHA pinning + ci.yml perms scope + enforce_admins | ✅ | no |
+| #79 | 8 small CodeQL fixes (stack-trace, ReDoS, SSRF, exit-from-finally, token-leak, etc) | ✅ | no |
+| #80 | path-injection root fix in _resolve_path | ✅ | no |
+| #81 | tarfile filter='data' defense-in-depth | ✅ | no |
+| #82 | log_safe() helper + 101 callsite wraps | ✅ | no |
+| #84 | py/empty-except sweep (110 debug logs, 16 narrowed, 2 bug fixes) | ✅ | no |
+| #85 | residual CodeQL warnings + singletons (17 fixes + 75 dismissals) | ❌ | **yes — see below** |
+
+## PR #85 — pause point for Jack
+
+**Auto-merge not enabled** because of one specific finding the agent surfaced:
+
+**`py/weak-sensitive-data-hashing` at `api/src/routers/workflow_keys.py:254`** — `hashlib.sha256()` over a `secrets.token_urlsafe(32)` random key.
+
+CodeQL's rule targets *password* hashing (where slow hashes like bcrypt/argon2 are required). For *high-entropy random tokens*, SHA-256 is standard practice — there's no rainbow-table risk because the input is already random. Migrating would break stored hashes (would need a migration plan or versioned-hash format).
+
+**Default decision:** keep SHA-256, dismiss the alert as `false positive` with the rationale above. The fix would be churn for no real security gain.
+
+**To action:** review `client/src/routers/workflow_keys.py:254`, confirm the hashing pattern, then either:
+- `gh pr review 85 --approve --body "agree, sha256 over token_urlsafe is fine for random keys"` then `gh pr merge 85 --auto --squash` — and dismiss the singleton CodeQL alert separately
+- OR comment with a different concern and close the PR
+
+## Eslint sweep — STILL IN FLIGHT
+
+A subagent is working in `/tmp/bifrost-worktrees/eslint-sweep` on the ~62 react-hooks errors that gate eslint 10 + react-hooks 7.1. **41 files modified**, ~990 insertions / ~807 deletions, no commits yet. The subagent is probably still ironing out the last few `set-state-in-effect` decisions.
+
+When you come back:
+
+1. **Check if it finished** — look for a PR titled something like `fix(client): code sweep for eslint 10 + react-hooks 7.1`.
+2. **If yes**, eyeball 5 random `set-state-in-effect` refactors to confirm they're real fixes (not blanket `eslint-disable`). The agent's brief said max 5 disabled sites — verify that count is honored.
+3. **If no, finish it manually**: the worktree at `/tmp/bifrost-worktrees/eslint-sweep` has 41 files modified. `cd` into it, run `npm run lint`, see what's left, finish whatever's incomplete, then commit + push + open PR.
+
+Once it lands, a follow-up PR can lift the dependabot ignore rules added in #73:
+
+```yaml
+# Remove these blocks from .github/dependabot.yml:
+- dependency-name: "eslint"
+  update-types: ["version-update:semver-major"]
+- dependency-name: "@eslint/js"
+  update-types: ["version-update:semver-major"]
+- dependency-name: "eslint-plugin-react-hooks"
+  versions: [">=7.1.0"]
+- dependency-name: "eslint-plugin-react-refresh"
+  versions: [">=0.5.0"]
+```
+
+Then Dependabot will re-open eslint 10 + plugin bumps, and they'll land cleanly.
+
+## Section C major-bump PRs — auto-merge queue
+
+| # | Bump | State |
+|---|---|---|
+| #41 | playwright v1.59 | green, BEHIND, will land on next refresh |
+| #42 | python 3.14 | fixed (Dockerfile paths), BEHIND |
+| #43 | node 25 | green, BEHIND |
+| #44 | docker/build-push v7 | green, BEHIND |
+| #45 | actions/checkout v6 | green, BEHIND |
+| #46 | docker/metadata v6 | green, BEHIND |
+| #47 | docker/login v4 | green, BEHIND |
+| #48 | docker/setup-buildx v4 | green, BEHIND |
+| #49 | codecov v6 | green, BEHIND |
+| #50 | actions/setup-node v6 | green, BEHIND |
+| #51 | github/codeql v4 | green, BEHIND |
+| #63 | vite 8 + plugin-react 6 + tailwindcss bundle | gated on #73 + recreate |
+| #64 | lucide-react 1.x (with local Github icon) | green, BEHIND |
+
+All have auto-merge enabled. They'll land naturally as the queue drains. If any get stuck, run:
+
+```bash
+for pr in 41 42 43 44 45 46 47 48 49 50 51 64; do
+  state=$(gh pr view $pr --repo jackmusick/bifrost --json mergeStateStatus --jq '.mergeStateStatus')
+  [ "$state" = "BEHIND" ] && gh api -X PUT "repos/jackmusick/bifrost/pulls/$pr/update-branch" >/dev/null && echo "  refreshed #$pr"
+done
+```
+
+## Closed with explanation (4 PRs)
+
+- **#61** (eslint 10) — closed; tracking issue #74 (now being executed by eslint sweep subagent)
+- **#62** (@eslint/js 10) — closed; bundled with #61
+- **#65** (typescript 6) — closed; blocked on openapi-typescript upstream PR #2774
+- **#66** (vite 8) — closed; bundled into #63
+
+## Tracking issues filed
+
+- **#74** — react-hooks code sweep (currently being executed)
+- **#83** — apply for OpenSSF Best Practices Badge (manual form fill, ~30 min — needs you)
+
+## Section F community PRs
+
+- **#27** Thomas timeout fix — past day-3 ping window. **Suggested action:** if Thomas hasn't responded, push the fix on his behalf (one-line fix at `routers/workflows.py:110`). Confirm `maintainer_can_modify: true` first.
+- **#28** Thomas vuln deps — comment posted, awaiting author response. If 7+ days no response, close with thank-you.
+- **#37** Thomas health probes draft — too soon for action.
+
+## Things deferred to a future session
+
+- **TypeScript 6** — blocked on openapi-typescript upstream. Revisit when their PR #2774 ships. No urgency.
+- **OpenSSF Best Practices Badge** (issue #83) — needs you to fill out the form at https://www.bestpractices.dev/.
+- **Thomas's #27** — needs your call on whether to push the fix on his behalf.
+- **Phase 2/3 of security-skill rollout** — schedule `bifrost-secaudit` weekday mornings via `/schedule`. Defer until ≥2 weeks of manual invocation builds confidence in the skill.
+
+## Items where Jack pushed back during the session
+
+These shaped the final approach:
+
+1. **"Why dismiss stuff that can be fixed?"** — caused me to reopen 134 empty-except + 6 dead-var alerts. Both are fixed in PRs #84 and #79.
+2. **"I don't believe we're truly trying to swallow that many exceptions. No way."** — confirmed #84's per-site-judgment approach was right.
+3. **"Code was almost entirely generated, smells weren't intended."** — drove the skeptical re-audit subagent. Confirmed all kept dismissals as true FPs; no false dismissals slipped through.
+4. **"The react thing you'd know better than me."** — eslint sweep subagent operates with full autonomy on react patterns; only flag for review if it ends up disabling more than 5 sites.
+
+## What can't be re-derived without this doc
+
+- The pause-point on PR #85 (workflow_keys.py:254 sha256 question) — surface this to Jack on resume.
+- The eslint sweep needs the dependabot.yml ignore rules lifted in a follow-up PR after it lands. Don't forget.
+- The OpenSSF badge issue is the only one requiring manual user action, not code.


### PR DESCRIPTION
## Summary
- Adds the audit-when-the-queue-is-empty checklist to the followups plan doc.
- Runs through Security tab (\`/bifrost-secaudit\`), CodeQL re-scan, Dependabot alerts, Scorecard, tracking issues #74/#83/#92, eslint ignore-rule lift, Thomas's PRs.
- Markdown only — no code changes.

## Why
After this session of work, ~24 PRs are queued and draining over the next several hours. Without an explicit post-drain checklist, anything that didn't auto-resolve (rare CodeQL stragglers, surprise Dependabot alert, badge form, etc) could go unnoticed for weeks.

## Test plan
- [ ] N/A (docs)