### PR TITLE
fix(watch): close echo race, block multi-session in workspace, fix validator dep classifier

### DIFF
--- a/api/bifrost/_workspace_lock.py
+++ b/api/bifrost/_workspace_lock.py
@@ -21,7 +21,6 @@ informational metadata only — the lock itself is the FD, not the file.
 """
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 import os
@@ -48,14 +47,6 @@ _HELD_LOCK = threading.Lock()
 
 def _lock_path(workspace: pathlib.Path) -> pathlib.Path:
     return workspace / ".bifrost" / _LOCK_NAME
-
-
-def _release_held(key: str) -> None:
-    """Drop the in-process reservation for `key`. Idempotent — running
-    twice is harmless. Used as an ExitStack callback so the reservation
-    rolls back automatically on failure during acquire."""
-    with _HELD_LOCK:
-        _HELD.discard(key)
 
 
 def _platform_lock(fh: IO[Any]) -> None:
@@ -123,83 +114,74 @@ class WorkspaceLock:
         self.command = command
         self.path = _lock_path(self.workspace)
         self._fh: IO[Any] | None = None
-        self._stack: contextlib.ExitStack | None = None
 
     def __enter__(self) -> "WorkspaceLock":
-        # Use an ExitStack so any failure between resource acquisition and
-        # the successful return unwinds in reverse order: close the FD,
-        # roll back the _HELD reservation. On success we hand the stack's
-        # cleanup callbacks to `self._stack` so __exit__ runs them later.
-        # This makes the cleanup invariant local and statically obvious
-        # (CodeQL recognizes the with-open-as pattern as guaranteed-close).
-        stack = contextlib.ExitStack()
-        try:
-            # In-process check first. POSIX flock is advisory and lets
-            # the same process flock one path twice — without this guard,
-            # two sessions in the same Python process would both succeed
-            # and ping-pong each other.
-            key = str(self.path)
-            with _HELD_LOCK:
-                if key in _HELD:
-                    raise WorkspaceLockError(self.workspace, _read_metadata(self.path))
-                # Reserve before opening the file so two threads racing
-                # through __enter__ can't both observe the empty set.
-                _HELD.add(key)
-            stack.callback(_release_held, key)
+        # In-process check first. POSIX flock is advisory and lets the
+        # same process flock one path twice — without this guard, two
+        # sessions in the same Python process would both succeed and
+        # ping-pong each other.
+        key = str(self.path)
+        with _HELD_LOCK:
+            if key in _HELD:
+                raise WorkspaceLockError(self.workspace, _read_metadata(self.path))
+            # Reserve before opening the file so two threads racing
+            # through __enter__ can't both observe the empty set.
+            _HELD.add(key)
 
+        # Assign the open FD directly to self._fh so the close path is
+        # local to this class — `self._fh.close()` runs in `_release()`,
+        # which both `__exit__` and the failure-path catch-all invoke.
+        # Any failure during enter calls `_release()` to close the FD
+        # and roll back the in-process reservation in one place.
+        try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             # Open in append mode so we don't truncate before we've
             # acquired the lock — if someone else holds it, we'd
-            # otherwise wipe their metadata. We seek+truncate AFTER
-            # acquiring. `enter_context` hands the FD's lifetime to the
-            # stack: stack unwind closes it (failure path), or self._stack
-            # runs the close on __exit__ (success path).
-            fh = stack.enter_context(open(self.path, "a+", encoding="utf-8"))
+            # otherwise wipe their metadata. seek+truncate runs AFTER
+            # acquiring.
+            self._fh = open(self.path, "a+", encoding="utf-8")
             try:
-                _platform_lock(fh)
+                _platform_lock(self._fh)
             except BlockingIOError:
-                holder = _read_metadata(self.path)
-                raise WorkspaceLockError(self.workspace, holder)
+                raise WorkspaceLockError(self.workspace, _read_metadata(self.path))
 
-            # We hold the lock. Now stamp our metadata. Failure here
-            # doesn't break correctness — the lock is on the FD, not the
-            # metadata. Log and continue.
+            # We hold the lock. Stamp metadata. Failure here doesn't
+            # break correctness — the lock is on the FD, not the file —
+            # so log and continue.
             try:
-                fh.seek(0)
-                fh.truncate()
+                self._fh.seek(0)
+                self._fh.truncate()
                 json.dump({
                     "pid": os.getpid(),
                     "command": self.command,
                     "started_at": datetime.now(timezone.utc).isoformat(),
-                }, fh)
-                fh.flush()
+                }, self._fh)
+                self._fh.flush()
             except OSError as e:
                 logger.debug(f"could not write lock metadata: {e}")
 
-            # Success: transfer the cleanup chain to self for __exit__.
-            self._fh = fh
-            self._stack = stack.pop_all()
             return self
         except BaseException:
-            # Any failure unwinds the stack: closes fh if opened, releases
-            # the _HELD reservation if added.
-            stack.close()
+            self._release()
             raise
 
     def __exit__(self, *exc: Any) -> None:
-        # Unwind the stack from __enter__: closes the FD (releasing the
-        # kernel-level lock) and discards the _HELD reservation, in that
-        # order. The lock file is intentionally NOT deleted — leaving it
-        # lets the next holder write fresh metadata, and a stale file
-        # with no FD holder doesn't block anyone (the next acquire just
-        # claims it).
-        if self._stack is not None:
+        self._release()
+
+    def _release(self) -> None:
+        # Closing the FD releases the kernel-level lock. The lock file
+        # is intentionally NOT deleted — a stale file with no FD holder
+        # doesn't block anyone (next acquire claims it and overwrites
+        # the metadata). Idempotent: __exit__ on a never-entered lock,
+        # or after a failed __enter__, is a no-op.
+        if self._fh is not None:
             try:
-                self._stack.close()
+                self._fh.close()
             except OSError as e:
-                logger.debug(f"error releasing workspace lock: {e}")
-            self._stack = None
-        self._fh = None
+                logger.debug(f"error closing lock file: {e}")
+            self._fh = None
+        with _HELD_LOCK:
+            _HELD.discard(str(self.path))
 
 
 

--- a/api/bifrost/_workspace_lock.py
+++ b/api/bifrost/_workspace_lock.py
@@ -127,6 +127,15 @@ class WorkspaceLock:
             # Reserve before opening the file so two threads racing through
             # __enter__ can't both observe the empty set.
             _HELD.add(key)
+
+        # `fh` is opened inside the try/except so any failure between
+        # open() and the successful self._fh assignment closes it. The
+        # outer except handles every remaining error path: BlockingIOError
+        # from cross-process contention, OSError from open/seek/truncate,
+        # KeyboardInterrupt mid-json.dump, anything. If we don't reach the
+        # successful return, the FD is closed and the in-process
+        # reservation is rolled back.
+        fh: IO[Any] | None = None
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             # Open in append mode so we don't truncate before we've
@@ -136,11 +145,12 @@ class WorkspaceLock:
             try:
                 _platform_lock(fh)
             except BlockingIOError:
-                fh.close()
                 holder = _read_metadata(self.path)
                 raise WorkspaceLockError(self.workspace, holder)
 
-            # We hold the lock. Now stamp our metadata.
+            # We hold the lock. Now stamp our metadata. Failure here
+            # doesn't break correctness — the lock is on the FD, not the
+            # metadata. Log and continue.
             try:
                 fh.seek(0)
                 fh.truncate()
@@ -151,16 +161,16 @@ class WorkspaceLock:
                 }, fh)
                 fh.flush()
             except OSError as e:
-                # Failure here doesn't break correctness — the lock is on
-                # the FD, not the metadata. Log and continue.
                 logger.debug(f"could not write lock metadata: {e}")
 
             self._fh = fh
             return self
         except BaseException:
-            # Reservation must roll back if anything fails between the
-            # _HELD.add and the successful return. Includes BlockingIOError
-            # from cross-process contention and any OSError on file open.
+            if fh is not None and self._fh is None:
+                try:
+                    fh.close()
+                except OSError as e:
+                    logger.debug(f"error closing lock file during rollback: {e}")
             with _HELD_LOCK:
                 _HELD.discard(key)
             raise

--- a/api/bifrost/_workspace_lock.py
+++ b/api/bifrost/_workspace_lock.py
@@ -1,0 +1,184 @@
+"""Per-workspace exclusion lock for `bifrost watch` / `bifrost sync`.
+
+Two `bifrost watch` instances pointed at the same workspace, or a `bifrost
+sync` running concurrently with a `bifrost watch`, both produce broken
+behavior — distinct session_ids that the server can't dedupe, so they ping-
+pong each other's writes back as "incoming" events. This module enforces
+single-session-per-workspace using an OS-level file lock.
+
+Why an OS lock and not a PID file:
+
+A PID file requires us to detect stale entries (process died without
+cleaning up) by checking whether the PID is still alive — racy and gets
+fooled by PID reuse. `fcntl.flock` (POSIX) and `msvcrt.locking` (Windows)
+are kernel-tracked: when the file descriptor is released — *whatever* the
+reason: clean exit, Ctrl-C, SIGKILL, OOM, panic, reboot — the kernel
+releases the lock automatically. There is no reaper, no TTL, no stale
+state to clean up.
+
+The lock file *also* records PID + command + start time, but as
+informational metadata only — the lock itself is the FD, not the file.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import IO, Any
+
+logger = logging.getLogger(__name__)
+
+
+_LOCK_NAME = ".session.lock"
+
+# In-process registry of currently-held workspace locks. POSIX flock is
+# advisory and per-open-file-description: multiple FDs in the same process
+# can hold an "exclusive" flock at the same time. That breaks the guarantee
+# we want (one session per workspace, period), so we add a process-local
+# guard that raises before flock is even attempted. Across processes, flock
+# still does the work.
+_HELD: set[str] = set()
+_HELD_LOCK = threading.Lock()
+
+
+def _lock_path(workspace: pathlib.Path) -> pathlib.Path:
+    return workspace / ".bifrost" / _LOCK_NAME
+
+
+def _platform_lock(fh: IO[Any]) -> None:
+    """Acquire an exclusive non-blocking lock on `fh`. Raises BlockingIOError
+    if another process holds it."""
+    if sys.platform == "win32":
+        import msvcrt
+        # LK_NBLCK = exclusive non-blocking. The "1 byte at offset 0" idiom
+        # is the standard pattern for advisory locking on Windows.
+        try:
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+        except OSError as e:
+            # Windows raises OSError(EACCES/EDEADLK) on contention. Translate
+            # to BlockingIOError so callers have one exception type.
+            raise BlockingIOError(str(e)) from e
+    else:
+        import fcntl
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def _read_metadata(path: pathlib.Path) -> dict[str, Any]:
+    """Read informational metadata from the lock file. Returns {} on any
+    error — metadata is for the error message only, never for correctness."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+class WorkspaceLockError(RuntimeError):
+    """A different bifrost session already holds the workspace lock."""
+
+    def __init__(self, workspace: pathlib.Path, holder: dict[str, Any]) -> None:
+        self.workspace = workspace
+        self.holder = holder
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        pid = self.holder.get("pid", "?")
+        command = self.holder.get("command", "?")
+        started = self.holder.get("started_at", "")
+        when = ""
+        if started:
+            try:
+                # Best-effort: parse the ISO timestamp and emit a friendlier
+                # "started 14:32:01" suffix. Fall back to raw string.
+                ts = datetime.fromisoformat(started)
+                when = f"  (started {ts.astimezone().strftime('%Y-%m-%d %H:%M:%S')})"
+            except ValueError:
+                when = f"  (started {started})"
+        return (
+            f"another bifrost session is active in this workspace.\n"
+            f"  PID {pid}  bifrost {command}{when}\n"
+            f"Stop it first or wait for it to finish."
+        )
+
+
+class WorkspaceLock:
+    """Acquire on `__enter__`, release on `__exit__` (or on process exit —
+    the kernel cleans up the FD if we crash)."""
+
+    def __init__(self, workspace: pathlib.Path, command: str) -> None:
+        self.workspace = workspace.resolve()
+        self.command = command
+        self.path = _lock_path(self.workspace)
+        self._fh: IO[Any] | None = None
+
+    def __enter__(self) -> "WorkspaceLock":
+        # In-process check first. POSIX flock is advisory and lets the same
+        # process flock one path twice — without this guard, two sessions
+        # in the same Python process would both succeed and ping-pong each
+        # other.
+        key = str(self.path)
+        with _HELD_LOCK:
+            if key in _HELD:
+                raise WorkspaceLockError(self.workspace, _read_metadata(self.path))
+            # Reserve before opening the file so two threads racing through
+            # __enter__ can't both observe the empty set.
+            _HELD.add(key)
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            # Open in append mode so we don't truncate before we've
+            # acquired the lock — if someone else holds it, we'd otherwise
+            # wipe their metadata. We seek+truncate AFTER acquiring.
+            fh = open(self.path, "a+", encoding="utf-8")
+            try:
+                _platform_lock(fh)
+            except BlockingIOError:
+                fh.close()
+                holder = _read_metadata(self.path)
+                raise WorkspaceLockError(self.workspace, holder)
+
+            # We hold the lock. Now stamp our metadata.
+            try:
+                fh.seek(0)
+                fh.truncate()
+                json.dump({
+                    "pid": os.getpid(),
+                    "command": self.command,
+                    "started_at": datetime.now(timezone.utc).isoformat(),
+                }, fh)
+                fh.flush()
+            except OSError as e:
+                # Failure here doesn't break correctness — the lock is on
+                # the FD, not the metadata. Log and continue.
+                logger.debug(f"could not write lock metadata: {e}")
+
+            self._fh = fh
+            return self
+        except BaseException:
+            # Reservation must roll back if anything fails between the
+            # _HELD.add and the successful return. Includes BlockingIOError
+            # from cross-process contention and any OSError on file open.
+            with _HELD_LOCK:
+                _HELD.discard(key)
+            raise
+
+    def __exit__(self, *exc: Any) -> None:
+        # Closing the FD releases the kernel-level lock. We deliberately do
+        # NOT delete the file — leaving it lets the next holder write fresh
+        # metadata, and a stale file with no FD holder doesn't block anyone
+        # (the next acquire just claims it).
+        if self._fh is not None:
+            try:
+                self._fh.close()
+            except OSError as e:
+                logger.debug(f"error closing lock file: {e}")
+            self._fh = None
+        with _HELD_LOCK:
+            _HELD.discard(str(self.path))
+
+
+
+

--- a/api/bifrost/_workspace_lock.py
+++ b/api/bifrost/_workspace_lock.py
@@ -21,6 +21,7 @@ informational metadata only — the lock itself is the FD, not the file.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -47,6 +48,14 @@ _HELD_LOCK = threading.Lock()
 
 def _lock_path(workspace: pathlib.Path) -> pathlib.Path:
     return workspace / ".bifrost" / _LOCK_NAME
+
+
+def _release_held(key: str) -> None:
+    """Drop the in-process reservation for `key`. Idempotent — running
+    twice is harmless. Used as an ExitStack callback so the reservation
+    rolls back automatically on failure during acquire."""
+    with _HELD_LOCK:
+        _HELD.discard(key)
 
 
 def _platform_lock(fh: IO[Any]) -> None:
@@ -114,34 +123,38 @@ class WorkspaceLock:
         self.command = command
         self.path = _lock_path(self.workspace)
         self._fh: IO[Any] | None = None
+        self._stack: contextlib.ExitStack | None = None
 
     def __enter__(self) -> "WorkspaceLock":
-        # In-process check first. POSIX flock is advisory and lets the same
-        # process flock one path twice — without this guard, two sessions
-        # in the same Python process would both succeed and ping-pong each
-        # other.
-        key = str(self.path)
-        with _HELD_LOCK:
-            if key in _HELD:
-                raise WorkspaceLockError(self.workspace, _read_metadata(self.path))
-            # Reserve before opening the file so two threads racing through
-            # __enter__ can't both observe the empty set.
-            _HELD.add(key)
-
-        # `fh` is opened inside the try/except so any failure between
-        # open() and the successful self._fh assignment closes it. The
-        # outer except handles every remaining error path: BlockingIOError
-        # from cross-process contention, OSError from open/seek/truncate,
-        # KeyboardInterrupt mid-json.dump, anything. If we don't reach the
-        # successful return, the FD is closed and the in-process
-        # reservation is rolled back.
-        fh: IO[Any] | None = None
+        # Use an ExitStack so any failure between resource acquisition and
+        # the successful return unwinds in reverse order: close the FD,
+        # roll back the _HELD reservation. On success we hand the stack's
+        # cleanup callbacks to `self._stack` so __exit__ runs them later.
+        # This makes the cleanup invariant local and statically obvious
+        # (CodeQL recognizes the with-open-as pattern as guaranteed-close).
+        stack = contextlib.ExitStack()
         try:
+            # In-process check first. POSIX flock is advisory and lets
+            # the same process flock one path twice — without this guard,
+            # two sessions in the same Python process would both succeed
+            # and ping-pong each other.
+            key = str(self.path)
+            with _HELD_LOCK:
+                if key in _HELD:
+                    raise WorkspaceLockError(self.workspace, _read_metadata(self.path))
+                # Reserve before opening the file so two threads racing
+                # through __enter__ can't both observe the empty set.
+                _HELD.add(key)
+            stack.callback(_release_held, key)
+
             self.path.parent.mkdir(parents=True, exist_ok=True)
             # Open in append mode so we don't truncate before we've
-            # acquired the lock — if someone else holds it, we'd otherwise
-            # wipe their metadata. We seek+truncate AFTER acquiring.
-            fh = open(self.path, "a+", encoding="utf-8")
+            # acquired the lock — if someone else holds it, we'd
+            # otherwise wipe their metadata. We seek+truncate AFTER
+            # acquiring. `enter_context` hands the FD's lifetime to the
+            # stack: stack unwind closes it (failure path), or self._stack
+            # runs the close on __exit__ (success path).
+            fh = stack.enter_context(open(self.path, "a+", encoding="utf-8"))
             try:
                 _platform_lock(fh)
             except BlockingIOError:
@@ -163,31 +176,30 @@ class WorkspaceLock:
             except OSError as e:
                 logger.debug(f"could not write lock metadata: {e}")
 
+            # Success: transfer the cleanup chain to self for __exit__.
             self._fh = fh
+            self._stack = stack.pop_all()
             return self
         except BaseException:
-            if fh is not None and self._fh is None:
-                try:
-                    fh.close()
-                except OSError as e:
-                    logger.debug(f"error closing lock file during rollback: {e}")
-            with _HELD_LOCK:
-                _HELD.discard(key)
+            # Any failure unwinds the stack: closes fh if opened, releases
+            # the _HELD reservation if added.
+            stack.close()
             raise
 
     def __exit__(self, *exc: Any) -> None:
-        # Closing the FD releases the kernel-level lock. We deliberately do
-        # NOT delete the file — leaving it lets the next holder write fresh
-        # metadata, and a stale file with no FD holder doesn't block anyone
-        # (the next acquire just claims it).
-        if self._fh is not None:
+        # Unwind the stack from __enter__: closes the FD (releasing the
+        # kernel-level lock) and discards the _HELD reservation, in that
+        # order. The lock file is intentionally NOT deleted — leaving it
+        # lets the next holder write fresh metadata, and a stale file
+        # with no FD holder doesn't block anyone (the next acquire just
+        # claims it).
+        if self._stack is not None:
             try:
-                self._fh.close()
+                self._stack.close()
             except OSError as e:
-                logger.debug(f"error closing lock file: {e}")
-            self._fh = None
-        with _HELD_LOCK:
-            _HELD.discard(str(self.path))
+                logger.debug(f"error releasing workspace lock: {e}")
+            self._stack = None
+        self._fh = None
 
 
 

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -2505,8 +2505,18 @@ async def _process_incoming(
                         except OSError as e:
                             # Permission / I/O issue reading existing file — fall through to overwrite
                             logger.debug(f"could not byte-compare {local_file}, will overwrite: {e}")
-                    local_file.write_bytes(content)
+                    # Set the cache hash BEFORE the disk write to close the
+                    # race window: watchdog runs in a separate thread and can
+                    # enqueue an event the moment write_bytes flushes — which
+                    # may be before this asyncio task gets to set_known_hash.
+                    # If the write later fails, forget the entry so the next
+                    # cycle re-pushes whatever's on disk.
                     state.set_known_hash(repo_path, content_hash)
+                    try:
+                        local_file.write_bytes(content)
+                    except OSError:
+                        state.forget_known_hash(repo_path)
+                        raise
                     if watch_app:
                         watch_app.log_pull(rel, user=user_name)
                     else:

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -19,9 +19,7 @@ import json
 import logging
 import os
 import pathlib
-import signal
 import shutil
-import subprocess
 import sys
 import textwrap
 import time
@@ -39,6 +37,7 @@ import httpx
 
 # Import credentials module directly (it's standalone)
 import bifrost.credentials as credentials
+from bifrost._workspace_lock import WorkspaceLock, WorkspaceLockError
 from bifrost.client import BifrostClient
 # Canonical platform export list. Shared with api/src/services/app_bundler.
 # A drift test (tests/unit/test_platform_names_match_runtime.py) keeps this
@@ -1525,23 +1524,34 @@ Examples:
         _print_not_a_workspace_error("push")
         return 1
 
-    # Authenticate BEFORE entering asyncio.run() so token refresh works
-    # (refresh_tokens() uses asyncio.run() internally, which fails inside a running loop)
+    # Block push if a watch (or another sync/push) is already running in
+    # this workspace — see handle_sync for rationale.
     try:
-        client = BifrostClient.get_instance(require_auth=True)
-    except RuntimeError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        lock = WorkspaceLock(resolved, "push").__enter__()
+    except WorkspaceLockError as e:
+        print(f"\nError: {e}", file=sys.stderr)
         return 1
 
-    _warn_if_git_workspace(parsed.local_path)
-
     try:
-        return asyncio.run(_sync_files(
-            parsed.local_path, mirror=parsed.mirror, validate=parsed.validate, force=parsed.force,
-            client=client,
-        ))
-    except KeyboardInterrupt:
-        return 130
+        # Authenticate BEFORE entering asyncio.run() so token refresh works
+        # (refresh_tokens() uses asyncio.run() internally, which fails inside a running loop)
+        try:
+            client = BifrostClient.get_instance(require_auth=True)
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+        _warn_if_git_workspace(parsed.local_path)
+
+        try:
+            return asyncio.run(_sync_files(
+                parsed.local_path, mirror=parsed.mirror, validate=parsed.validate, force=parsed.force,
+                client=client,
+            ))
+        except KeyboardInterrupt:
+            return 130
+    finally:
+        lock.__exit__()
 
 
 def handle_sync(args: list[str]) -> int:
@@ -1590,81 +1600,34 @@ Examples:
         _print_not_a_workspace_error("sync")
         return 1
 
-    # Authenticate BEFORE entering asyncio.run()
+    # Block sync if a watch (or another sync) is already running in this
+    # workspace — concurrent watch+sync would issue separate session_ids
+    # that the server can't dedupe, ping-ponging each other's writes.
     try:
-        client = BifrostClient.get_instance(require_auth=True)
-    except RuntimeError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        lock = WorkspaceLock(resolved, "sync").__enter__()
+    except WorkspaceLockError as e:
+        print(f"\nError: {e}", file=sys.stderr)
         return 1
 
-    _warn_if_git_workspace(parsed.local_path)
-
     try:
-        return asyncio.run(_sync_files(
-            parsed.local_path, mirror=parsed.mirror, validate=parsed.validate, force=parsed.force,
-            client=client,
-        ))
-    except KeyboardInterrupt:
-        return 130
-
-
-def _check_existing_watch() -> list[tuple[int, str]]:
-    """Check for other running 'bifrost watch' processes. Returns list of (pid, cmdline)."""
-    current_pid = os.getpid()
-    parent_pid = os.getppid()
-    results: list[tuple[int, str]] = []
-    try:
-        proc = subprocess.run(
-            ["ps", "ax", "-o", "pid=,args="],
-            capture_output=True, text=True, timeout=5,
-        )
-        for line in proc.stdout.strip().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            parts = line.split(None, 1)
-            if len(parts) < 2:
-                continue
-            try:
-                pid = int(parts[0])
-            except ValueError:
-                continue
-            cmdline = parts[1]
-            if pid in (current_pid, parent_pid):
-                continue
-            if "bifrost" in cmdline and "watch" in cmdline and "grep" not in cmdline:
-                results.append((pid, cmdline))
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
-        # ps unavailable (Windows / restricted env) or timed out — skip the check
-        logger.debug(f"could not enumerate existing watch processes: {e}")
-    return results
-
-
-def _kill_watch_processes(processes: list[tuple[int, str]]) -> bool:
-    """Kill watch processes via SIGTERM, wait up to 5s. Returns True if all stopped."""
-    for pid, _cmdline in processes:
+        # Authenticate BEFORE entering asyncio.run()
         try:
-            os.kill(pid, signal.SIGTERM)
-        except ProcessLookupError:
-            continue
-        except PermissionError:
-            print(f"  Permission denied killing PID {pid}. Kill it manually.", file=sys.stderr)
-            return False
+            client = BifrostClient.get_instance(require_auth=True)
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
 
-    for _ in range(50):  # 5 seconds in 100ms increments
-        time.sleep(0.1)
-        all_dead = True
-        for pid, _ in processes:
-            try:
-                os.kill(pid, 0)  # check if still alive
-                all_dead = False
-            except ProcessLookupError:
-                continue
-            except PermissionError:
-                all_dead = False
-        if all_dead:
-            return True
-    return False
+        _warn_if_git_workspace(parsed.local_path)
+
+        try:
+            return asyncio.run(_sync_files(
+                parsed.local_path, mirror=parsed.mirror, validate=parsed.validate, force=parsed.force,
+                client=client,
+            ))
+        except KeyboardInterrupt:
+            return 130
+    finally:
+        lock.__exit__()
 
 
 def handle_watch(args: list[str]) -> int:
@@ -1700,29 +1663,6 @@ Examples:
 """.strip())
         return 0
 
