### PR TITLE
[codex] Add ZAP baseline scan

### DIFF
--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,0 +1,70 @@
+name: OWASP ZAP Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Sanctioned Bifrost endpoint to scan
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - poc
+  schedule:
+    - cron: "37 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  select-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.targets.outputs.matrix }}
+    steps:
+      - name: Select sanctioned targets
+        id: targets
+        env:
+          TARGET: ${{ github.event.inputs.target || 'all' }}
+        run: |
+          case "${TARGET}" in
+            all)
+              MATRIX='{"include":[{"name":"poc","url":"https://20.9.81.122"}]}'
+              ;;
+            poc)
+              MATRIX='{"include":[{"name":"poc","url":"https://20.9.81.122"}]}'
+              ;;
+            *)
+              echo "Unsupported target: ${TARGET}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
+  zap-baseline:
+    name: ZAP baseline (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: select-targets
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.select-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run OWASP ZAP passive baseline
+        uses: zaproxy/action-baseline@6c5a007541891231cd9e0ddec25d4f25c59c9874 # v0.15.0
+        with:
+          target: ${{ matrix.url }}
+          docker_name: ghcr.io/zaproxy/zaproxy:stable
+          allow_issue_writing: false
+          fail_action: false
+          artifact_name: zap-baseline-${{ matrix.name }}
+          cmd_options: >-
+            -m 3
+            -z "-config view.locale=en_GB"

--- a/docs/security/ZAP-BASELINE.md
+++ b/docs/security/ZAP-BASELINE.md
@@ -1,0 +1,40 @@
+# OWASP ZAP Baseline Scanning
+
+Bifrost uses a sanctioned OWASP ZAP baseline workflow for passive DAST coverage of the exposed proof deployment.
+
+## Scope
+
+The workflow is intentionally limited to known Midtown-owned Bifrost endpoints:
+
+- POC: `https://20.9.81.122`
+
+The workflow does not accept arbitrary URLs. Add or replace targets in code review so scan scope stays explicit. When a stable hostname replaces the current Azure public IP, update both the workflow matrix and this document in the same change.
+
+## What It Runs
+
+The workflow uses `zaproxy/action-baseline` with the stable ZAP container. This runs the ZAP spider briefly and waits for passive scanning to complete. It is intended for staging and proof systems because it does not run active attack payloads.
+
+Current settings:
+
+- manual `workflow_dispatch` target selection: `all` or `poc`;
+- weekly scheduled scan on Monday morning UTC;
+- passive baseline only;
+- no GitHub issue auto-writing;
+- reports uploaded as workflow artifacts;
+- `fail_action: false` while the first findings are triaged.
+
+## Operating Notes
+
+- Treat this as perimeter and unauthenticated coverage first.
+- Do not enable active scans against the proof environment until there is a seeded throwaway organization, a low-privilege test user, and a cleanup/reset path.
+- Do not scan customer production domains or third-party systems from this workflow.
+- Do not put bearer tokens, cookies, passwords, or TOTP secrets into workflow logs.
+- Review reports after each run and convert real findings into tracked remediation work.
+
+## Next Hardening Steps
+
+1. Review the first baseline artifacts and classify findings into true positives, accepted proof limits, and false positives.
+2. Add a small ZAP rules file only after triage, keeping each ignore documented.
+3. Replace the public IP target with the stable Bifrost hostname when DNS is ready.
+4. Add authenticated coverage with a disposable user and seeded proof data.
+5. Consider a separate active-scan workflow gated by an environment approval and pointed only at resettable test data.


### PR DESCRIPTION
## Summary

- adds a weekly/manual OWASP ZAP passive baseline workflow for the exposed Bifrost POC endpoint
- keeps scan scope hard-coded to sanctioned targets only, with no arbitrary URL input
- documents the current scan posture, operating notes, and next hardening steps in `docs/security/ZAP-BASELINE.md`

## Validation

- Parsed `.github/workflows/zap-baseline.yml` with Python/PyYAML
- Confirmed `https://20.9.81.122` returns `200 OK` over HTTPS from this workstation

## Notes

This mirrors the Bifrost Docs ZAP posture: passive baseline only, no issue auto-writing, and `fail_action: false` while the first artifacts are triaged. The current target is the Azure POC public IP; the workflow and docs should be updated together when a stable hostname replaces it.