### PR TITLE
fix(cli): drop walk-up; require an explicit workspace marker

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -1221,6 +1221,14 @@ Examples:
     if parsed is None:
         return 1
 
+    resolved = pathlib.Path(parsed.local_path).resolve()
+    if not resolved.exists() or not resolved.is_dir():
+        print(f"Error: {parsed.local_path} is not a valid directory", file=sys.stderr)
+        return 1
+    if not _ensure_workspace_marker(resolved):
+        _print_not_a_workspace_error("push")
+        return 1
+
     # Authenticate BEFORE entering asyncio.run() so token refresh works
     # (refresh_tokens() uses asyncio.run() internally, which fails inside a running loop)
     try:
@@ -1276,6 +1284,14 @@ Examples:
 
     parsed = _parse_push_watch_args(args)
     if parsed is None:
+        return 1
+
+    resolved = pathlib.Path(parsed.local_path).resolve()
+    if not resolved.exists() or not resolved.is_dir():
+        print(f"Error: {parsed.local_path} is not a valid directory", file=sys.stderr)
+        return 1
+    if not _ensure_workspace_marker(resolved):
+        _print_not_a_workspace_error("sync")
         return 1
 
     # Authenticate BEFORE entering asyncio.run()
@@ -1421,11 +1437,8 @@ Examples:
         print(f"Error: {parsed.local_path} is not a valid directory", file=sys.stderr)
         return 1
 
-    bifrost_dir = _find_bifrost_dir(resolved)
-    if not bifrost_dir.exists() or not bifrost_dir.is_dir():
-        print("Error: not a Bifrost workspace (no .bifrost/ directory found)", file=sys.stderr)
-        print("  Run 'bifrost watch' from a directory that contains .bifrost/,", file=sys.stderr)
-        print("  or run 'bifrost git commit' and 'bifrost git push' to initialize your workspace first.", file=sys.stderr)
+    if not _ensure_workspace_marker(resolved):
+        _print_not_a_workspace_error("watch")
         return 1
 
     # Authenticate
@@ -1519,6 +1532,14 @@ Examples:
             print(f"Unexpected argument: {arg}", file=sys.stderr)
             return 1
 
+    resolved = pathlib.Path(local_path).resolve()
+    if not resolved.exists() or not resolved.is_dir():
+        print(f"Error: {local_path} is not a valid directory", file=sys.stderr)
+        return 1
+    if not _ensure_workspace_marker(resolved):
+        _print_not_a_workspace_error("pull")
+        return 1
+
     # Authenticate
     try:
         client = BifrostClient.get_instance(require_auth=True)
@@ -1537,57 +1558,107 @@ Examples:
 
 
 def _detect_repo_prefix(path: pathlib.Path) -> str:
-    """Detect the repo prefix from a local path by finding the .bifrost/ directory.
+    """Compute the repo prefix for ``path`` relative to the workspace root.
 
-    Anchors on the .bifrost/ directory — its parent is the workspace root.
-    Everything relative to that root is the repo prefix.
+    With walk-up gone, the workspace root is the current working directory:
+    the dir the user invoked the CLI from. The prefix is whatever sub-path
+    of that root the caller targeted (e.g. ``bifrost push apps/my-app``
+    yields ``apps/my-app``). The launch directory itself yields ``""``.
 