-    # Check for other running bifrost watch processes
-    existing = _check_existing_watch()
-    if existing:
-        print("\n⚠ Another bifrost watch process is already running:", file=sys.stderr)
-        for pid, cmdline in existing:
-            print(f"  PID {pid} — {cmdline}", file=sys.stderr)
-        print(file=sys.stderr)
-        if not sys.stdin.isatty():
-            print("Cannot prompt in non-interactive mode. Stop the existing watch first.", file=sys.stderr)
-            return 1
-        try:
-            answer = input("Kill and start a new watch session? [y/N]: ").strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            print(file=sys.stderr)
-            return 1
-        if answer != "y":
-            return 1
-        print("Stopping existing watch...", file=sys.stderr)
-        if not _kill_watch_processes(existing):
-            print("Failed to stop existing watch processes. Kill them manually.", file=sys.stderr)
-            return 1
-        print("Stopped.", file=sys.stderr)
-
     parsed = _parse_push_watch_args(args)
     if parsed is None:
         return 1
@@ -1737,31 +1677,43 @@ Examples:
         _print_not_a_workspace_error("watch")
         return 1
 
-    # Authenticate
+    # Acquire the per-workspace lock. Held for the lifetime of the watch
+    # process; the kernel releases it on any exit (including crashes), so no
+    # cleanup or stale-state recovery is needed.
     try:
