### PR TITLE
fix(e2e): close test isolation flakes (#101, #102)

### DIFF
--- a/api/alembic/versions/20260426_171650_partial_uq_system_configs_null_org.py
+++ b/api/alembic/versions/20260426_171650_partial_uq_system_configs_null_org.py
@@ -1,0 +1,42 @@
+"""add partial unique index for system_configs with null organization_id
+
+Postgres treats NULL as distinct in unique constraints, so the table-level
+``uq_system_config_category_key_org`` constraint does NOT enforce uniqueness
+when ``organization_id IS NULL`` (platform-wide rows like the MCP master
+config). A partial unique index closes that hole — at most one row per
+``(category, key)`` is allowed when ``organization_id`` is NULL.
+
+Revision ID: 20260426_part_uq_sysconfig
+Revises: 20260420_hmac_scheme
+Create Date: 2026-04-26 17:16:50.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260426_part_uq_sysconfig"
+down_revision: Union[str, None] = "20260420_hmac_scheme"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "uq_system_config_category_key_null_org",
+        "system_configs",
+        ["category", "key"],
+        unique=True,
+        postgresql_where=sa.text("organization_id IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_system_config_category_key_null_org",
+        table_name="system_configs",
+        postgresql_where=sa.text("organization_id IS NULL"),
+    )

--- a/api/src/services/mcp_server/config_service.py
+++ b/api/src/services/mcp_server/config_service.py
@@ -8,7 +8,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import delete as sa_delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.orm.config import SystemConfig
@@ -102,6 +102,15 @@ class MCPConfigService:
 
         Returns:
             Updated MCPConfig
+
+        Notes:
+            ``system_configs`` has no unique constraint on
+            ``(category, key, organization_id)``, so a SELECT-then-INSERT
+            pattern can leave duplicate rows behind under concurrency. We
+            collapse all matching rows down to one in a single transaction
+            (delete-extras-then-update-or-insert) and commit explicitly so
+            the next request observes the new state regardless of when the
+            FastAPI dependency cleanup runs.
         """
         config_data = {
             "enabled": enabled,
@@ -109,7 +118,8 @@ class MCPConfigService:
             "blocked_tool_ids": blocked_tool_ids or [],
         }
 
-        # Check if config exists
+        # Load all matching rows. Under steady-state there is exactly one;
+        # this path also self-heals if a prior race left duplicates.
         result = await self.session.execute(
             select(SystemConfig).where(
                 SystemConfig.category == MCP_CONFIG_CATEGORY,
@@ -117,18 +127,21 @@ class MCPConfigService:
                 SystemConfig.organization_id.is_(None),
             )
         )
-        existing = result.scalars().first()
+        existing_rows = list(result.scalars().all())
 
         now = datetime.now(timezone.utc)
 
-        if existing:
-            # Update existing
-            existing.value_json = config_data
-            existing.updated_by = updated_by
-            existing.updated_at = now
+        if existing_rows:
+            # Keep the first row, drop any duplicates so future GETs are
+            # deterministic.
+            primary = existing_rows[0]
+            for extra in existing_rows[1:]:
+                await self.session.delete(extra)
+            primary.value_json = config_data
+            primary.updated_by = updated_by
+            primary.updated_at = now
             logger.info(f"MCP config updated by {updated_by}")
         else:
-            # Create new
             new_config = SystemConfig(
                 category=MCP_CONFIG_CATEGORY,
                 key=MCP_CONFIG_KEY,
@@ -138,6 +151,13 @@ class MCPConfigService:
             )
             self.session.add(new_config)
             logger.info(f"MCP config created by {updated_by}")
+
+        # Commit before returning so the caller (and any racing reader on a
+        # different pgbouncer-routed connection) immediately sees the write.
+        # Relying solely on the FastAPI ``get_db`` dependency's post-yield
+        # commit is correct in principle but harder to reason about under a
+        # transaction-pooled pgbouncer; an explicit commit closes the gap.
+        await self.session.commit()
 
         return MCPConfig(
             enabled=enabled,
@@ -152,20 +172,28 @@ class MCPConfigService:
         Delete MCP configuration (revert to defaults).
 
         Returns:
-            True if config existed and was deleted, False otherwise
+            True if at least one config row was deleted, False otherwise
+
+        Notes:
+            Uses a bulk DELETE statement so any duplicate rows left by a
+            prior race are removed in a single round-trip. Commits
+            explicitly for the same reason as ``save_config``.
         """
         result = await self.session.execute(
-            select(SystemConfig).where(
+            sa_delete(SystemConfig).where(
                 SystemConfig.category == MCP_CONFIG_CATEGORY,
                 SystemConfig.key == MCP_CONFIG_KEY,
                 SystemConfig.organization_id.is_(None),
             )
         )
-        config = result.scalars().first()
+        await self.session.commit()
+        deleted = result.rowcount or 0
 
-        if config:
-            await self.session.delete(config)
-            logger.info("MCP config deleted (reverted to defaults)")
+        if deleted:
+            logger.info(
+                "MCP config deleted (reverted to defaults)",
+                extra={"rows_deleted": deleted},
+            )
             return True
 
         return False

--- a/api/src/services/mcp_server/config_service.py
+++ b/api/src/services/mcp_server/config_service.py
@@ -102,15 +102,6 @@ class MCPConfigService:
 
         Returns:
             Updated MCPConfig
-
-        Notes:
-            ``system_configs`` has no unique constraint on
-            ``(category, key, organization_id)``, so a SELECT-then-INSERT
-            pattern can leave duplicate rows behind under concurrency. We
-            collapse all matching rows down to one in a single transaction
-            (delete-extras-then-update-or-insert) and commit explicitly so
-            the next request observes the new state regardless of when the
-            FastAPI dependency cleanup runs.
         """
         config_data = {
             "enabled": enabled,
@@ -118,8 +109,7 @@ class MCPConfigService:
             "blocked_tool_ids": blocked_tool_ids or [],
         }
 
-        # Load all matching rows. Under steady-state there is exactly one;
-        # this path also self-heals if a prior race left duplicates.
+        # Check if config exists
         result = await self.session.execute(
             select(SystemConfig).where(
                 SystemConfig.category == MCP_CONFIG_CATEGORY,
@@ -127,21 +117,18 @@ class MCPConfigService:
                 SystemConfig.organization_id.is_(None),
             )
         )
-        existing_rows = list(result.scalars().all())
+        existing = result.scalars().first()
 
         now = datetime.now(timezone.utc)
 
-        if existing_rows:
-            # Keep the first row, drop any duplicates so future GETs are
-            # deterministic.
-            primary = existing_rows[0]
-            for extra in existing_rows[1:]:
-                await self.session.delete(extra)
-            primary.value_json = config_data
-            primary.updated_by = updated_by
-            primary.updated_at = now
+        if existing:
+            # Update existing
+            existing.value_json = config_data
+            existing.updated_by = updated_by
+            existing.updated_at = now
             logger.info(f"MCP config updated by {updated_by}")
         else:
+            # Create new
             new_config = SystemConfig(
                 category=MCP_CONFIG_CATEGORY,
                 key=MCP_CONFIG_KEY,
@@ -151,13 +138,6 @@ class MCPConfigService:
             )
             self.session.add(new_config)
             logger.info(f"MCP config created by {updated_by}")
-
-        # Commit before returning so the caller (and any racing reader on a
-        # different pgbouncer-routed connection) immediately sees the write.
-        # Relying solely on the FastAPI ``get_db`` dependency's post-yield
-        # commit is correct in principle but harder to reason about under a
-        # transaction-pooled pgbouncer; an explicit commit closes the gap.
-        await self.session.commit()
 
         return MCPConfig(
             enabled=enabled,
@@ -171,13 +151,12 @@ class MCPConfigService:
         """
         Delete MCP configuration (revert to defaults).
 
+        Uses a bulk DELETE so any duplicate rows left by an upstream polluter
+        (e.g. a test that PUT enabled=True without cleaning up) are wiped in
+        a single round-trip rather than just removing the first match.
+
         Returns:
             True if at least one config row was deleted, False otherwise
-
-        Notes:
-            Uses a bulk DELETE statement so any duplicate rows left by a
-            prior race are removed in a single round-trip. Commits
-            explicitly for the same reason as ``save_config``.
         """
         result = await self.session.execute(
             sa_delete(SystemConfig).where(
@@ -186,7 +165,6 @@ class MCPConfigService:
                 SystemConfig.organization_id.is_(None),
             )
         )
-        await self.session.commit()
         deleted = result.rowcount or 0
 
         if deleted:

--- a/api/tests/e2e/api-integration/test_mcp_endpoints.py
+++ b/api/tests/e2e/api-integration/test_mcp_endpoints.py
@@ -354,17 +354,28 @@ class TestMCPConfigToolFiltering:
 
     @pytest.fixture(autouse=True)
     def reset_config(self):
-        """Reset MCP config before and after each test."""
+        """Reset MCP config before and after each test.
+
+        Asserts the teardown DELETE actually returned 200 so that a silent
+        teardown failure (e.g. transient API unavailability) cannot leak
+        state into the next test and present as a stale-read flake.
+        """
         token = create_test_jwt(is_superuser=True)
         headers = auth_headers(token)
 
-        # Reset before test
-        requests.delete(f"{TEST_API_URL}/api/mcp/config", headers=headers)
+        # Reset before test — must succeed; failure leaves stale state.
+        pre = requests.delete(f"{TEST_API_URL}/api/mcp/config", headers=headers)
+        assert pre.status_code == 200, (
+            f"reset_config pre-test DELETE failed: {pre.status_code} {pre.text}"
+        )
 
         yield
 
-        # Reset after test
-        requests.delete(f"{TEST_API_URL}/api/mcp/config", headers=headers)
+        # Reset after test — same contract.
+        post = requests.delete(f"{TEST_API_URL}/api/mcp/config", headers=headers)
+        assert post.status_code == 200, (
+            f"reset_config post-test DELETE failed: {post.status_code} {post.text}"
+        )
 
     @pytest.mark.e2e
     def test_config_saves_allowed_tool_ids(self):

--- a/api/tests/e2e/api-integration/test_mcp_endpoints.py
+++ b/api/tests/e2e/api-integration/test_mcp_endpoints.py
@@ -30,6 +30,34 @@ TEST_API_URL = os.getenv("TEST_API_URL", "http://api:8000")
 class TestMCPConfigEndpoint:
     """Tests for /api/mcp/config endpoint access control."""
 
+    @pytest.fixture(autouse=True)
+    def reset_config(self):
+        """Reset MCP config before and after each test.
+
+        ``test_put_config_success_for_platform_admin`` PUTs ``enabled=True``
+        and never cleans up; without this fixture the leaked row persists
+        into ``TestMCPConfigToolFiltering`` (collected later in the same
+        file) and causes stale-read failures there. Asserting 200 on both
+        DELETEs ensures a teardown failure surfaces as a teardown failure
+        rather than as a flake two layers downstream.
+        """
+        token = create_test_jwt(is_superuser=True)
+        headers = auth_headers(token)
+
+        # Reset before test — must succeed; failure leaves stale state.
+        pre = requests.delete(f"{TEST_API_URL}/api/mcp/config", headers=headers)
+        assert pre.status_code == 200, (
+            f"reset_config pre-test DELETE failed: {pre.status_code} {pre.text}"
+        )
+
+        yield
+
+        # Reset after test — same contract.
+        post = requests.delete(f"{TEST_API_URL}/api/mcp/config", headers=headers)
+        assert post.status_code == 200, (
+            f"reset_config post-test DELETE failed: {post.status_code} {post.text}"
+        )
+
     @pytest.mark.e2e
     def test_get_config_requires_auth(self):
         """Should return 401 when no auth provided."""

--- a/api/tests/e2e/api/test_workflow_scheduling_flow.py
+++ b/api/tests/e2e/api/test_workflow_scheduling_flow.py
@@ -121,8 +121,16 @@ async def test_schedule_promote_run_terminal(
     await asyncio.sleep(3)
     from src.jobs.schedulers.deferred_execution_promoter import promote_due_executions
 
-    promoted, failures = await promote_due_executions()
-    assert promoted >= 1, f"expected at least 1 promoted row, got {promoted}"
+    # The scheduler container ALSO runs promote_due_executions every 60s
+    # (next_run_time=now at boot). If its tick lands inside our 3s sleep
+    # above, it picks up our row via SELECT FOR UPDATE SKIP LOCKED before
+    # this direct call runs, and our call returns promoted=0. That is
+    # behaviorally fine — the row still gets promoted and the worker still
+    # runs it — but it makes asserting `promoted >= 1` flaky. So we drop
+    # the promoted-count assertion and verify the post-condition: the row
+    # left SCHEDULED (regardless of which tick promoted it) and any
+    # publishes our call attempted didn't fail.
+    _, failures = await promote_due_executions()
     assert failures == 0, f"expected 0 publish failures, got {failures}"
 
     # Poll for the worker to run it to a terminal status.

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -835,11 +835,12 @@ class TestMCPConfigService:
         """Should create new config when none exists."""
         from src.services.mcp_server.config_service import MCPConfigService
 
-        # Mock no existing config
+        # Mock no existing config (empty list from .scalars().all())
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_result.scalars.return_value.all.return_value = []
         mock_session.execute = AsyncMock(return_value=mock_result)
         mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         config = await service.save_config(
@@ -850,6 +851,7 @@ class TestMCPConfigService:
         )
 
         mock_session.add.assert_called_once()
+        mock_session.commit.assert_awaited_once()
         assert config.enabled is False
         assert config.blocked_tool_ids == ["search_knowledge"]
 
@@ -858,12 +860,13 @@ class TestMCPConfigService:
         """Should update existing config."""
         from src.services.mcp_server.config_service import MCPConfigService
 
-        # Mock existing config
+        # Mock existing config (single row from .scalars().all())
         mock_config = MagicMock()
         mock_config.value_json = {"enabled": True}
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = mock_config
+        mock_result.scalars.return_value.all.return_value = [mock_config]
         mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         config = await service.save_config(
@@ -876,34 +879,67 @@ class TestMCPConfigService:
         assert config.enabled is False
         assert mock_config.value_json["enabled"] is False
         assert mock_config.updated_by == "admin@test.com"
+        mock_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_save_config_collapses_duplicate_rows(self, mock_session):
+        """Should drop duplicate rows when more than one exists.
+
+        ``system_configs`` has no unique constraint on
+        ``(category, key, organization_id)``, so a prior race could leave
+        duplicates. ``save_config`` should collapse them down to one in the
+        same transaction so future GETs are deterministic.
+        """
+        from src.services.mcp_server.config_service import MCPConfigService
+
+        primary = MagicMock()
+        primary.value_json = {"enabled": True}
+        extra = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [primary, extra]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.delete = AsyncMock()
+        mock_session.commit = AsyncMock()
+
+        service = MCPConfigService(mock_session)
+        await service.save_config(
+            enabled=False,
+            allowed_tool_ids=None,
+            blocked_tool_ids=[],
+            updated_by="admin@test.com",
+        )
+
+        mock_session.delete.assert_awaited_once_with(extra)
+        assert primary.value_json["enabled"] is False
 
     @pytest.mark.asyncio
     async def test_delete_config_removes_existing(self, mock_session):
-        """Should delete existing config."""
+        """Should delete existing config via bulk DELETE."""
         from src.services.mcp_server.config_service import MCPConfigService
 
-        # Mock existing config
-        mock_config = MagicMock()
+        # Mock bulk DELETE returning rowcount=1
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = mock_config
+        mock_result.rowcount = 1
         mock_session.execute = AsyncMock(return_value=mock_result)
-        mock_session.delete = AsyncMock()
+        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         deleted = await service.delete_config()
 
         assert deleted is True
-        mock_session.delete.assert_called_once_with(mock_config)
+        mock_session.execute.assert_awaited_once()
+        mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_delete_config_returns_false_when_none_exists(self, mock_session):
-        """Should return False when no config to delete."""
+        """Should return False when no config to delete (rowcount=0)."""
         from src.services.mcp_server.config_service import MCPConfigService
 
-        # Mock no config
+        # Mock bulk DELETE returning rowcount=0
         mock_result = MagicMock()
-        mock_result.scalars.return_value.first.return_value = None
+        mock_result.rowcount = 0
         mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         deleted = await service.delete_config()

--- a/api/tests/unit/services/test_mcp_tools.py
+++ b/api/tests/unit/services/test_mcp_tools.py
@@ -835,12 +835,11 @@ class TestMCPConfigService:
         """Should create new config when none exists."""
         from src.services.mcp_server.config_service import MCPConfigService
 
-        # Mock no existing config (empty list from .scalars().all())
+        # Mock no existing config
         mock_result = MagicMock()
-        mock_result.scalars.return_value.all.return_value = []
+        mock_result.scalars.return_value.first.return_value = None
         mock_session.execute = AsyncMock(return_value=mock_result)
         mock_session.add = MagicMock()
-        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         config = await service.save_config(
@@ -851,7 +850,6 @@ class TestMCPConfigService:
         )
 
         mock_session.add.assert_called_once()
-        mock_session.commit.assert_awaited_once()
         assert config.enabled is False
         assert config.blocked_tool_ids == ["search_knowledge"]
 
@@ -860,13 +858,12 @@ class TestMCPConfigService:
         """Should update existing config."""
         from src.services.mcp_server.config_service import MCPConfigService
 
-        # Mock existing config (single row from .scalars().all())
+        # Mock existing config
         mock_config = MagicMock()
         mock_config.value_json = {"enabled": True}
         mock_result = MagicMock()
-        mock_result.scalars.return_value.all.return_value = [mock_config]
+        mock_result.scalars.return_value.first.return_value = mock_config
         mock_session.execute = AsyncMock(return_value=mock_result)
-        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         config = await service.save_config(
@@ -879,38 +876,6 @@ class TestMCPConfigService:
         assert config.enabled is False
         assert mock_config.value_json["enabled"] is False
         assert mock_config.updated_by == "admin@test.com"
-        mock_session.commit.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_save_config_collapses_duplicate_rows(self, mock_session):
-        """Should drop duplicate rows when more than one exists.
-
-        ``system_configs`` has no unique constraint on
-        ``(category, key, organization_id)``, so a prior race could leave
-        duplicates. ``save_config`` should collapse them down to one in the
-        same transaction so future GETs are deterministic.
-        """
-        from src.services.mcp_server.config_service import MCPConfigService
-
-        primary = MagicMock()
-        primary.value_json = {"enabled": True}
-        extra = MagicMock()
-        mock_result = MagicMock()
-        mock_result.scalars.return_value.all.return_value = [primary, extra]
-        mock_session.execute = AsyncMock(return_value=mock_result)
-        mock_session.delete = AsyncMock()
-        mock_session.commit = AsyncMock()
-
-        service = MCPConfigService(mock_session)
-        await service.save_config(
-            enabled=False,
-            allowed_tool_ids=None,
-            blocked_tool_ids=[],
-            updated_by="admin@test.com",
-        )
-
-        mock_session.delete.assert_awaited_once_with(extra)
-        assert primary.value_json["enabled"] is False
 
     @pytest.mark.asyncio
     async def test_delete_config_removes_existing(self, mock_session):
@@ -921,14 +886,12 @@ class TestMCPConfigService:
         mock_result = MagicMock()
         mock_result.rowcount = 1
         mock_session.execute = AsyncMock(return_value=mock_result)
-        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         deleted = await service.delete_config()
 
         assert deleted is True
         mock_session.execute.assert_awaited_once()
-        mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_delete_config_returns_false_when_none_exists(self, mock_session):
@@ -939,7 +902,6 @@ class TestMCPConfigService:
         mock_result = MagicMock()
         mock_result.rowcount = 0
         mock_session.execute = AsyncMock(return_value=mock_result)
-        mock_session.commit = AsyncMock()
 
         service = MCPConfigService(mock_session)
         deleted = await service.delete_config()


### PR DESCRIPTION
## Summary

Closes two intermittent E2E flakes that have been thrashing CI. Past 48h saw #102 fail 11x and #101 fail 5x across PRs.

**#102 (`test_schedule_promote_run_terminal`):** the scheduler container also runs `promote_due_executions` every 60s starting at boot, and its tick can land inside the test's 3s sleep — grabbing the matured row via `SELECT FOR UPDATE SKIP LOCKED` before the test's direct call. The `promoted >= 1` assertion was checking "this specific call did the work" rather than the actual post-condition. Drop it; the existing poll loop on `ExecutionStatus.SUCCESS` already verifies the row got promoted by either tick and the worker ran it through.

**#101 (`TestMCPConfigToolFiltering` stale GET reads):** the actual upstream polluter is `TestMCPConfigEndpoint::test_put_config_success_for_platform_admin`, which PUTs `enabled=True` and never cleans up. Pytest collects `TestMCPConfigEndpoint` before `TestMCPConfigToolFiltering` (class order in the file), so the leaked row persists into the next class. Two fixes:
- Add an autouse `reset_config` fixture to `TestMCPConfigEndpoint` mirroring the one on `TestMCPConfigToolFiltering` (DELETE before/after, asserting 200 in both directions so teardown failures surface loudly).
- Add a partial unique index `uq_system_config_category_key_null_org` on `system_configs (category, key) WHERE organization_id IS NULL` so platform-wide rows can't duplicate (Postgres treats NULL as distinct in regular unique constraints, so the existing `(category, key, organization_id)` constraint doesn't catch this case).
- Switch `MCPConfigService.delete_config` to a bulk SQL DELETE so any pre-existing duplicates from the past are wiped in one round-trip — defense-in-depth alongside the unique index.

## Test plan

- [x] `tests/e2e/api-integration/test_mcp_endpoints.py` alone: 5/5 clean
- [x] Both files together (`test_workflow_scheduling_flow.py` + `test_mcp_endpoints.py`): 5/5 clean
- [x] `tests/unit/services/test_mcp_tools.py`: 54/54 pass
- [x] `pyright` and `ruff check` clean
- [x] Partial unique index live in test DB after `./test.sh stack reset`

Closes #101, closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)