-    Examples:
-        /home/user/workspace/apps/my-app -> "apps/my-app"
-        /home/user/workspace/.bifrost     -> ".bifrost"
-        /home/user/workspace/             -> "" (workspace root, no prefix needed)
+    Paths that don't sit under the cwd (unusual: an absolute path outside
+    the workspace) fall through to ``""`` — the caller is expected to have
+    already validated the path via ``_ensure_workspace_marker``.
     """
-    # Find .bifrost/ directory — its parent is the workspace root
-    bifrost_dir = _find_bifrost_dir(path)
-    if bifrost_dir.exists():
-        workspace_root = bifrost_dir.parent
-        try:
-            relative = path.relative_to(workspace_root)
-            prefix = str(relative)
-            return "" if prefix == "." else prefix
-        except ValueError:
-            pass
+    try:
+        cwd = pathlib.Path.cwd().resolve()
+        relative = path.resolve().relative_to(cwd)
+    except (OSError, ValueError):
+        return ""
+    prefix = str(relative)
+    return "" if prefix == "." else prefix
 
-    # Workspace root — files already have correct relative paths
-    return ""
+
+_WORKSPACE_SENTINEL = ".workspace"
+
+
+def _is_workspace_bifrost_dir(d: pathlib.Path) -> bool:
+    """Distinguish a workspace ``.bifrost/`` from the CLI config ``~/.bifrost/``.
+
+    A workspace ``.bifrost/`` either contains manifest YAMLs (``tables.yaml``,
+    ``workflows.yaml``, etc., produced by sync/export) or the empty
+    ``.workspace`` sentinel file (created on first ``bifrost watch`` /
+    ``push`` / ``pull`` after the user confirms this is their workspace).
+
+    The CLI config directory at ``~/.bifrost/`` only contains
+    ``credentials.json`` and must NOT be treated as a workspace.
+    """
+    if not d.is_dir():
+        return False
+    try:
+        if (d / _WORKSPACE_SENTINEL).exists():
+            return True
+        return any(d.glob("*.yaml"))
+    except OSError:
+        return False
 
 
 def _find_bifrost_dir(local_root: pathlib.Path) -> pathlib.Path:
-    """Find the .bifrost/ manifest directory relative to a push root.
+    """Return the workspace ``.bifrost/`` for ``local_root``.
 
-    Resolution order:
-    1. If local_root IS the .bifrost/ directory, return it
-    2. Check local_root/.bifrost/
-    3. Walk up parent directories (max 10 levels) looking for .bifrost/
-    4. Fallback: return local_root/.bifrost/ (may not exist)
+    The launch directory IS the workspace root — no walk-up. Either:
+    1. ``local_root`` itself IS a workspace ``.bifrost/`` (e.g., user ran
+       ``bifrost watch .bifrost``); return it.
+    2. ``local_root/.bifrost/`` exists and looks like a workspace; return it.
+    3. Otherwise return ``local_root/.bifrost`` as the *expected* path. The
+       caller is responsible for verifying existence (and, in interactive
+       contexts, prompting the user to mark this directory as a workspace).
+
+    Removing the walk-up eliminates a class of "wrong workspace inferred"
+    bugs — most notably the credentials-only ``~/.bifrost/`` collision that
+    silently rooted every relative path at ``$HOME``.
     """
-    if local_root.name == ".bifrost":
+    if local_root.name == ".bifrost" and _is_workspace_bifrost_dir(local_root):
         return local_root
 
     candidate = local_root / ".bifrost"
-    if candidate.exists() and candidate.is_dir():
+    if _is_workspace_bifrost_dir(candidate):
         return candidate
 
-    search = local_root.parent
-    for _ in range(10):
-        candidate = search / ".bifrost"
-        if candidate.exists() and candidate.is_dir():
-            return candidate
-        if search.parent == search:
-            break  # Hit filesystem root
-        search = search.parent
+    return local_root / ".bifrost"  # Expected path; may not exist
 