-        client = BifrostClient.get_instance(require_auth=True)
-    except RuntimeError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        lock = WorkspaceLock(resolved, "watch").__enter__()
+    except WorkspaceLockError as e:
+        print(f"\nError: {e}", file=sys.stderr)
         return 1
 
-    _warn_if_git_workspace(parsed.local_path)
-
-    repo_prefix = _detect_repo_prefix(resolved)
     try:
-        return asyncio.run(_push_with_precheck(
-            parsed.local_path, mirror=parsed.mirror, validate=parsed.validate, watch=True, force=parsed.force,
-            client=client,
-        ))
-    except KeyboardInterrupt:
-        print("\nStopping watch...", flush=True)
+        # Authenticate
         try:
-            client.post_sync("/api/files/watch", json={
-                "action": "stop", "prefix": repo_prefix,
-            })
-        except Exception as e:
-            # Server may already be unreachable — session expires server-side via TTL
-            logger.debug(f"could not notify server of watch stop: {e}")
-        return 130
+            client = BifrostClient.get_instance(require_auth=True)
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+        _warn_if_git_workspace(parsed.local_path)
+
+        repo_prefix = _detect_repo_prefix(resolved)
+        try:
+            return asyncio.run(_push_with_precheck(
+                parsed.local_path, mirror=parsed.mirror, validate=parsed.validate, watch=True, force=parsed.force,
+                client=client,
+            ))
+        except KeyboardInterrupt:
+            print("\nStopping watch...", flush=True)
+            try:
+                client.post_sync("/api/files/watch", json={
+                    "action": "stop", "prefix": repo_prefix,
+                })
+            except Exception as e:
+                # Server may already be unreachable — session expires server-side via TTL
+                logger.debug(f"could not notify server of watch stop: {e}")
+            return 130
+    finally:
+        lock.__exit__()
 
 
 def handle_pull(args: list[str]) -> int:
