### PR TITLE
chore(deps): bump vulnerable Python deps to close known CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@
 # =============================================================================
 fastapi
 uvicorn[standard]
-python-multipart  # Form data handling
+python-multipart>=0.0.26  # Form data handling (CVE fixes through 0.0.26)
 
 # =============================================================================
 # Database (PostgreSQL)
 # =============================================================================
 sqlalchemy[asyncio]
-asyncpg  # Async PostgreSQL driver
+asyncpg>=0.30.0  # Async PostgreSQL driver (CVE-2024-25737 RCE fixed in 0.29.0)
 psycopg2-binary  # Sync PostgreSQL driver (for SDK/workflow threads)
 alembic  # Database migrations
 greenlet  # Required by SQLAlchemy async
@@ -47,7 +47,7 @@ email-validator  # Required by Pydantic for email validation
 # HTTP & Async
 # =============================================================================
 httpx  # Async HTTP client
-aiohttp
+aiohttp>=3.13.4  # Closes 20 CVEs incl. CVSS 9.1
 aiofiles
 
 # =============================================================================
@@ -73,7 +73,7 @@ jinja2
 # =============================================================================
 dulwich
 PyGithub
-GitPython
+GitPython>=3.1.41  # Closes 5 CVEs incl. CVSS 9.8 RCE
 
 # =============================================================================
 # Background Jobs


### PR DESCRIPTION
## Summary

Bumps Python dependencies in `requirements.txt` (repo root) to close vulnerabilities flagged by OSV-Scanner. Improves OpenSSF Scorecard `VulnerabilitiesID` score (currently 0) and closes several CVSS 8+/9+ severity issues.

Tracks OpenSSF Scorecard issue [#29 (`VulnerabilitiesID`)](https://github.com/jackmusick/bifrost/issues/29).

## Bumps

| Package | Was | Now (min) | Resolved | CVEs closed |
|---|---|---|---|---|
| `aiohttp` | unpinned (3.9.5 floor via transitive) | `>=3.13.4` | 3.13.5 | 20 CVEs incl. CVSS 9.1 (request smuggling, header parsing) |
| `asyncpg` | unpinned (0.9.0 floor) | `>=0.30.0` | 0.31.0 | CVE-2024-25737 RCE (CVSS 9.8) |
| `python-multipart` | unpinned (0.0.9 floor) | `>=0.0.26` | 0.0.26 | 3 CVEs (DoS via malformed boundaries) |
| `GitPython` | unpinned (3.1.9 floor) | `>=3.1.41` | 3.1.47 | 5 CVEs incl. CVSS 9.8 RCE (CVE-2023-40590, CVE-2024-22190) |

## Transitive deps (NOT added)

`mako`, `setuptools`, and `tqdm` were also flagged but are transitive (not in our `requirements.txt`). Verified that pip already resolves them above their fix versions today via upstream constraints from FastAPI / SQLAlchemy / Anthropic SDK:

| Package | Fix needed | Resolved | Notes |
|---|---|---|---|
| `mako` | 1.3.11 | 1.3.11 | Pulled by alembic |
| `setuptools` | 78.1.1 | 79.0.1 | Build-time only, pulled by Python ecosystem |
| `tqdm` | 4.66.3 | 4.67.3 | Pulled by openai/anthropic |

If we want defensive pins on these later, that's a separate change.

## Validation

1. **Clean install in `python:3.11-slim`** — succeeds without conflict errors.
2. **Import sanity check** — all of `aiohttp`, `asyncpg`, `multipart`, `git`, `mako`, `setuptools`, `tqdm` import successfully at the resolved versions above.
3. **Unit test suite** — 3136 tests pass against bumped deps in the worktree's test stack (~3 min).

## Test plan

- [x] Clean `pip install -r requirements.txt` in fresh container
- [x] Import smoke test of all bumped packages
- [x] `./test.sh unit` — full unit test suite passes
- [ ] CI validates on PR (full backend e2e + client e2e)