### PR TITLE
ci: skip CI on more non-code path changes

### DIFF
--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -12,6 +12,11 @@
 #
 # Keep the `name:` of each job below in EXACT sync with the corresponding
 # job's `name:` in ci.yml.
+#
+# The `paths:` list below MUST stay byte-identical to ci.yml's
+# `paths-ignore:` list — any drift breaks branch protection (either CI
+# runs twice on the same change, or neither workflow runs and merge is
+# blocked forever).
 
 name: CI
 
@@ -20,12 +25,27 @@ on:
     branches: [main]
     paths:
       - "**/*.md"
+      - "**/*.txt"
+      - "**/*.png"
+      - "**/*.jpg"
+      - "**/*.jpeg"
+      - "**/*.gif"
+      - "**/*.svg"
+      - "**/*.webp"
+      - "**/*.ico"
       - ".claude/**"
       - "docs/**"
       - "LICENSE"
       - ".github/CODEOWNERS"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/dependabot.yml"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - ".prettierrc*"
+      - ".prettierignore"
+      - ".vscode/**"
+      - ".idea/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,36 @@ on:
     #
     # IMPORTANT: do NOT add .github/workflows/** to this list — workflow
     # changes must always run CI so we catch CI-breaking edits before merge.
+    # Also do NOT add **/*.yml, **/*.yaml, **/*.json, or **/*.toml — these
+    # cover real config (docker-compose, package-lock, tsconfig, pyproject)
+    # that does affect runtime/tests and must run CI.
+    #
+    # The companion ci-noop.yml `paths:` list MUST stay byte-identical to
+    # this `paths-ignore:` list — branch protection relies on the inverse
+    # mapping to always report the required check names.
     paths-ignore:
       - "**/*.md"
+      - "**/*.txt"
+      - "**/*.png"
+      - "**/*.jpg"
+      - "**/*.jpeg"
+      - "**/*.gif"
+      - "**/*.svg"
+      - "**/*.webp"
+      - "**/*.ico"
       - ".claude/**"
       - "docs/**"
       - "LICENSE"
       - ".github/CODEOWNERS"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/dependabot.yml"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - ".prettierrc*"
+      - ".prettierignore"
+      - ".vscode/**"
+      - ".idea/**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Extends the existing \`paths-ignore\` / \`ci-noop.yml\` pattern with conservative additions: image assets, plain text, IDE config files. No per-job conditional skipping (deferred — too risky for a one-shot).

## What's added

To both \`ci.yml\` (paths-ignore) and \`ci-noop.yml\` (paths) — they MUST stay in sync for branch protection:

- \`**/*.txt\`
- \`**/*.png\`, \`**/*.jpg\`, \`**/*.jpeg\`, \`**/*.gif\`, \`**/*.svg\`, \`**/*.webp\`, \`**/*.ico\`
- \`.gitignore\`, \`.gitattributes\`, \`.editorconfig\`
- \`.prettierrc*\`, \`.prettierignore\`
- \`.vscode/**\`, \`.idea/**\`

Comment blocks updated in both files to call out what's deliberately NOT in scope (\`**/*.yml\`, \`**/*.yaml\`, \`**/*.json\`, \`**/*.toml\`, \`.github/workflows/**\` — all could affect runtime).

## Test plan

- [x] YAML parse cleanly (\`python -c "import yaml; yaml.safe_load(...)"\` for both files)
- [x] Two lists are byte-identical
- [ ] Verified by future PRs that touch only image/IDE config skip CI as expected

Closes #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)