@@ -1836,20 +1788,31 @@ Examples:
         _print_not_a_workspace_error("pull")
         return 1
 
-    # Authenticate
+    # Block pull if a watch (or another sync/push/pull) is already running
+    # in this workspace — see handle_sync for rationale.
     try:
-        client = BifrostClient.get_instance(require_auth=True)
-    except RuntimeError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        lock = WorkspaceLock(resolved, "pull").__enter__()
+    except WorkspaceLockError as e:
+        print(f"\nError: {e}", file=sys.stderr)
         return 1
 
     try:
-        return asyncio.run(_sync_files(
-            local_path, mirror=mirror, force=force, client=client,
-        ))
-    except KeyboardInterrupt:
-        print("\nPull cancelled.")
-        return 130
+        # Authenticate
+        try:
+            client = BifrostClient.get_instance(require_auth=True)
+        except RuntimeError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+        try:
+            return asyncio.run(_sync_files(
+                local_path, mirror=mirror, force=force, client=client,
+            ))
+        except KeyboardInterrupt:
+            print("\nPull cancelled.")
+            return 130
+    finally:
+        lock.__exit__()
 
 
 

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -60,6 +60,31 @@ class AppValidationResponse(BaseModel):
     warnings: list[AppValidationIssue] = []
 
 
