### PR TITLE
fix(codeql): close remaining log-injection multi-value cases + script cleanups

### DIFF
--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -205,7 +205,7 @@ class ApplicationRepository(OrgScopedRepository[Application]):
 
         await self.session.refresh(application)
 
-        logger.info(f"Created application '{log_safe(data.slug)}' in org {self.org_id} with access_level={data.access_level}")
+        logger.info(f"Created application '{log_safe(data.slug)}' in org {self.org_id} with access_level={log_safe(data.access_level)}")
         return application
 
     async def update_application(

--- a/api/src/routers/config.py
+++ b/api/src/routers/config.py
@@ -260,7 +260,7 @@ class ConfigRepository(OrgScopedRepository[ConfigModel]):  # type: ignore[type-v
         await self.session.flush()
         await self.session.refresh(config)
 
-        logger.info(f"Updated config {log_safe(config.key)} (id={log_safe(config_id)}) org={config.organization_id}")
+        logger.info(f"Updated config {log_safe(config.key)} (id={log_safe(config_id)}) org={log_safe(config.organization_id)}")
 
         response_type = ConfigType(config.config_type.value) if config.config_type else ConfigType.STRING
         stored_value = config.value.get("value") if isinstance(config.value, dict) else config.value

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -1420,7 +1420,7 @@ async def update_workflow(
         except Exception as e:
             logger.warning(f"Failed to refresh MCP workflow tools: {e}")
 
-        logger.info(f"Updated workflow '{log_safe(workflow.name)}' organization_id={workflow.organization_id}, access_level={workflow.access_level}")
+        logger.info(f"Updated workflow '{log_safe(workflow.name)}' organization_id={log_safe(workflow.organization_id)}, access_level={log_safe(workflow.access_level)}")
         return _convert_workflow_orm_to_schema(workflow)
 
     except HTTPException:
@@ -1717,7 +1717,7 @@ async def deactivate_workflow(
         if ref_count > 0:
             warning = f"{ref_count} {'form/app still references' if ref_count == 1 else 'forms/apps still reference'} this workflow"
 
-        logger.info(f"Deactivated workflow {log_safe(workflow_id)} (refs: {ref_count})")
+        logger.info(f"Deactivated workflow {log_safe(workflow_id)} (refs: {log_safe(ref_count)})")
 
         return DeactivateWorkflowResponse(
             success=True,

--- a/api/tests/unit/routers/test_health.py
+++ b/api/tests/unit/routers/test_health.py
@@ -45,7 +45,7 @@ async def test_health_is_liveness_and_does_not_check_dependencies(monkeypatch):
         raise AssertionError("dependency checks should not run")
 
     monkeypatch.setattr(health, "build_health_components", fail_if_called)
-    monkeypatch.setattr(health, "get_settings", lambda: _settings())
+    monkeypatch.setattr(health, "get_settings", _settings)
 
     result = await health.health_check()
 
@@ -59,7 +59,7 @@ async def test_live_is_liveness_and_does_not_check_dependencies(monkeypatch):
         raise AssertionError("dependency checks should not run")
 
     monkeypatch.setattr(health, "build_health_components", fail_if_called)
-    monkeypatch.setattr(health, "get_settings", lambda: _settings())
+    monkeypatch.setattr(health, "get_settings", _settings)
 
     result = await health.live_health_check()
 
@@ -69,7 +69,7 @@ async def test_live_is_liveness_and_does_not_check_dependencies(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ready_returns_healthy_when_core_dependencies_pass(monkeypatch):
-    monkeypatch.setattr(health, "get_settings", lambda: _settings())
+    monkeypatch.setattr(health, "get_settings", _settings)
     monkeypatch.setattr(health, "build_health_components", _build_components)
 
     response = Response()
@@ -83,7 +83,7 @@ async def test_ready_returns_healthy_when_core_dependencies_pass(monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("component", ["database", "redis", "rabbitmq", "s3"])
 async def test_ready_returns_503_when_required_dependency_fails(monkeypatch, component):
-    monkeypatch.setattr(health, "get_settings", lambda: _settings())
+    monkeypatch.setattr(health, "get_settings", _settings)
 
     components = {
         "database": {"status": "healthy", "type": "postgresql"},
@@ -159,7 +159,7 @@ async def test_error_output_does_not_include_secret_values(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_detailed_uses_same_component_status_logic(monkeypatch):
-    monkeypatch.setattr(health, "get_settings", lambda: _settings())
+    monkeypatch.setattr(health, "get_settings", _settings)
     async def build_components(db, settings):
         return {
             "database": {"status": "healthy", "type": "postgresql"},

--- a/scripts/docs/bootstrap-manifest.mjs
+++ b/scripts/docs/bootstrap-manifest.mjs
@@ -11,8 +11,8 @@
  *   screenshots.yaml      draft manifest covering every existing image reference
  *   bootstrap-report.md   gap list + low-confidence flags
  */
-import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from "node:fs";
-import { resolve, relative, dirname, join, basename } from "node:path";
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, renameSync } from "node:fs";
+import { resolve, relative, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
 
@@ -415,7 +415,11 @@ function main() {
     },
     entries,
   };
-  writeFileSync(manifestPath, yaml.dump(manifest, { lineWidth: 120, noRefs: true }));
+  // Atomic write: write to temp file then rename, so a concurrent reader
+  // never sees a half-written manifest (closes CodeQL js/file-system-race).
+  const manifestTmp = `${manifestPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(manifestTmp, yaml.dump(manifest, { lineWidth: 120, noRefs: true }));
+  renameSync(manifestTmp, manifestPath);
 
   const reportLines = [];
   reportLines.push(`# Bootstrap Report`);

--- a/scripts/docs/post-process.mjs
+++ b/scripts/docs/post-process.mjs
@@ -21,7 +21,7 @@
  * Outputs (to stdout):
  *   JSON summary { committed, unchanged, errors, missing }
  */
-import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync, renameSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { execSync } from "node:child_process";
 import yaml from "js-yaml";
@@ -201,7 +201,11 @@ async function main() {
       }
 
       if (shouldCommit) {
-        writeFileSync(targetPath, finalBuf);
+        // Atomic write: write to temp file then rename, so a concurrent reader
+        // never sees a half-written PNG (closes CodeQL js/file-system-race).
+        const targetTmp = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
+        writeFileSync(targetTmp, finalBuf);
+        renameSync(targetTmp, targetPath);
         entry.captured_at = { bifrost_sha: sha, timestamp: new Date().toISOString() };
       }
 
@@ -216,8 +220,10 @@ async function main() {
     }
   }
 
-  // Write back the manifest with updated captured_at fields.
-  writeFileSync(manifestPath, yaml.dump(manifest, { lineWidth: 120, noRefs: true }));
+  // Write back the manifest with updated captured_at fields (atomic).
+  const manifestTmp = `${manifestPath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(manifestTmp, yaml.dump(manifest, { lineWidth: 120, noRefs: true }));
+  renameSync(manifestTmp, manifestPath);
 
   console.log(JSON.stringify(summary, null, 2));
 }


### PR DESCRIPTION
Closes the final 13 open CodeQL alerts on jackmusick/bifrost (excluding meta-rule Scorecard/SAST/Vulnerabilities alerts that auto-clear).

## Alerts addressed

### py/log-injection (alerts #1070, #1071, #1072, #1073)
Multi-value f-strings where one value was already wrapped with `log_safe()` from PR #82 / #98 but additional user-controlled values were left bare:

- `#1070` — `api/src/routers/applications.py:208` — wrap `data.access_level`
- `#1071` — `api/src/routers/config.py:263` — wrap `config.organization_id`
- `#1072` — `api/src/routers/workflows.py:1423` — wrap both `workflow.organization_id` and `workflow.access_level`
- `#1073` — `api/src/routers/workflows.py:1720` — wrap `ref_count` (CodeQL flags it because it derives from a query parametrized by the user-controlled `workflow_id` path param)

### js/unused-local-variable (alerts #1078, #1079)
- `#1078` — `scripts/docs/post-process.mjs:24` — drop unused `copyFileSync` from `node:fs` import
- `#1079` — `scripts/docs/bootstrap-manifest.mjs:15` — drop unused `basename` from `node:path` import

### js/file-system-race (alerts #1075, #1076)
Classic check-then-write race fixed with the canonical atomic-write pattern (`writeFileSync(tmpPath, content); renameSync(tmpPath, targetPath)`):

- `#1076` — `scripts/docs/bootstrap-manifest.mjs:418` — manifest write
- `#1075` — `scripts/docs/post-process.mjs:204` — PNG write inside `if (shouldCommit)` block
- Also hardened the manifest writeback at `post-process.mjs:220` for consistency (same pattern, no separate alert)

### py/unnecessary-lambda (alerts #1065–#1069)
Replaced `lambda: _settings()` with `_settings` (the helper accepts only a defaulted kwarg) in `api/tests/unit/routers/test_health.py`:

- `#1065` — line 48
- `#1066` — line 62
- `#1067` — line 72
- `#1068` — line 86
- `#1069` — line 162

Lines 113 and 142 keep their lambdas — they bind a non-default argument or a captured variable, so the simplification doesn't apply.

## Verification

- `cd api && pyright` — no new errors (only pre-existing `pytest` import warnings under `tests/unit`)
- `cd api && ruff check .` — passes
- `cd client && npm run tsc` — passes
- `cd client && npx eslint .` — passes (only pre-existing `react-hooks/incompatible-library` warnings on `useForm().watch()` calls)

## Test plan

- [ ] CodeQL re-scan on `main` after merge confirms all 13 alerts closed
- [ ] No regression in existing log-injection alerts (no bare user values reintroduced)

Generated with [Claude Code](https://claude.com/claude-code)