### PR TITLE
fix(manifest-import): refresh dependent caches after integration UUID rewrite

### DIFF
--- a/api/src/services/manifest_import.py
+++ b/api/src/services/manifest_import.py
@@ -705,6 +705,18 @@ class ManifestResolver:
 
         Returns a cache dict that _resolve_* methods use for O(1) lookups
         instead of per-entity SELECT queries.
+
+        Cache invariant
+        ---------------
+        All caches are keyed on parent UUIDs **as of prefetch time**. When a
+        resolver rewrites an entity's primary key in the same transaction
+        (cross-env id sync via the existing-by-name path), Postgres FK ON
+        UPDATE CASCADE migrates dependents to the new id, but the cache is
+        still keyed on the old id. The resolver responsible for the rewrite
+        MUST refresh / rekey any dependent caches before subsequent reads —
+        otherwise downstream lookups miss and fall through to INSERT, which
+        collides with the cascade-migrated rows. See `_resolve_integration`
+        for the canonical pattern and issue #148 for the original incident.
         """
         from src.models.orm.applications import Application
         from src.models.orm.config import Config
@@ -1777,6 +1789,7 @@ class ManifestResolver:
         }
 
         # Upsert integration row FIRST (must exist before config schema / mapping FKs)
+        id_was_rewritten = existing_by_name is not None and existing_by_name != integ_id
         if existing_by_name is not None:
             upsert_op = Upsert(
                 model=Integration,
@@ -1792,6 +1805,45 @@ class ManifestResolver:
                 match_on="id",
             )
         await upsert_op.execute(self.db)
+
+        # If the upsert rewrote the integration's PK (cross-env id sync), the
+        # FK ON UPDATE CASCADE on integration_config_schema, integration_mappings,
+        # and configs migrated those rows from existing_by_name → integ_id in the
+        # same statement. The prefetch cache is still keyed on the OLD id, so
+        # refresh dependent caches before we read them — otherwise the
+        # upsert-by-natural-key path below misses the (now-migrated) rows and
+        # tries to INSERT, hitting unique-index violations.
+        if id_was_rewritten and cache is not None:
+            cs_refresh = await self.db.execute(
+                select(IntegrationConfigSchema).where(
+                    IntegrationConfigSchema.integration_id == integ_id
+                )
+            )
+            cache["integ_cs"][integ_id] = {
+                cs.key: cs for cs in cs_refresh.scalars().all()
+            }
+            cache["integ_cs"].pop(existing_by_name, None)
+
+            m_refresh = await self.db.execute(
+                select(IntegrationMapping).where(
+                    IntegrationMapping.integration_id == integ_id
+                )
+            )
+            cache["integ_mappings"][integ_id] = {
+                str(m.organization_id) if m.organization_id else None: m
+                for m in m_refresh.scalars().all()
+            }
+            cache["integ_mappings"].pop(existing_by_name, None)
+
+            # _resolve_config runs later and reads cache["config_by_natural"]
+            # keyed on (key, integ_id, org_id). After CASCADE the underlying
+            # rows live under integ_id; rewrite cache keys to match so the
+            # update path is taken instead of an insert that would collide.
+            cfg_natural = cache.get("config_by_natural")
+            if cfg_natural:
+                stale_keys = [k for k in cfg_natural if k[1] == existing_by_name]
+                for old_key in stale_keys:
+                    cfg_natural[(old_key[0], integ_id, old_key[2])] = cfg_natural.pop(old_key)
 
         # Sync config schema items: upsert by (integration_id, key) to preserve IDs
         # (Config rows reference schema IDs via FK — deleting schema cascades to configs)

--- a/api/tests/e2e/platform/test_git_sync_local.py
+++ b/api/tests/e2e/platform/test_git_sync_local.py
@@ -2836,6 +2836,217 @@ class TestPullUpsertNaturalKeys:
         assert len(rows) == 1, f"Expected 1 integration, got {len(rows)}"
         assert rows[0].id == id_b, f"Expected manifest ID {id_b}, got {rows[0].id}"
 
+    async def test_integration_import_with_different_id_and_config_schema(
+        self,
+        db_session: AsyncSession,
+        sync_service,
+        bare_repo,
+        working_clone,
+    ):
+        """Regression for #148: integration UUID rewrite + existing config_schema rows
+        must not collide with the FK ON UPDATE CASCADE-migrated rows.
+
+        Pre-fix: prefetch cache is keyed on the OLD integration_id. After the
+        upsert rewrites the integration's id, the cascade migrates the schema
+        rows to the new id, but the cache lookup at the new id returns {},
+        the loop falls through to INSERT, and hits a unique violation on
+        (integration_id, key).
+        """
+        from src.models.orm.integrations import Integration, IntegrationConfigSchema
+
+        # Existing integration with config_schema rows under id_a
+        id_a = uuid4()
+        integ = Integration(id=id_a, name="CascadeSchemaInteg", is_deleted=False)
+        db_session.add(integ)
+        await db_session.flush()
+        db_session.add_all([
+            IntegrationConfigSchema(
+                integration_id=id_a, key="api_key", type="secret",
+                required=True, position=0,
+            ),
+            IntegrationConfigSchema(
+                integration_id=id_a, key="region", type="string",
+                required=False, position=1,
+            ),
+        ])
+        await db_session.commit()
+
+        # Manifest references the same integration name with a different UUID,
+        # plus the same two schema keys.
+        id_b = uuid4()
+        clone_dir = Path(working_clone.working_dir)
+        bifrost_dir = clone_dir / ".bifrost"
+        bifrost_dir.mkdir(exist_ok=True)
+        (bifrost_dir / "integrations.yaml").write_text(yaml.dump({
+            "integrations": {
+                "CascadeSchemaInteg": {
+                    "id": str(id_b),
+                    "config_schema": [
+                        {"key": "api_key", "type": "secret", "required": True, "position": 0},
+                        {"key": "region", "type": "string", "required": False, "position": 1},
+                    ],
+                },
+            },
+        }, default_flow_style=False))
+
+        working_clone.index.add([".bifrost/integrations.yaml"])
+        working_clone.index.commit("integration with cross-env id + config schema")
+        working_clone.remotes.origin.push("main")
+
+        sync_result = await sync_service.desktop_sync(confirm_deletes=True)
+        assert sync_result.success, f"Sync failed: {sync_result.error}"
+
+        # Integration now has id_b and exactly the two schema rows under id_b.
+        integ_rows = (await db_session.execute(
+            select(Integration).where(Integration.name == "CascadeSchemaInteg")
+        )).scalars().all()
+        assert len(integ_rows) == 1
+        assert integ_rows[0].id == id_b
+
+        cs_rows = (await db_session.execute(
+            select(IntegrationConfigSchema).where(
+                IntegrationConfigSchema.integration_id == id_b
+            ).order_by(IntegrationConfigSchema.position)
+        )).scalars().all()
+        assert [c.key for c in cs_rows] == ["api_key", "region"]
+        # No orphan rows under id_a
+        orphans = (await db_session.execute(
+            select(IntegrationConfigSchema).where(
+                IntegrationConfigSchema.integration_id == id_a
+            )
+        )).scalars().all()
+        assert orphans == []
+
+    async def test_integration_import_with_different_id_and_mapping(
+        self,
+        db_session: AsyncSession,
+        sync_service,
+        bare_repo,
+        working_clone,
+    ):
+        """Same #148 cache-staleness pattern, applied to integration_mappings:
+        the unique index is (integration_id, organization_id), and the cache
+        key is the OLD integration_id."""
+        from src.models.orm.integrations import Integration, IntegrationMapping
+        from src.models.orm.organizations import Organization
+
+        org_id = uuid4()
+        db_session.add(Organization(id=org_id, name="MappingCascadeOrg", created_by="test"))
+
+        id_a = uuid4()
+        db_session.add(Integration(id=id_a, name="CascadeMappingInteg", is_deleted=False))
+        await db_session.flush()
+        db_session.add(IntegrationMapping(
+            integration_id=id_a, organization_id=org_id, entity_id="tenant-a",
+        ))
+        await db_session.commit()
+
+        id_b = uuid4()
+        clone_dir = Path(working_clone.working_dir)
+        bifrost_dir = clone_dir / ".bifrost"
+        bifrost_dir.mkdir(exist_ok=True)
+        (bifrost_dir / "integrations.yaml").write_text(yaml.dump({
+            "integrations": {
+                "CascadeMappingInteg": {
+                    "id": str(id_b),
+                    "mappings": [
+                        {"organization_id": str(org_id), "entity_id": "tenant-a"},
+                    ],
+                },
+            },
+        }, default_flow_style=False))
+
+        working_clone.index.add([".bifrost/integrations.yaml"])
+        working_clone.index.commit("integration with cross-env id + mapping")
+        working_clone.remotes.origin.push("main")
+
+        sync_result = await sync_service.desktop_sync(confirm_deletes=True)
+        assert sync_result.success, f"Sync failed: {sync_result.error}"
+
+        m_rows = (await db_session.execute(
+            select(IntegrationMapping).where(
+                IntegrationMapping.integration_id == id_b
+            )
+        )).scalars().all()
+        assert len(m_rows) == 1
+        assert m_rows[0].entity_id == "tenant-a"
+        assert m_rows[0].organization_id == org_id
+
+    async def test_integration_import_with_different_id_and_config(
+        self,
+        db_session: AsyncSession,
+        sync_service,
+        bare_repo,
+        working_clone,
+    ):
+        """Same #148 cache-staleness pattern, applied to configs that
+        reference the integration. The Config unique index is
+        (integration_id, organization_id, key); after CASCADE the existing
+        config row sits at the new integ_id, so a fresh INSERT collides."""
+        from src.models.orm.config import Config
+        from src.models.orm.integrations import Integration
+
+        id_a = uuid4()
+        db_session.add(Integration(id=id_a, name="CascadeConfigInteg", is_deleted=False))
+        await db_session.flush()
+        cfg_id = uuid4()
+        db_session.add(Config(
+            id=cfg_id, key="api_url", value={"value": "https://old.example.com"},
+            integration_id=id_a, organization_id=None,
+            updated_by="test",
+        ))
+        await db_session.commit()
+
+        id_b = uuid4()
+        clone_dir = Path(working_clone.working_dir)
+        bifrost_dir = clone_dir / ".bifrost"
+        bifrost_dir.mkdir(exist_ok=True)
+        (bifrost_dir / "integrations.yaml").write_text(yaml.dump({
+            "integrations": {
+                "CascadeConfigInteg": {
+                    "id": str(id_b),
+                },
+            },
+        }, default_flow_style=False))
+        # Manifest carries the same config under the NEW integ_id (cross-env
+        # parent rewrite is the trigger for the cache-staleness bug here).
+        new_cfg_id = uuid4()
+        (bifrost_dir / "configs.yaml").write_text(yaml.dump({
+            "configs": {
+                "api_url": {
+                    "id": str(new_cfg_id),
+                    "key": "api_url",
+                    "config_type": "string",
+                    "value": {"value": "https://new.example.com"},
+                    "integration_id": str(id_b),
+                },
+            },
+        }, default_flow_style=False))
+
+        working_clone.index.add([
+            ".bifrost/integrations.yaml",
+            ".bifrost/configs.yaml",
+        ])
+        working_clone.index.commit("integration with cross-env id + config")
+        working_clone.remotes.origin.push("main")
+
+        sync_result = await sync_service.desktop_sync(confirm_deletes=True)
+        assert sync_result.success, f"Sync failed: {sync_result.error}"
+
+        cfg_rows = (await db_session.execute(
+            select(Config).where(
+                Config.key == "api_url",
+                Config.integration_id == id_b,
+            )
+        )).scalars().all()
+        assert len(cfg_rows) == 1, f"Expected 1 config row under integ id_b, got {len(cfg_rows)}"
+        assert cfg_rows[0].value == {"value": "https://new.example.com"}
+        # And nothing left under the old integ id (CASCADE moved them all)
+        orphans = (await db_session.execute(
+            select(Config).where(Config.integration_id == id_a)
+        )).scalars().all()
+        assert orphans == []
+
     async def test_app_import_with_different_id(
         self,
         db_session: AsyncSession,


### PR DESCRIPTION
## Summary

Fixes #148.

When manifest sync rewrites an integration's UUID via the existing-by-name path, FK `ON UPDATE CASCADE` on `integration_config_schema`, `integration_mappings`, and `configs` migrates dependent rows old→new in the same statement. The prefetch cache (`integ_cs`, `integ_mappings`, `config_by_natural`) is still keyed on the old UUID, so subsequent cache lookups miss, fall through to INSERT, and hit unique-index violations.

The original report only describes the `integration_config_schema` collision. While validating, I found the same shape applies to **two other caches** in the same code path:
- `integ_mappings` — unique idx `(integration_id, organization_id)`
- `config_by_natural` — unique idx `(integration_id, organization_id, key)` — this one is hit by `_resolve_config` running later in the same import.

This PR fixes all three in a single targeted change.

## Approach

Per the issue's suggested option (a), refresh the dependent caches from the DB after the upsert detects an id rewrite. Two SELECTs and one in-place rekey of `config_by_natural`. Cost is ~zero outside the cross-env-rewrite case (gated on `existing_by_name != integ_id`).

Why option (a) over (b) (mirroring CASCADE in app code): (b) duplicates DB-level FK behavior in Python and is exactly the kind of fragile drift CLAUDE.md calls out for the manifest layer.

Also adds a docstring on `_prefetch_existing_entities` documenting the cache invariant (parent UUIDs are keyed as-of-prefetch-time; resolvers that rewrite an id must refresh dependents) so future resolvers with the same shape have an explicit reference.

## Tests

Three new regression tests in `TestPullUpsertNaturalKeys` covering each cache shape:
- `test_integration_import_with_different_id_and_config_schema` (the originally reported case)
- `test_integration_import_with_different_id_and_mapping`
- `test_integration_import_with_different_id_and_config`

All three RED on `main` (each fails with the specific unique-violation in the report), GREEN with the fix.

The existing `test_integration_import_with_different_id` still passes — it was the no-dependents case that didn't exercise the bug.

## Test plan

- [x] 3 new regression tests fail on `main`, pass with the fix
- [x] Full `tests/e2e/platform/test_git_sync_local.py` suite (78 tests) passes
- [x] Full `tests/e2e/platform/test_manifest_import.py` suite (7 tests) passes
- [x] `./test.sh all` passes (3186 passed, 1152 skipped, 0 failures)
- [x] `./test.sh unit` passes (3189 passed)
- [x] `pyright` 0 errors, `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)