+_IMPORT_RE = re.compile(
+    r'^\s*import\s+.*?\s+from\s+["\']([^"\']+)["\']\s*;?\s*$',
+    re.MULTILINE,
+)
+
+
+def extract_external_deps(content: str) -> set[str]:
+    """Extract bare-specifier import targets from a TS/TSX source.
+
+    Excludes:
+    - the bifrost runtime (resolved by the bundler)
+    - relative imports (./, ../) and absolute paths (/) — these resolve
+      within the app and are not external dependencies
+
+    Used by the validator to flag undeclared external deps.
+    """
+    deps: set[str] = set()
+    for match in _IMPORT_RE.finditer(content):
+        pkg = match.group(1)
+        if pkg == "bifrost" or pkg.startswith((".", "/")):
+            continue
+        deps.add(pkg)
+    return deps
+
+
 # =============================================================================
 # Repository
 # =============================================================================
@@ -1148,15 +1173,7 @@ async def validate_application(
                             line=i,
                         ))
 
-            # Extract external import references (non-bifrost) for dependency checking
-            for match in re.finditer(
-                r'^\s*import\s+.*?\s+from\s+["\']([^"\']+)["\']\s*;?\s*$',
-                content,
-                re.MULTILINE,
-            ):
-                pkg = match.group(1)
-                if pkg != "bifrost":
-                    referenced_deps.add(pkg)
+            referenced_deps |= extract_external_deps(content)
 
             # Check workflow IDs
             # Match useWorkflowQuery("...") and useWorkflowMutation("...")

--- a/api/src/services/mcp_server/tools/apps.py
+++ b/api/src/services/mcp_server/tools/apps.py
@@ -619,6 +619,7 @@ async def validate_app(context: Any, app_id: str) -> ToolResult:
     from src.models.orm.applications import Application
     from src.models.orm.file_index import FileIndex
     from src.models.orm.workflows import Workflow
+    from src.routers.applications import extract_external_deps
 
     logger.info(f"MCP validate_app called with id={app_id}")
 
@@ -692,16 +693,8 @@ async def validate_app(context: Any, app_id: str) -> ToolResult:
                         if "{children}" in content and "Outlet" not in content:
                             errors.append({"severity": "error", "file": rel_path, "message": "Layout uses {children} but should use <Outlet /> for page routing. Replace {children} with <Outlet />."})
 
-                    # Extract external import references (non-bifrost)
-                    for match in re.finditer(
-                        r'^\s*import\s+.*?\s+from\s+["\']([^"\']+)["\']\s*;?\s*$',
-                        content,
-                        re.MULTILINE,
-                    ):
-                        pkg = match.group(1)
-                        if pkg != "bifrost":
-                            # Handle scoped packages: @scope/pkg → @scope/pkg
-                            referenced_deps.add(pkg)
+                    # Handle scoped packages: @scope/pkg → @scope/pkg
+                    referenced_deps |= extract_external_deps(content)
 
                     # Check workflow IDs
                     wf_refs = re.findall(r'(?:useWorkflowQuery|useWorkflowMutation)\s*\(\s*["\']([^"\']+)["\']', content)