-    return local_root / ".bifrost"  # Fallback (may not exist)
+
+def _ensure_workspace_marker(local_root: pathlib.Path, *, prompt: bool = True) -> bool:
+    """Confirm ``local_root`` is the user's workspace and create the marker.
+
+    If ``local_root/.bifrost/`` already looks like a workspace, returns True
+    immediately. Otherwise, asks the user (when ``prompt`` is True and stdin
+    is a tty) whether to mark this directory. On confirmation, creates
+    ``.bifrost/.workspace``. Returns True on success, False if the user
+    declined or stdin isn't a tty.
+    """
+    bifrost_dir = local_root / ".bifrost"
+    if _is_workspace_bifrost_dir(bifrost_dir):
+        return True
+
+    if not prompt or not sys.stdin.isatty():
+        return False
+
+    print(f"No .bifrost/ found in {local_root}.", file=sys.stderr)
+    answer = input("Is this your Bifrost workspace? Create a marker so future commands recognize it? [y/N] ").strip().lower()
+    if answer not in {"y", "yes"}:
+        return False
+
+    bifrost_dir.mkdir(parents=True, exist_ok=True)
+    (bifrost_dir / _WORKSPACE_SENTINEL).touch()
+    print(f"Marked {local_root} as a Bifrost workspace.", file=sys.stderr)
+    return True
+
+
+def _print_not_a_workspace_error(command: str) -> None:
+    """Print the standard 'not a workspace' error for a CLI command."""
+    print("Error: not a Bifrost workspace.", file=sys.stderr)
+    print(f"  Run 'bifrost {command}' from a directory that contains .bifrost/,", file=sys.stderr)
+    print("  or confirm the prompt above to mark this directory.", file=sys.stderr)
 
 
 async def _push_with_precheck(

--- a/api/tests/unit/test_cli_find_bifrost_dir.py
+++ b/api/tests/unit/test_cli_find_bifrost_dir.py
@@ -1,0 +1,209 @@
+"""Tests for workspace detection in the Bifrost CLI.
+
+Regression: an earlier walk-up implementation accepted *any* ``.bifrost/``
+ancestor as the workspace root. On a machine with
+``~/.bifrost/credentials.json`` (the CLI auth config dir) and a workspace
+under ``~/some-project/`` that did NOT yet have its own ``.bifrost/``, the
+walk-up reached ``~/.bifrost/`` and returned it, collapsing the workspace
+root to ``$HOME`` and pushing files to the wrong key prefix.
+
+The new design drops walk-up entirely. The launch directory IS the
+workspace root. If ``.bifrost/`` is absent, the CLI prompts the user
+(``_ensure_workspace_marker``) to drop a ``.bifrost/.workspace`` sentinel
+so subsequent commands recognise the dir.
+"""
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+from bifrost.cli import (
+    _ensure_workspace_marker,
+    _find_bifrost_dir,
+    _is_workspace_bifrost_dir,
+)
+
+
+# ─── _find_bifrost_dir ─────────────────────────────────────────────────
+
+
+def test_local_root_with_workspace_bifrost_returns_it(tmp_path: pathlib.Path) -> None:
+    """A workspace .bifrost/ in the launch dir is returned directly."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    bifrost = workspace / ".bifrost"
+    bifrost.mkdir()
+    (bifrost / "tables.yaml").write_text("tables: {}\n")
+
+    assert _find_bifrost_dir(workspace) == bifrost
+
+
+def test_local_root_is_the_workspace_bifrost(tmp_path: pathlib.Path) -> None:
+    """If ``local_root`` IS the ``.bifrost/`` itself, return it as-is."""
+    bifrost = tmp_path / ".bifrost"
+    bifrost.mkdir()
+    (bifrost / "tables.yaml").write_text("tables: {}\n")
+
+    assert _find_bifrost_dir(bifrost) == bifrost
+
+
+def test_credentials_only_dir_is_not_a_workspace(tmp_path: pathlib.Path) -> None:
+    """A ``.bifrost/`` containing only ``credentials.json`` (CLI config dir)
+    must NOT be treated as a workspace. This is the regression case."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    config = fake_home / ".bifrost"
+    config.mkdir()
+    (config / "credentials.json").write_text('{"access_token":"x"}')
+
+    workspace = fake_home / "GitHub" / "my-project"
+    workspace.mkdir(parents=True)
+
+    found = _find_bifrost_dir(workspace)
+
+    # Must NOT be the CLI config dir
+    assert found != config
+    # Falls back to the workspace's own (non-existent) .bifrost/
+    assert found == workspace / ".bifrost"
+
+
+def test_no_walk_up(tmp_path: pathlib.Path) -> None:
+    """The new design has no walk-up: a child directory of a workspace
+    does NOT inherit its parent's ``.bifrost/``. The launch directory is
+    expected to be the workspace root."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    parent_bifrost = workspace / ".bifrost"
+    parent_bifrost.mkdir()
+    (parent_bifrost / "tables.yaml").write_text("tables: {}\n")
+    sub = workspace / "apps" / "my-app"
+    sub.mkdir(parents=True)
+
+    # Walk-up is gone — we get sub/.bifrost, not the parent's .bifrost.
+    assert _find_bifrost_dir(sub) == sub / ".bifrost"
+
+
+def test_no_bifrost_anywhere_returns_fallback(tmp_path: pathlib.Path) -> None:
+    """No ``.bifrost/`` anywhere → fallback to ``local_root/.bifrost``."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    found = _find_bifrost_dir(workspace)
+    assert found == workspace / ".bifrost"
+    assert not found.exists()
+
+
+# ─── _is_workspace_bifrost_dir ─────────────────────────────────────────
+
+
+def test_is_workspace_bifrost_dir_with_yaml(tmp_path: pathlib.Path) -> None:
+    d = tmp_path / ".bifrost"
+    d.mkdir()
+    (d / "agents.yaml").write_text("agents: {}\n")
+    assert _is_workspace_bifrost_dir(d) is True
+
+
+def test_is_workspace_bifrost_dir_with_sentinel(tmp_path: pathlib.Path) -> None:
+    """The empty ``.workspace`` sentinel alone marks a workspace dir."""
+    d = tmp_path / ".bifrost"
+    d.mkdir()
+    (d / ".workspace").touch()
+    assert _is_workspace_bifrost_dir(d) is True
+
+
+def test_is_workspace_bifrost_dir_credentials_only(tmp_path: pathlib.Path) -> None:
+    d = tmp_path / ".bifrost"
+    d.mkdir()
+    (d / "credentials.json").write_text("{}")
+    assert _is_workspace_bifrost_dir(d) is False
+
+
+def test_is_workspace_bifrost_dir_missing(tmp_path: pathlib.Path) -> None:
+    assert _is_workspace_bifrost_dir(tmp_path / "nope") is False
+
+
+def test_is_workspace_bifrost_dir_not_a_dir(tmp_path: pathlib.Path) -> None:
+    f = tmp_path / "thing"
+    f.write_text("not a dir")
+    assert _is_workspace_bifrost_dir(f) is False
+
+
+# ─── _ensure_workspace_marker ──────────────────────────────────────────
+
+
+def test_ensure_workspace_marker_existing_yaml_workspace(tmp_path: pathlib.Path) -> None:
+    """An existing workspace with manifest YAMLs is recognised without prompting."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    bifrost = workspace / ".bifrost"
+    bifrost.mkdir()
+    (bifrost / "tables.yaml").write_text("tables: {}\n")
+
+    with mock.patch("bifrost.cli.input", side_effect=AssertionError("should not prompt")):
+        assert _ensure_workspace_marker(workspace) is True
+
+
+def test_ensure_workspace_marker_existing_sentinel(tmp_path: pathlib.Path) -> None:
+    """A sentinel-only .bifrost/ is also recognised without prompting."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    bifrost = workspace / ".bifrost"
+    bifrost.mkdir()
+    (bifrost / ".workspace").touch()
+
+    with mock.patch("bifrost.cli.input", side_effect=AssertionError("should not prompt")):
+        assert _ensure_workspace_marker(workspace) is True
+
+
+def test_ensure_workspace_marker_creates_sentinel_on_yes(tmp_path: pathlib.Path) -> None:
+    """When the user confirms, ``.bifrost/.workspace`` is created."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    with mock.patch("bifrost.cli.sys.stdin.isatty", return_value=True), mock.patch(
+        "bifrost.cli.input", return_value="y",
+    ):
+        assert _ensure_workspace_marker(workspace) is True
+
+    sentinel = workspace / ".bifrost" / ".workspace"
+    assert sentinel.exists()
+    # The marker alone is enough for subsequent calls.
+    assert _is_workspace_bifrost_dir(workspace / ".bifrost") is True
+
+
+def test_ensure_workspace_marker_returns_false_on_no(tmp_path: pathlib.Path) -> None:
+    """Declining the prompt returns False and creates no files."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    with mock.patch("bifrost.cli.sys.stdin.isatty", return_value=True), mock.patch(
+        "bifrost.cli.input", return_value="n",
+    ):
+        assert _ensure_workspace_marker(workspace) is False
+
+    assert not (workspace / ".bifrost").exists()
+
+
+def test_ensure_workspace_marker_returns_false_on_non_tty(tmp_path: pathlib.Path) -> None:
+    """Non-interactive shells must not block on input(); they just fail."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    with mock.patch("bifrost.cli.sys.stdin.isatty", return_value=False), mock.patch(
+        "bifrost.cli.input", side_effect=AssertionError("must not prompt on non-tty"),
+    ):
+        assert _ensure_workspace_marker(workspace) is False
+
+    assert not (workspace / ".bifrost").exists()
+
+
+def test_ensure_workspace_marker_no_prompt_kwarg(tmp_path: pathlib.Path) -> None:
+    """``prompt=False`` is a programmatic guard for non-interactive callers."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+
+    with mock.patch(
+        "bifrost.cli.input", side_effect=AssertionError("prompt=False must skip input()"),
+    ):
+        assert _ensure_workspace_marker(workspace, prompt=False) is False
+    assert not (workspace / ".bifrost").exists()


