### PR TITLE
feat(client): restore agent-scoped MCP URL copy on fleet cards

### DIFF
--- a/client/src/pages/agents/FleetPage.test.tsx
+++ b/client/src/pages/agents/FleetPage.test.tsx
@@ -6,8 +6,8 @@
  * scope so we can control loading / data states deterministically.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, within } from "@/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, renderWithProviders, screen, within } from "@/test-utils";
 
 // -----------------------------------------------------------------------------
 // Mocks
@@ -31,6 +31,14 @@ vi.mock("@/contexts/AuthContext", () => ({
 
 vi.mock("@/components/agents/SummaryBackfillButton", () => ({
 	SummaryBackfillButton: () => null,
+}));
+
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+	toast: {
+		success: (...args: unknown[]) => mockToastSuccess(...args),
+		error: vi.fn(),
+	},
 }));
 
 // -----------------------------------------------------------------------------
@@ -167,6 +175,63 @@ describe("FleetPage — agent cards (grid)", () => {
 		await renderPage();
 		const link = screen.getByRole("link", { name: /alpha/i });
 		expect(link).toHaveAttribute("href", "/agents/alpha-id");
+	});
+});
+
+describe("FleetPage — agent MCP URL copy badge", () => {
+	let writeText: ReturnType<typeof vi.fn>;
+	let originalWriteText: typeof navigator.clipboard.writeText | undefined;
+
+	beforeEach(() => {
+		mockToastSuccess.mockClear();
+		writeText = vi.fn().mockResolvedValue(undefined);
+		// happy-dom's Clipboard is a real EventTarget on the Navigator prototype
+		// and resists `defineProperty(navigator, "clipboard", ...)`. Patch the
+		// method on the existing instance instead.
+		originalWriteText = navigator.clipboard?.writeText.bind(
+			navigator.clipboard,
+		);
+		(
+			navigator.clipboard as unknown as {
+				writeText: typeof writeText;
+			}
+		).writeText = writeText;
+	});
+
+	afterEach(() => {
+		if (originalWriteText) {
+			(
+				navigator.clipboard as unknown as {
+					writeText: typeof originalWriteText;
+				}
+			).writeText = originalWriteText;
+		}
+	});
+
+	it("copies the agent-scoped MCP URL when the badge is clicked", async () => {
+		mockUseAgents.mockReturnValue({
+			data: [makeAgent({ id: "agent-xyz", name: "Alpha" })],
+			isLoading: false,
+		});
+		await renderPage();
+		fireEvent.click(screen.getByTestId("agent-mcp-copy"));
+		expect(writeText).toHaveBeenCalledWith(
+			`${window.location.origin}/mcp/agent-xyz`,
+		);
+		expect(mockToastSuccess).toHaveBeenCalledWith("Agent MCP URL copied");
+	});
+
+	it("badge click prevents the default action so the card link doesn't navigate", async () => {
+		mockUseAgents.mockReturnValue({
+			data: [makeAgent({ id: "agent-xyz", name: "Alpha" })],
+			isLoading: false,
+		});
+		await renderPage();
+		const badge = screen.getByTestId("agent-mcp-copy");
+		const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+		badge.dispatchEvent(event);
+		expect(writeText).toHaveBeenCalledTimes(1);
+		expect(event.defaultPrevented).toBe(true);
 	});
 });
 

--- a/client/src/pages/agents/FleetPage.tsx
+++ b/client/src/pages/agents/FleetPage.tsx
@@ -7,13 +7,14 @@
  * (N+1; acceptable v1, TODO for a denormalized list endpoint).
  */
 
-import { useMemo, useState } from "react";
+import { type MouseEvent, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
 	AlertTriangle,
 	Bot,
 	Building2,
 	Clock,
+	Copy,
 	Globe,
 	Hash,
 	History,
@@ -25,6 +26,7 @@ import {
 	Power,
 	Search,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -452,12 +454,38 @@ function AgentGridCard({
 					</p>
 				)}
 			</div>
-			{showOrg ? (
-				<div className="border-t px-4 py-2.5">
+			<div className="flex items-center justify-between gap-2 border-t px-4 py-2.5">
+				{showOrg ? (
 					<OrgBadge orgId={agent.organization_id} name={orgName} />
-				</div>
-			) : null}
+				) : (
+					<span />
+				)}
+				{agent.id ? <McpUrlBadge agentId={agent.id} /> : null}
+			</div>
 		</Link>
+	);
+}
+
+function McpUrlBadge({ agentId }: { agentId: string }) {
+	const url = `${window.location.origin}/mcp/${agentId}`;
+	const handleCopy = (e: MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		void navigator.clipboard.writeText(url);
+		toast.success("Agent MCP URL copied");
+	};
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			title={url}
+			aria-label="Copy agent MCP URL"
+			data-testid="agent-mcp-copy"
+			className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+		>
+			MCP
+			<Copy className="h-3 w-3" />
+		</button>
 	);
 }
 


### PR DESCRIPTION
## Summary
- Adds an "MCP" copy badge to the footer of each agent card on the fleet dashboard
- Click copies `${origin}/mcp/{agent.id}` to the clipboard and shows a toast; `preventDefault`/`stopPropagation` keep the wrapping card link from navigating
- Footer row now renders unconditionally so the badge is in a consistent spot across all cards (previously the row was hidden unless `showOrg` was true)
- Title row is untouched, preserving title real-estate

Fixes #130

## Test plan
- [x] `npm run tsc` (client)
- [x] `npm run lint` (client) — only the pre-existing FormRenderer warning
- [x] `npx vitest run src/pages/agents/FleetPage.test.tsx` — 14 passing, includes new coverage for copy behavior + `preventDefault`
- [ ] Manual: click the MCP badge on a card, confirm clipboard contents and toast, confirm no navigation to agent detail