--- a/api/tests/unit/test_app_validator_deps.py
+++ b/api/tests/unit/test_app_validator_deps.py
@@ -1,0 +1,103 @@
+"""Unit tests for `extract_external_deps` — the validator helper that
+classifies import targets as external (must be declared in the app
+manifest) vs. internal/relative (resolves within the app, no manifest
+entry needed).
+
+Regression: the validator used to flag relative imports like
+`./components/CommandPalette` and `../lib/format` as missing
+dependencies, producing a wall of false-positive errors on every
+push. Only bare specifiers (and not the `bifrost` runtime) are
+external.
+"""
+from __future__ import annotations
+
+from src.routers.applications import extract_external_deps
+
+
+def test_relative_imports_are_not_external():
+    src = '''
+import { CommandPalette } from "./components/CommandPalette";
+import { fmt } from "./lib/format";
+import { wf } from "../lib/workflows";
+'''
+    assert extract_external_deps(src) == set()
+
+
+def test_absolute_path_imports_are_not_external():
+    src = '''
+import { something } from "/some/root/path";
+'''
+    assert extract_external_deps(src) == set()
+
+
+def test_bifrost_runtime_is_not_external():
+    src = '''
+import { useState, Link } from "bifrost";
+'''
+    assert extract_external_deps(src) == set()
+
+
+def test_bare_specifiers_are_external():
+    src = '''
+import { Search } from "lucide-react";
+import { useLocation } from "react-router-dom";
+'''
+    assert extract_external_deps(src) == {"lucide-react", "react-router-dom"}
+
+
+def test_scoped_packages_are_external():
+    src = '''
+import { something } from "@scope/pkg";
+import { other } from "@scope/pkg/sub";
+'''
+    assert extract_external_deps(src) == {"@scope/pkg", "@scope/pkg/sub"}
+
+
+def test_mixed_imports_only_picks_externals():
+    src = '''
+import { useState, Link, cn } from "bifrost";
+import { useLocation, Outlet } from "react-router-dom";
+import { CommandPalette } from "./components/CommandPalette";
+import { Search } from "lucide-react";
+'''
+    assert extract_external_deps(src) == {"react-router-dom", "lucide-react"}
+
+
+def test_default_imports_are_picked_up():
+    src = '''
+import React from "react";
+import clsx from "clsx";
+'''
+    assert extract_external_deps(src) == {"react", "clsx"}
+
+
+def test_namespace_imports_are_picked_up():
+    src = '''
+import * as utils from "lodash";
+'''
+    assert extract_external_deps(src) == {"lodash"}
+
+
+def test_empty_source_returns_empty_set():
+    assert extract_external_deps("") == set()
+
+
+def test_no_imports_returns_empty_set():
+    src = '''
+export default function Foo() {
+  return <div>hi</div>;
+}
+'''
+    assert extract_external_deps(src) == set()
+
+
+def test_commented_imports_are_ignored():
+    """The regex requires `import` at the start of the line — line comments
+    that mention the word `import` shouldn't be picked up."""
+    src = '''
+// import { Foo } from "fake-pkg";
+import { Real } from "real-pkg";
+'''
+    deps = extract_external_deps(src)
+    assert "real-pkg" in deps
+    assert "fake-pkg" not in deps