### PR DESCRIPTION
## Summary

`_find_bifrost_dir` walked up from the launch directory looking for any `.bifrost/` to anchor the workspace root. It accepted `~/.bifrost/` — the CLI auth config dir created by `bifrost login`, which only contains `credentials.json` — collapsing the workspace root to `$HOME` and pushing files to wrong S3 keys.

The first revision of this PR added a content-check (require `*.yaml` to count as a workspace). After review, walk-up itself was deemed the wrong design: it makes the workspace root a function of the filesystem rather than the user's intent, and creates "wrong workspace inferred" surprises whenever a plausible `.bifrost/` exists somewhere up the tree.

This PR drops walk-up entirely. **The launch directory IS the workspace root, full stop.**

## Changes

- `_find_bifrost_dir(local_root)` returns `local_root/.bifrost` (or `local_root` itself if it already IS the `.bifrost/`). No parent traversal.
- `_is_workspace_bifrost_dir` recognises both manifest YAMLs and a new `.bifrost/.workspace` sentinel file.
- `_ensure_workspace_marker` prompts on first use ("Is this your Bifrost workspace?") and drops the sentinel on confirmation. Returns False on decline or non-tty stdin.
- `handle_watch`, `handle_push`, `handle_pull`, and `handle_sync` all call `_ensure_workspace_marker` before proceeding and emit a consistent "not a Bifrost workspace" error on refusal.
- `_detect_repo_prefix` simplified — computes prefix relative to `pathlib.Path.cwd()` (the workspace root, by definition). The old `bifrost_dir.parent` traversal is gone.

## How the bug manifested

Run `bifrost login` (creates `~/.bifrost/credentials.json`). `mkdir ~/somewhere/new-project && cd ~/somewhere/new-project && bifrost watch`. Edit a file. Watch pushes it to `somewhere/new-project/<file>` instead of `<file>`. The workflow runtime, having registered the file at the canonical path, never sees the update — module cache stays stale, behavior changes don't propagate. Silent: watch reports a successful push, the file is on the platform (just under a wrong key).

## Test plan

- [x] `tests/unit/test_cli_find_bifrost_dir.py` covers: regression case (credentials-only `.bifrost/` upstream of workspace), no-walk-up guarantee, sentinel-only recognition, prompt yes/no/non-tty/`prompt=False` paths.
- [x] Existing watch and sync unit tests still pass: `test_cli_watch.py`, `test_watch_echo_suppression.py`, `test_watch_hash_cache.py`, `test_watch_two_observers.py`, `test_sync_ops.py`, `test_sync_lock.py`. **84/84 passed locally.**
- [x] `ruff check` and `pyright` clean on the changed file.

Generated with [Claude Code](https://claude.com/claude-code)
