### PR TITLE
chore(workflows): add workflow_dispatch to Scorecard + CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,7 @@ on:
     # Weekly run catches CVEs in newly-published advisories that match
     # existing code patterns (CodeQL queries are updated by GitHub).
     - cron: "0 9 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ on:
     - cron: "0 10 * * 1"
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
Lets us manually trigger fresh scans after deps bumps land. Trivial 2-line change adding `workflow_dispatch:` to both workflow trigger lists.