--- a/api/tests/unit/test_watch_echo_suppression.py
+++ b/api/tests/unit/test_watch_echo_suppression.py
@@ -262,6 +262,95 @@ async def test_seeded_cache_drops_identical_local_file_push(tmp_path: pathlib.Pa
 
 
 @pytest.mark.asyncio
+async def test_cache_is_set_before_disk_write(tmp_path: pathlib.Path) -> None:
+    """Watchdog runs in a separate thread and can enqueue an observer event
+    the moment write_bytes flushes — which may be before this asyncio task
+    gets to set_known_hash. Setting the cache *before* the write closes the
+    race so a concurrent push-batch lookup sees a hit.
+
+    We can't directly observe "set_known_hash before write_bytes" without
+    monkey-patching, so this test substitutes Path.write_bytes with a probe
+    that asserts the cache is already populated when the write fires.
+    """
+    repo_path = "apps/demo/race.tsx"
+    content = b"export default () => null\n"
+
+    state = _WatchState(tmp_path)
+    client: Any = _RecordingClient(server_files={repo_path: content})
+
+    abs_path = tmp_path / repo_path
+    cache_at_write_time: list[str | None] = []
+
+    real_write_bytes = pathlib.Path.write_bytes
+
+    def probing_write_bytes(self: pathlib.Path, data: bytes) -> int:
+        if str(self) == str(abs_path):
+            cache_at_write_time.append(state.get_known_hash(repo_path))
+        return real_write_bytes(self, data)
+
+    pathlib.Path.write_bytes = probing_write_bytes  # type: ignore[method-assign]
+    try:
+        await _process_incoming(
+            client,
+            files=[([repo_path], "user_a")],
+            deletes=[],
+            base_path=tmp_path,
+            repo_prefix="",
+            state=state,
+        )
+    finally:
+        pathlib.Path.write_bytes = real_write_bytes  # type: ignore[method-assign]
+
+    assert len(cache_at_write_time) == 1, (
+        "Probe should have observed exactly one write to the target path"
+    )
+    assert cache_at_write_time[0] == _hash_for_cache(content), (
+        "Cache must be populated BEFORE the disk write so a concurrent "
+        "watchdog observer event finds a hit on lookup. "
+        f"Saw cache={cache_at_write_time[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_write_failure_clears_cache(tmp_path: pathlib.Path) -> None:
+    """If the disk write fails after the cache has been pre-set, the cache
+    entry must be cleared so the next observer event for whatever IS on disk
+    re-pushes (rather than being silently suppressed by a hash that no longer
+    matches local content)."""
+    repo_path = "apps/demo/fails.tsx"
+    content = b"never landed\n"
+
+    state = _WatchState(tmp_path)
+    client: Any = _RecordingClient(server_files={repo_path: content})
+
+    real_write_bytes = pathlib.Path.write_bytes
+
+    def failing_write_bytes(self: pathlib.Path, data: bytes) -> int:
+        raise OSError("disk full")
+
+    pathlib.Path.write_bytes = failing_write_bytes  # type: ignore[method-assign]
+    try:
+        # _process_incoming wraps each path in a try/except and logs — it
+        # does not propagate the inner OSError. We just need to confirm the
+        # cache rollback ran.
+        await _process_incoming(
+            client,
+            files=[([repo_path], "user_a")],
+            deletes=[],
+            base_path=tmp_path,
+            repo_prefix="",
+            state=state,
+        )
+    finally:
+        pathlib.Path.write_bytes = real_write_bytes  # type: ignore[method-assign]
+
+    assert state.get_known_hash(repo_path) is None, (
+        "Failed write must roll back the optimistic cache entry so future "
+        "observer events for the un-updated local file are not suppressed."
+    )
+
+
+@pytest.mark.asyncio
 async def test_incoming_delete_evicts_cache(tmp_path: pathlib.Path) -> None:
     """A delete event from another user must remove the cache entry so a
     later recreation of the file with the same bytes still pushes."""

--- a/api/tests/unit/test_workspace_lock.py
+++ b/api/tests/unit/test_workspace_lock.py
@@ -1,0 +1,194 @@
+"""Unit tests for the per-workspace exclusion lock.
+
+The lock guards `bifrost watch` / `bifrost sync` / `bifrost push` /
+`bifrost pull` against the multi-session_id ping-pong: two sessions in one
+workspace publish events with distinct session_ids that the server can't
+dedupe, so they bounce each other's writes back as "incoming."
+
+Properties under test:
+
+- A second acquire on the same workspace fails with `WorkspaceLockError`.
+- The error message exposes the holder's PID + command + start time so
+  the user can find and stop them.
+- Releasing (or letting the FD go out of scope) lets a fresh acquire
+  succeed.
+- The lock file lives under `.bifrost/.session.lock`. We do not test
+  `flock` semantics on NFS / Windows here — the wrappers in
+  `_workspace_lock.py` rely on platform-native primitives that the
+  kernel manages.
+- After a process holding the lock dies (subprocess that opens the lock
+  and is then SIGKILLed), the next acquire from this process succeeds —
+  i.e. no manual cleanup is needed.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+from bifrost._workspace_lock import (
+    WorkspaceLock,
+    WorkspaceLockError,
+)
+
+
+def _make_workspace(tmp_path: pathlib.Path) -> pathlib.Path:
+    (tmp_path / ".bifrost").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_acquire_succeeds_when_no_holder(tmp_path: pathlib.Path) -> None:
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        pass
+
+
+def test_second_acquire_in_same_process_fails(tmp_path: pathlib.Path) -> None:
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        with pytest.raises(WorkspaceLockError) as exc_info:
+            with WorkspaceLock(ws, "sync"):
+                pass
+        msg = str(exc_info.value)
+        assert "watch" in msg, f"holder command should appear in error: {msg}"
+        assert str(os.getpid()) in msg, f"holder PID should appear in error: {msg}"
+
+
+def test_release_allows_reacquire(tmp_path: pathlib.Path) -> None:
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        pass
+    # Should not raise — previous holder is gone.
+    with WorkspaceLock(ws, "sync"):
+        pass
+
+
+def test_lock_file_is_under_dot_bifrost(tmp_path: pathlib.Path) -> None:
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        assert (ws / ".bifrost" / ".session.lock").exists()
+
+
+def test_acquire_creates_dot_bifrost_if_missing(tmp_path: pathlib.Path) -> None:
+    """The lock helper should mkdir(parents=True, exist_ok=True) so callers
+    don't need to bootstrap the dir themselves."""
+    # Note: in real callers the workspace marker is checked first; this is
+    # purely about the helper's robustness.
+    with WorkspaceLock(tmp_path, "watch"):
+        assert (tmp_path / ".bifrost").is_dir()
+
+
+def test_holder_metadata_records_command(tmp_path: pathlib.Path) -> None:
+    """The lock file should record the holder's command so a contender can
+    name what to stop."""
+    import json
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        meta = json.loads((ws / ".bifrost" / ".session.lock").read_text())
+        assert meta["command"] == "watch"
+        assert meta["pid"] == os.getpid()
+        assert "started_at" in meta
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock semantics")
+def test_killed_holder_releases_lock(tmp_path: pathlib.Path) -> None:
+    """Kernel cleans up the FD even on SIGKILL. After the holder dies, a new
+    acquire must succeed without manual cleanup or PID checking."""
+    ws = _make_workspace(tmp_path)
+
+    # Spawn a subprocess that acquires the lock and then sleeps. We SIGKILL
+    # it without giving it a chance to clean up — the kernel must release
+    # the flock on its own.
+    #
+    # The child needs the bifrost package on sys.path. The test container
+    # mounts the source at /app, but locally pytest runs from the repo root.
+    # Inherit the parent's PYTHONPATH so whichever applies works.
+    holder_script = textwrap.dedent(f"""
+        import pathlib
+        from bifrost._workspace_lock import WorkspaceLock
+        with WorkspaceLock(pathlib.Path({str(ws)!r}), "watch"):
+            print("ACQUIRED", flush=True)
+            import time
+            time.sleep(60)
+    """).strip()
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", holder_script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env={**os.environ, "PYTHONPATH": os.environ.get("PYTHONPATH", "") + ":/app:."},
+    )
+    captured: list[str] = []
+    try:
+        # Wait for the child to confirm it acquired before we test contention
+        deadline = time.time() + 10
+        acquired = False
+        while time.time() < deadline:
+            assert proc.stdout is not None
+            line = proc.stdout.readline().decode("utf-8", errors="replace").strip()
+            captured.append(line)
+            if line == "ACQUIRED":
+                acquired = True
+                break
+        assert acquired, (
+            f"child process did not report ACQUIRED in time. captured={captured!r}, "
+            f"poll={proc.poll()!r}"
+        )
+
+        # While the child holds the lock, our acquire must fail.
+        with pytest.raises(WorkspaceLockError):
+            with WorkspaceLock(ws, "sync"):
+                pass
+
+        # Kill -9 the child. No chance for cleanup. The kernel must release
+        # the FD.
+        proc.send_signal(signal.SIGKILL)
+        proc.wait(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    # Now acquire must succeed — kernel released the lock.
+    with WorkspaceLock(ws, "sync"):
+        pass
+
+
+def test_workspace_lock_error_includes_human_readable_time(tmp_path: pathlib.Path) -> None:
+    """The error message should render the lock holder's start time in a
+    locale-friendly form, not a raw ISO string."""
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        with pytest.raises(WorkspaceLockError) as exc_info:
+            with WorkspaceLock(ws, "sync"):
+                pass
+        msg = str(exc_info.value)
+        # Either ISO or formatted — but never empty
+        assert "started" in msg.lower(), f"missing started_at in error: {msg}"
+
+
+def test_context_manager_protocol(tmp_path: pathlib.Path) -> None:
+    """`WorkspaceLock` should support `with` directly (not just
+    `WorkspaceLock().__exit__()`)."""
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        pass
+    # Reusable
+    with WorkspaceLock(ws, "sync"):
+        pass
+
+
+def test_concurrent_workspaces_do_not_block(tmp_path: pathlib.Path) -> None:
+    """Two different workspaces must not block each other — the lock is
+    per-workspace, not global."""
+    ws_a = _make_workspace(tmp_path / "a")
+    ws_b = _make_workspace(tmp_path / "b")
+    with WorkspaceLock(ws_a, "watch"):
+        with WorkspaceLock(ws_b, "watch"):
+            pass

--- a/api/tests/unit/test_workspace_lock.py
+++ b/api/tests/unit/test_workspace_lock.py
@@ -32,10 +32,8 @@ import time
 
 import pytest
 
-from bifrost._workspace_lock import (
-    WorkspaceLock,
-    WorkspaceLockError,
-)
+from bifrost import _workspace_lock
+from bifrost._workspace_lock import WorkspaceLock, WorkspaceLockError
 
 
 def _make_workspace(tmp_path: pathlib.Path) -> pathlib.Path:
@@ -207,12 +205,10 @@ def test_failed_acquire_closes_fd_and_rolls_back_reservation(
 
     # Force `_platform_lock` to raise an unexpected error (not
     # BlockingIOError) — exercises the catch-all rollback path.
-    import bifrost._workspace_lock as wl
-
     def boom(_fh: object) -> None:
         raise RuntimeError("simulated platform lock failure")
 
-    monkeypatch.setattr(wl, "_platform_lock", boom)
+    monkeypatch.setattr(_workspace_lock, "_platform_lock", boom)
 
     with pytest.raises(RuntimeError, match="simulated"):
         with WorkspaceLock(ws, "watch"):

--- a/api/tests/unit/test_workspace_lock.py
+++ b/api/tests/unit/test_workspace_lock.py
@@ -192,3 +192,53 @@ def test_concurrent_workspaces_do_not_block(tmp_path: pathlib.Path) -> None:
     with WorkspaceLock(ws_a, "watch"):
         with WorkspaceLock(ws_b, "watch"):
             pass
+
+
+def test_failed_acquire_closes_fd_and_rolls_back_reservation(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Any exception between `open()` and the successful return of
+    `__enter__` must close the FD and roll back the in-process
+    reservation. Otherwise a contended acquire leaks an FD per attempt
+    and a half-failed acquire blocks all future ones in the same process.
+    """
+    ws = _make_workspace(tmp_path)
+
+    # Force `_platform_lock` to raise an unexpected error (not
+    # BlockingIOError) — exercises the catch-all rollback path.
+    import bifrost._workspace_lock as wl
+
+    def boom(_fh: object) -> None:
+        raise RuntimeError("simulated platform lock failure")
+
+    monkeypatch.setattr(wl, "_platform_lock", boom)
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        with WorkspaceLock(ws, "watch"):
+            pass
+
+    # Reservation rolled back: a fresh acquire must succeed.
+    monkeypatch.undo()
+    with WorkspaceLock(ws, "watch"):
+        pass
+
+
+def test_blocking_acquire_does_not_leak_fd_or_reservation(tmp_path: pathlib.Path) -> None:
+    """A BlockingIOError from a cross-process contender must close the
+    contender's FD and roll back the in-process reservation, leaving the
+    workspace acquirable again once the holder releases."""
+    ws = _make_workspace(tmp_path)
+    with WorkspaceLock(ws, "watch"):
+        # First attempt fails as expected.
+        with pytest.raises(WorkspaceLockError):
+            with WorkspaceLock(ws, "sync"):
+                pass
+        # Second attempt also fails — proves the first didn't leave a
+        # stale entry in `_HELD` that would mask the real holder.
+        with pytest.raises(WorkspaceLockError):
+            with WorkspaceLock(ws, "sync"):
+                pass
+    # Holder released; acquire now succeeds.
+    with WorkspaceLock(ws, "sync"):
+        pass


### PR DESCRIPTION
## Summary

Three layered fixes for the recurring `bifrost watch` echo behavior plus a validator false-positive that's been spamming push errors.

### 1. Close the pull→write→re-push race
`_process_incoming` set the known-hash cache *after* `local_file.write_bytes`. Watchdog runs in a separate thread and can enqueue the path the moment the OS notifies it of the write — before this asyncio task gets to `set_known_hash`. If the next loop tick drained that pending change before the cache populated, the push batcher saw a hash mismatch and round-tripped the pulled content. Now the cache is set *before* the write; on OSError the entry rolls back so observer events re-push whatever's actually on disk.

### 2. Per-workspace exclusion lock — kills the multi-session_id ping-pong at the source
Two sessions in one workspace generate distinct `session_id`s. The server's file-activity broadcast doesn't dedupe by session, each client only filters its own events, so peer events always come through. With two sessions in one folder both keep echoing each other's writes — the hash cache papers it over but only after wasted RTT and attribution clobber.

`bifrost watch | sync | push | pull` now hold a kernel-tracked `flock` under `<workspace>/.bifrost/.session.lock` for the lifetime of the operation. A second attempt fails with:

```
Error: another bifrost session is active in this workspace.
  PID 4172204  bifrost watch  (started 2026-04-29 23:46:39)
Stop it first or wait for it to finish.
```

Why flock and not a PID file: the kernel releases the FD on **any** process exit — clean shutdown, Ctrl-C, SIGKILL, OOM, panic, reboot. No reaper, no TTL, no PID-reuse races, no manual cleanup. Lock file metadata (PID/command/started_at) is informational only.

The previous `_check_existing_watch` walked global `ps` and pattern-matched "bifrost...watch" — false-positived across folders (a prod watch in one workspace blocked a debug watch in another) and missed the watch-vs-sync race entirely. Removed.

### 3. Validator: relative imports are not external deps
The app validator was misclassifying `./components/X`, `../lib/format`, and `/foo` as external dependencies, producing a wall of "Missing dependency" false positives on every push of any non-trivial app. Extracted the classifier into `extract_external_deps()`, reused from both the REST validator and the MCP tool, with `./`, `../`, and `/` excluded.

## Verification

- 38 unit tests pass: `test_workspace_lock.py` (10), `test_watch_two_observers.py` (2), `test_watch_echo_suppression.py` (7, including new pre-write-cache + write-failure-rollback probes), `test_watch_hash_cache.py` (8), `test_app_validator_deps.py` (11).
- `pyright` + `ruff` clean on all changed files.
- End-to-end against an isolated debug stack:
  - Two simulated watch sessions, peer push triggers a pull on the other side, **zero echo**.
  - Validator on a synthetic app importing `bifrost`, `./components/X`, `../lib/Y`, `lucide-react`, `react-router-dom` — only the last two flagged.
  - Live lock test: started a `bifrost watch` in one folder, second `watch` and `sync` in the same folder both rejected with the named-PID error; different folder unaffected; SIGKILL on the holder let the next acquire succeed without cleanup.

## Test plan

- [x] Unit tests pass locally (`./test.sh tests/unit/test_workspace_lock.py tests/unit/test_watch_*.py tests/unit/test_app_validator_deps.py`)
- [x] Pyright + ruff clean
- [x] Live debug-stack repro for echo suppression
- [x] Live debug-stack repro for lock blocking watch+sync in same folder
- [x] SIGKILL → kernel releases lock, next acquire succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)