### PR TITLE
feat(files): unified {location}/{scope}/{path} model + signed-url location fix

### DIFF
--- a/api/bifrost/files.py
+++ b/api/bifrost/files.py
@@ -33,8 +33,9 @@ from typing import Literal
 from .client import get_client, raise_for_status_with_detail
 from ._context import resolve_scope
 
-Location = Literal["workspace", "temp", "uploads"]
 Mode = Literal["local", "cloud"]
+# `location` is a free string. Reserved names: "workspace", "temp", "uploads".
+# Anything else is a freeform user-defined location (e.g. "reports", "exports").
 
 
 class files:
@@ -51,23 +52,20 @@ class files:
     @staticmethod
     async def read(
         path: str,
-        location: Location = "workspace",
+        location: str = "workspace",
         mode: Mode = "cloud",
+        scope: str | None = None,
     ) -> str:
         """
         Read a text file.
 
         Args:
             path: File path relative to location root
-            location: Storage location (workspace, temp, or uploads)
+            location: Storage location. Reserved: "workspace", "temp", "uploads".
+                Freeform names (e.g. "reports") are also allowed.
             mode: Storage mode (local or cloud, default: cloud)
-
-        Returns:
-            str: File contents
-
-        Raises:
-            FileNotFoundError: If file doesn't exist
-            ValueError: If path is outside allowed directories
+            scope: Org scope. Defaults to the current execution's org.
+                Provider orgs may pass an explicit scope to read from another org.
 
         Example:
             >>> from bifrost import files
@@ -75,9 +73,10 @@ class files:
             >>> uploaded = await files.read("form_id/uuid/file.txt", location="uploads")
         """
         client = get_client()
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/read",
-            json={"path": path, "location": location, "mode": mode, "binary": False}
+            json={"path": path, "location": location, "mode": mode, "binary": False, "scope": effective_scope}
         )
         raise_for_status_with_detail(response)
         return response.json()["content"]
@@ -85,32 +84,24 @@ class files:
     @staticmethod
     async def read_bytes(
         path: str,
-        location: Location = "workspace",
+        location: str = "workspace",
         mode: Mode = "cloud",
+        scope: str | None = None,
     ) -> bytes:
         """
         Read a binary file.
 
         Args:
             path: File path relative to location root
-            location: Storage location (workspace, temp, or uploads)
+            location: Storage location (reserved or freeform)
             mode: Storage mode (local or cloud, default: cloud)
-
-        Returns:
-            bytes: File contents
-
-        Raises:
-            FileNotFoundError: If file doesn't exist
-            ValueError: If path is outside allowed directories
-
-        Example:
-            >>> from bifrost import files
-            >>> data = await files.read_bytes("reports/report.pdf")
+            scope: Org scope; provider-org override allowed.
         """
         client = get_client()
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/read",
-            json={"path": path, "location": location, "mode": mode, "binary": True}
+            json={"path": path, "location": location, "mode": mode, "binary": True, "scope": effective_scope}
         )
         raise_for_status_with_detail(response)
         import base64
@@ -120,8 +111,9 @@ class files:
     async def write(
         path: str,
         content: str,
-        location: Location = "workspace",
+        location: str = "workspace",
         mode: Mode = "cloud",
+        scope: str | None = None,
     ) -> None:
         """
         Write text to a file.
@@ -129,20 +121,15 @@ class files:
         Args:
             path: File path relative to location root
             content: Text content to write
-            location: Storage location (workspace or temp)
+            location: Storage location (reserved or freeform)
             mode: Storage mode (local or cloud, default: cloud)
-
-        Raises:
-            ValueError: If path is outside allowed directories
-
-        Example:
-            >>> from bifrost import files
-            >>> await files.write("output/report.txt", "Report data")
+            scope: Org scope; provider-org override allowed.
         """
         client = get_client()
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/write",
-            json={"path": path, "content": content, "location": location, "mode": mode, "binary": False}
+            json={"path": path, "content": content, "location": location, "mode": mode, "binary": False, "scope": effective_scope}
         )
         raise_for_status_with_detail(response)
 
@@ -150,8 +137,9 @@ class files:
     async def write_bytes(
         path: str,
         content: bytes,
-        location: Location = "workspace",
+        location: str = "workspace",
         mode: Mode = "cloud",
+        scope: str | None = None,
     ) -> None:
         """
         Write binary data to a file.
@@ -159,30 +147,26 @@ class files:
         Args:
             path: File path relative to location root
             content: Binary content to write
-            location: Storage location (workspace or temp)
+            location: Storage location (reserved or freeform)
             mode: Storage mode (local or cloud, default: cloud)
-
-        Raises:
-            ValueError: If path is outside allowed directories
-
-        Example:
-            >>> from bifrost import files
-            >>> await files.write_bytes("uploads/image.png", image_data)
+            scope: Org scope; provider-org override allowed.
         """
         client = get_client()
         import base64
         encoded_content = base64.b64encode(content).decode('utf-8')
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/write",
-            json={"path": path, "content": encoded_content, "location": location, "mode": mode, "binary": True}
+            json={"path": path, "content": encoded_content, "location": location, "mode": mode, "binary": True, "scope": effective_scope}
         )
         raise_for_status_with_detail(response)
 
     @staticmethod
     async def list(
         directory: str = "",
-        location: Location = "workspace",
+        location: str = "workspace",
         mode: Mode = "cloud",
+        scope: str | None = None,
     ) -> list[str]:
         """
         List files in a directory.
@@ -205,9 +189,10 @@ class files:
             ...     print(item)
         """
         client = get_client()
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/list",
-            json={"directory": directory, "location": location, "mode": mode}
+            json={"directory": directory, "location": location, "mode": mode, "scope": effective_scope}
         )
         raise_for_status_with_detail(response)
         return response.json()["files"]
@@ -215,61 +200,52 @@ class files:
     @staticmethod
     async def delete(
         path: str,
-        location: Location = "workspace",
+        location: str = "workspace",
         mode: Mode = "cloud",
+        scope: str | None = None,
     ) -> None:
         """
         Delete a file.
 
         Args:
             path: File path relative to location root
-            location: Storage location (workspace or temp)
+            location: Storage location (reserved or freeform)
             mode: Storage mode (local or cloud, default: cloud)
-
-        Raises:
-            FileNotFoundError: If file doesn't exist
-            ValueError: If path is outside allowed directories
+            scope: Org scope; provider-org override allowed.
 
         Example:
             >>> from bifrost import files
             >>> await files.delete("temp/old_file.txt", location="temp")
         """
         client = get_client()
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/delete",
-            json={"path": path, "location": location, "mode": mode}
+            json={"path": path, "location": location, "mode": mode, "scope": effective_scope}
         )
         raise_for_status_with_detail(response)
 
     @staticmethod
     async def exists(
         path: str,
-        location: Location = "workspace",
+        location: str = "workspace",
         mode: Mode = "cloud",
+        scope: str | None = None,
     ) -> bool:
         """
         Check if a file exists.
 
         Args:
             path: File path relative to location root
-            location: Storage location (workspace or temp)
+            location: Storage location (reserved or freeform)
             mode: Storage mode (local or cloud, default: cloud)
-
-        Returns:
-            bool: True if path exists
-
-        Raises:
-            ValueError: If path is outside allowed directories
-
-        Example:
-            >>> from bifrost import files
-            >>> if await files.exists("data/customers.csv"):
-            ...     data = await files.read("data/customers.csv")
+            scope: Org scope; provider-org override allowed.
         """
         client = get_client()
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/exists",
-            json={"path": path, "location": location, "mode": mode}
+            json={"path": path, "location": location, "mode": mode, "scope": effective_scope}
         )
         raise_for_status_with_detail(response)
         return response.json()["exists"]
@@ -279,23 +255,43 @@ class files:
         path: str,
         method: Literal["PUT", "GET"] = "PUT",
         content_type: str = "application/octet-stream",
+        location: str = "uploads",
+        scope: str | None = None,
     ) -> dict:
         """
         Generate a presigned S3 URL for direct file upload or download.
 
         Args:
-            path: File path (scoped automatically by org)
+            path: File path relative to location root (NOT including scope segment)
             method: "PUT" for upload, "GET" for download
             content_type: MIME type (only used for PUT)
+            location: Storage location. Defaults to "uploads" for backwards
+                compatibility with form upload flows. Use "workspace" to sign
+                URLs for files written via `files.write_bytes(..., location="workspace")`.
+            scope: Org scope; provider-org override allowed.
 
         Returns:
             dict with keys: url, path, expires_in
+
+        Example:
+            >>> # Generate a download URL for a file written to workspace
+            >>> await files.write_bytes("report.pdf", pdf_bytes, location="workspace")
+            >>> signed = await files.get_signed_url(
+            ...     "report.pdf", method="GET", location="workspace",
+            ...     content_type="application/pdf",
+            ... )
         """
         client = get_client()
-        scope = resolve_scope(None)
+        effective_scope = resolve_scope(scope)
         response = await client.post(
             "/api/files/signed-url",
-            json={"path": path, "method": method, "content_type": content_type, "scope": scope}
+            json={
+                "path": path,
+                "method": method,
+                "content_type": content_type,
+                "location": location,
+                "scope": effective_scope,
+            }
         )
         raise_for_status_with_detail(response)
         return response.json()

--- a/api/shared/file_paths.py
+++ b/api/shared/file_paths.py
@@ -36,14 +36,8 @@ WORKSPACE_PREFIX = "_repo/"
 TEMP_PREFIX = "_tmp/"
 UPLOADS_PREFIX = "uploads/"
 
-RESERVED_LOCATION_NAMES: frozenset[str] = frozenset({
-    "workspace",
-    "uploads",
-    "temp",
-    "_repo",
-    "_tmp",
-    "_apps",
-})
+RESERVED_LOCATIONS: frozenset[str] = frozenset({"workspace", "uploads", "temp"})
+BLOCKED_LOCATION_NAMES: frozenset[str] = frozenset({"_repo", "_tmp", "_apps"})
 
 _FREEFORM_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
@@ -55,9 +49,9 @@ def validate_location_name(location: str) -> None:
     so users can't bypass the `{location}/{scope}/` layout by addressing the underlying
     bucket prefix directly.
     """
-    if location in ("workspace", "uploads", "temp"):
+    if location in RESERVED_LOCATIONS:
         return
-    if location in ("_repo", "_tmp", "_apps"):
+    if location in BLOCKED_LOCATION_NAMES:
         raise ValueError(
             f"Invalid location: '{location}' is a reserved bucket prefix; "
             "use 'workspace', 'temp', or 'uploads' instead."

--- a/api/shared/file_paths.py
+++ b/api/shared/file_paths.py
@@ -1,0 +1,103 @@
+"""
+File path resolution for the unified Files SDK.
+
+All file operations (`read`, `write`, `list`, `delete`, `exists`, `signed-url`)
+resolve their S3 keys through `resolve_s3_key()` here. One source of truth.
+
+Layout:
+    {location}/{scope}/{path}
+
+Reserved (managed) locations:
+    workspace -> _repo/{path}            (unscoped — platform codebase)
+    uploads   -> uploads/{scope}/{path}  (form upload bucket)
+    temp      -> _tmp/{scope}/{path}
+
+Freeform (user-defined) locations:
+    {name}    -> {name}/{scope}/{path}
+
+`workspace` is the only unscoped location — it's conceptually a git repo
+shared across orgs. Everything else requires scope. Scope semantics
+(default-from-execution-context vs explicit override) are enforced upstream
+in `bifrost._context.resolve_scope`.
+
+Form-submission paths under `uploads/` are produced by `api/src/routers/forms.py`
+as `{form_id}/{uuid}/{filename}` *relative to the location*; the resolver
+prepends `uploads/{scope}/`. Existing form-upload references in storage that
+predate this change live at `uploads/{form_id}/{uuid}/{filename}` (no scope
+segment) and remain readable only via direct S3 access — they are not
+addressable through the resolver.
+"""
+
+from __future__ import annotations
+
+import re
+
+WORKSPACE_PREFIX = "_repo/"
+TEMP_PREFIX = "_tmp/"
+UPLOADS_PREFIX = "uploads/"
+
+RESERVED_LOCATION_NAMES: frozenset[str] = frozenset({
+    "workspace",
+    "uploads",
+    "temp",
+    "_repo",
+    "_tmp",
+    "_apps",
+})
+
+_FREEFORM_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def validate_location_name(location: str) -> None:
+    """Validate that `location` is a recognized reserved name or a legal freeform name.
+
+    Reserved direct prefix names (`_repo`, `_tmp`, `_apps`) are rejected as locations
+    so users can't bypass the `{location}/{scope}/` layout by addressing the underlying
+    bucket prefix directly.
+    """
+    if location in ("workspace", "uploads", "temp"):
+        return
+    if location in ("_repo", "_tmp", "_apps"):
+        raise ValueError(
+            f"Invalid location: '{location}' is a reserved bucket prefix; "
+            "use 'workspace', 'temp', or 'uploads' instead."
+        )
+    if not _FREEFORM_NAME_RE.match(location):
+        raise ValueError(
+            f"Invalid location name: '{location}' must match {_FREEFORM_NAME_RE.pattern}"
+        )
+
+
+def _validate_path(path: str) -> None:
+    if ".." in path.split("/"):
+        raise ValueError(f"Invalid path: path traversal not allowed: {path}")
+    if path.startswith("/"):
+        raise ValueError(f"Invalid path: must be relative: {path}")
+
+
+def resolve_s3_key(location: str, scope: str | None, path: str) -> str:
+    """Resolve `(location, scope, path)` to an S3 key.
+
+    Raises:
+        ValueError: invalid location name, traversal in path, or missing scope
+            for a scoped location.
+    """
+    validate_location_name(location)
+    _validate_path(path)
+
+    clean_path = path.lstrip("/")
+
+    if location == "workspace":
+        return f"{WORKSPACE_PREFIX}{clean_path}"
+
+    if scope is None or scope == "":
+        raise ValueError(
+            f"Scope is required for location '{location}'."
+        )
+
+    if location == "uploads":
+        return f"{UPLOADS_PREFIX}{scope}/{clean_path}"
+    if location == "temp":
+        return f"{TEMP_PREFIX}{scope}/{clean_path}"
+
+    return f"{location}/{scope}/{clean_path}"

--- a/api/src/core/requirements_cache.py
+++ b/api/src/core/requirements_cache.py
@@ -247,3 +247,24 @@ def append_package_to_requirements(
     # Filter empty lines and ensure trailing newline
     lines = [line for line in lines if line.strip()]
     return ("\n".join(lines) + "\n" if lines else "", found)
+
+
+def remove_package_from_requirements(current: str, package: str) -> tuple[str, bool]:
+    """Remove a package from requirements.txt content.
+
+    Returns (updated content, was_present).
+    """
+    lines = current.strip().split("\n") if current.strip() else []
+    package_lower = package.lower()
+    kept: list[str] = []
+    found = False
+    for line in lines:
+        line_package = (
+            line.split("==")[0].split(">=")[0].split("<=")[0].split("~=")[0].strip()
+        )
+        if line_package.lower() == package_lower:
+            found = True
+            continue
+        if line.strip():
+            kept.append(line)
+    return ("\n".join(kept) + "\n" if kept else "", found)

--- a/api/src/jobs/consumers/package_install.py
+++ b/api/src/jobs/consumers/package_install.py
@@ -60,6 +60,33 @@ class PackageInstallConsumer(BroadcastConsumer):
             {"type": "complete", "status": status, "message": message},
         )
 
+    async def _pip_uninstall(self, package: str) -> bool:
+        """Run pip uninstall for a package on this worker."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, "-m", "pip", "uninstall", "-y", package, "--quiet",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
+            if proc.returncode == 0:
+                logger.info(f"Uninstalled {package}")
+                return True
+            err = stderr.decode()
+            # pip exits non-zero when the package isn't installed; that's fine
+            # for our purposes — the post-condition (package absent) holds.
+            if "not installed" in err.lower() or "skipping" in err.lower():
+                logger.info(f"Package {package} was not installed; nothing to do")
+                return True
+            logger.warning(f"pip uninstall {package} failed: {err}")
+            return False
+        except asyncio.TimeoutError:
+            logger.error(f"pip uninstall {package} timed out")
+            return False
+        except Exception as e:
+            logger.error(f"pip uninstall {package} error: {e}")
+            return False
+
     async def _pip_install(self, package: str, version: str | None) -> bool:
         """
         Run pip install for a specific package on this worker.
@@ -173,36 +200,44 @@ class PackageInstallConsumer(BroadcastConsumer):
             logger.warning(f"Failed to drain/restart after pip install: {e}")
 
     async def process_message(self, body: dict[str, Any]) -> None:
-        """Process a package installation message."""
+        """Process a package install or uninstall message.
+
+        `action` is "install" (default) or "uninstall". For "install" with
+        `package=None`, runs pip install -r requirements.txt (sync from cache).
+        """
+        action = body.get("action", "install")
         package = body.get("package")
         version = body.get("version")
         package_spec = f"{package}=={version}" if package and version else (package or "requirements.txt")
 
-        logger.info(f"Processing package install: {package_spec}")
+        logger.info(f"Processing package {action}: {package_spec}")
 
-        # Step 1: pip install on this worker
-        await self._send_log(f"Installing {package_spec}...")
-
-        if package:
+        if action == "uninstall":
+            if not package:
+                await self._send_complete("error", "uninstall requires a package name")
+                return
+            await self._send_log(f"Uninstalling {package}...")
+            success = await self._pip_uninstall(package)
+        elif package:
+            await self._send_log(f"Installing {package_spec}...")
             success = await self._pip_install(package, version)
         else:
+            await self._send_log("Installing from requirements.txt...")
             success = await self._pip_install_requirements()
 
         if success:
-            await self._send_log(f"Installed {package_spec}")
+            await self._send_log(f"{action.capitalize()}ed {package_spec}")
         else:
-            await self._send_log(f"Failed to install {package_spec}", "error")
-            await self._send_complete("error", f"Installation failed: {package_spec}")
+            await self._send_log(f"Failed to {action} {package_spec}", "error")
+            await self._send_complete("error", f"{action.capitalize()} failed: {package_spec}")
             return
 
-        # Step 2: Always recycle worker processes after installation.
-        # Worker subprocesses are forked before pip install runs, so they
-        # won't see newly installed packages on the filesystem until recycled.
+        # Worker subprocesses are forked before pip runs; recycle so they pick
+        # up the new on-disk state.
         await self._send_log("Recycling worker processes...")
         await self._recycle_workers()
 
-        # Step 3: Update package list in Redis
         await self._update_pool_packages()
 
-        await self._send_complete("success", "Installation complete")
-        logger.info("Package install completed")
+        await self._send_complete("success", f"{action.capitalize()} complete")
+        logger.info(f"Package {action} completed")

--- a/api/src/models/contracts/common.py
+++ b/api/src/models/contracts/common.py
@@ -64,10 +64,15 @@ class FileUploadRequest(BaseModel):
 
 
 class UploadedFileMetadata(BaseModel):
-    """Metadata for uploaded file that workflows can use to access the file"""
+    """Metadata for uploaded file that workflows can use to access the file.
+
+    `path` is relative to the `uploads` location: pass it directly to
+    `files.read(path, location="uploads")` in a workflow and the SDK handles
+    scoping. The full S3 key is `uploads/{scope}/{path}`.
+    """
     name: str = Field(..., description="Original file name")
     container: str = Field(..., description="Blob storage container name (e.g., 'uploads')")
-    path: str = Field(..., description="Blob path within container")
+    path: str = Field(..., description="Path relative to uploads/ (e.g., '{form_id}/{uuid}/{filename}')")
     content_type: str = Field(..., description="MIME type of the file")
     size: int = Field(..., description="File size in bytes")
 

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -60,14 +60,17 @@ router = APIRouter(prefix="/api/files", tags=["Files"])
 # Request Models with Mode Parameter
 # =============================================================================
 
-Location = Literal["workspace", "temp", "uploads"]
 Mode = Literal["local", "cloud"]
+
+# Location is now a free string; reserved-vs-freeform validation lives in
+# `shared.file_paths.validate_location_name` and is applied by the resolver.
 
 
 class FileReadRequest(BaseModel):
     """Request to read a file."""
     path: str = Field(..., description="File path relative to location root")
-    location: Location = Field(default="workspace", description="Storage location")
+    location: str = Field(default="workspace", description="Storage location: reserved (workspace, temp, uploads) or freeform")
+    scope: str | None = Field(default=None, description="Org scope. Required for non-workspace, non-uploads locations.")
     mode: Mode = Field(default="cloud", description="Storage mode: local or cloud")
     binary: bool = Field(default=False, description="If true, return base64-encoded content")
 
@@ -76,7 +79,8 @@ class FileWriteRequest(BaseModel):
     """Request to write a file."""
     path: str = Field(..., description="File path relative to location root")
     content: str = Field(..., description="File content (text or base64 for binary)")
-    location: Location = Field(default="workspace", description="Storage location")
+    location: str = Field(default="workspace", description="Storage location: reserved (workspace, temp, uploads) or freeform")
+    scope: str | None = Field(default=None, description="Org scope. Required for non-workspace, non-uploads locations.")
     mode: Mode = Field(default="cloud", description="Storage mode: local or cloud")
     binary: bool = Field(default=False, description="If true, content is base64-encoded")
 
@@ -84,14 +88,16 @@ class FileWriteRequest(BaseModel):
 class FileDeleteRequest(BaseModel):
     """Request to delete a file."""
     path: str = Field(..., description="File path relative to location root")
-    location: Location = Field(default="workspace", description="Storage location")
+    location: str = Field(default="workspace", description="Storage location: reserved (workspace, temp, uploads) or freeform")
+    scope: str | None = Field(default=None, description="Org scope. Required for non-workspace, non-uploads locations.")
     mode: Mode = Field(default="cloud", description="Storage mode: local or cloud")
 
 
 class FileListRequest(BaseModel):
     """Request to list files."""
     directory: str = Field(default="", description="Directory path relative to location root")
-    location: Location = Field(default="workspace", description="Storage location")
+    location: str = Field(default="workspace", description="Storage location: reserved (workspace, temp, uploads) or freeform")
+    scope: str | None = Field(default=None, description="Org scope. Required for non-workspace, non-uploads locations.")
     mode: Mode = Field(default="cloud", description="Storage mode: local or cloud")
     include_metadata: bool = Field(default=False, description="If true, return ETags + last_modified per file")
 
@@ -99,7 +105,8 @@ class FileListRequest(BaseModel):
 class FileExistsRequest(BaseModel):
     """Request to check file existence."""
     path: str = Field(..., description="File path relative to location root")
-    location: Location = Field(default="workspace", description="Storage location")
+    location: str = Field(default="workspace", description="Storage location: reserved (workspace, temp, uploads) or freeform")
+    scope: str | None = Field(default=None, description="Org scope. Required for non-workspace, non-uploads locations.")
     mode: Mode = Field(default="cloud", description="Storage mode: local or cloud")
 
 
@@ -130,10 +137,11 @@ class FileExistsResponse(BaseModel):
 
 class SignedUrlRequest(BaseModel):
     """Request to generate a presigned S3 URL."""
-    path: str = Field(..., description="File path (scoped automatically by org)")
+    path: str = Field(..., description="File path relative to location root (NOT including scope segment)")
     method: Literal["PUT", "GET"] = Field(default="PUT", description="HTTP method: PUT for upload, GET for download")
     content_type: str = Field(default="application/octet-stream", description="MIME type (only used for PUT)")
-    scope: str | None = Field(default=None, description="Organization scope (auto-resolved from context if None)")
+    location: str = Field(default="uploads", description="Storage location. Defaults to 'uploads' for backwards compatibility with form upload flows.")
+    scope: str | None = Field(default=None, description="Org scope. Required for non-workspace, non-uploads locations.")
 
 
 class SignedUrlResponse(BaseModel):
@@ -158,7 +166,7 @@ async def read_file(
     """Read a file from workspace, temp, or uploads."""
     try:
         backend = get_backend(request.mode, db)
-        content = await backend.read(request.path, request.location)
+        content = await backend.read(request.path, request.location, scope=request.scope)
 
         if request.binary:
             return FileReadResponse(content=base64.b64encode(content).decode(), binary=True)
@@ -198,7 +206,16 @@ async def write_file(
             content = request.content.encode("utf-8")
 
         updated_by = user.email if user else "system"
-        await backend.write(request.path, content, request.location, updated_by)
+        if request.location == "workspace" and request.mode == "cloud":
+            if await _is_workspace_git_locked():
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Workspace contains a .git directory; writes are blocked when the "
+                        "workspace is git-controlled."
+                    ),
+                )
+        await backend.write(request.path, content, request.location, updated_by, scope=request.scope)
 
         logger.info(f"Wrote file: {log_safe(request.path)} ({len(content)} bytes, mode={log_safe(request.mode)}, location={log_safe(request.location)})")
 
@@ -219,7 +236,7 @@ async def delete_file(
     """Delete a file from workspace, temp, or uploads."""
     try:
         backend = get_backend(request.mode, db)
-        await backend.delete(request.path, request.location)
+        await backend.delete(request.path, request.location, scope=request.scope)
 
         logger.info(f"Deleted file: {log_safe(request.path)} (mode={log_safe(request.mode)}, location={log_safe(request.location)})")
 
@@ -280,7 +297,7 @@ async def list_files_simple(
             )
 
         backend = get_backend(request.mode, db)
-        files = await backend.list(request.directory, request.location)
+        files = await backend.list(request.directory, request.location, scope=request.scope)
         return FileListResponse(files=files)
 
     except ValueError as e:
@@ -300,7 +317,7 @@ async def file_exists(
     """Check if a file exists."""
     try:
         backend = get_backend(request.mode, db)
-        exists = await backend.exists(request.path, request.location)
+        exists = await backend.exists(request.path, request.location, scope=request.scope)
         return FileExistsResponse(exists=exists)
 
     except ValueError as e:
@@ -310,8 +327,6 @@ async def file_exists(
         )
 
 
-RESERVED_PREFIXES = ("_repo/", "_apps/", "_tmp/")
-
 @router.post("/signed-url", response_model=SignedUrlResponse)
 async def get_signed_url(
     request: SignedUrlRequest,
@@ -319,25 +334,29 @@ async def get_signed_url(
     user: CurrentSuperuser,
     db: AsyncSession = Depends(get_db),
 ) -> SignedUrlResponse:
-    """Generate a presigned S3 URL for direct file upload or download."""
-    # Validate path - no traversal
-    if ".." in request.path or request.path.startswith("/"):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid path: must be relative and cannot contain '..'",
-        )
+    """Generate a presigned S3 URL for direct file upload or download.
 
-    # Block reserved prefixes
-    for prefix in RESERVED_PREFIXES:
-        if request.path.startswith(prefix):
+    Path resolution goes through `shared.file_paths.resolve_s3_key`, so the
+    URL targets the same key as a `files.read`/`files.write` to the same
+    `(location, scope, path)`. For workspace writes, requires the workspace
+    to not be a checked-out git repo (`_repo/.git/` absent).
+    """
+    from shared.file_paths import resolve_s3_key
+
+    try:
+        s3_path = resolve_s3_key(request.location, request.scope, request.path)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    if request.location == "workspace" and request.method == "PUT":
+        if await _is_workspace_git_locked():
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid path: '{prefix}' is a reserved prefix",
+                detail=(
+                    "Workspace contains a .git directory; signed-url uploads to workspace "
+                    "are blocked when the workspace is git-controlled."
+                ),
             )
-
-    # Build scoped S3 path
-    scope = request.scope or "global"
-    s3_path = f"uploads/{scope}/{request.path}"
 
     file_storage = FileStorageService(db)
 
@@ -355,6 +374,14 @@ async def get_signed_url(
         url=url,
         path=s3_path,
     )
+
+
+async def _is_workspace_git_locked() -> bool:
+    """Return True if `_repo/.git/` exists in the bucket — workspace is git-controlled."""
+    from src.services.repo_storage import RepoStorage
+    repo = RepoStorage()
+    children = await repo.list(".git/")
+    return len(children) > 0
 
 
 # =============================================================================

--- a/api/src/routers/forms.py
+++ b/api/src/routers/forms.py
@@ -1126,16 +1126,24 @@ async def generate_upload_url(
                         detail=f"File size {request.file_size} bytes exceeds maximum {field.max_size_mb}MB",
                     )
 
-    # Generate unique path for upload
+    # Generate the upload's relative path. The full S3 key is built by the
+    # unified files resolver: `uploads/{scope}/{relative_path}`. Scope is the
+    # caller's effective org (matches what the workflow's SDK will resolve to
+    # when it reads the file with `location="uploads"` and no explicit scope).
+    from shared.file_paths import resolve_s3_key
     file_uuid = str(uuid4())
     sanitized_name = _sanitize_filename(request.file_name)
-    path = f"uploads/{form_id}/{file_uuid}/{sanitized_name}"
+    relative_path = f"{form_id}/{file_uuid}/{sanitized_name}"
+    upload_scope = str(ctx.org_id) if ctx.org_id else "global"
+    s3_key = resolve_s3_key("uploads", upload_scope, relative_path)
 
-    # Generate presigned URL
+    # Generate presigned URL against the full S3 key, but surface the
+    # location-relative path to callers so workflows can use
+    # `files.read(blob_uri, location="uploads")` without prefix-stripping.
     storage = FileStorageService(db)
     try:
         upload_url = await storage.generate_presigned_upload_url(
-            path=path,
+            path=s3_key,
             content_type=request.content_type,
             expires_in=600,  # 10 minutes
         )
@@ -1151,12 +1159,12 @@ async def generate_upload_url(
 
     return FileUploadResponse(
         upload_url=upload_url,
-        blob_uri=path,
+        blob_uri=relative_path,
         expires_at=expires_at,
         file_metadata=UploadedFileMetadata(
             name=request.file_name,
-            container="uploads",  # Root folder prefix
-            path=path,
+            container="uploads",
+            path=relative_path,
             content_type=request.content_type,
             size=request.file_size,
         ),

--- a/api/src/routers/packages.py
+++ b/api/src/routers/packages.py
@@ -29,6 +29,7 @@ from src.core.redis_client import get_redis_client
 from src.core.requirements_cache import (
     append_package_to_requirements,
     get_requirements,
+    remove_package_from_requirements,
     save_requirements,
     warm_requirements_cache,
 )
@@ -371,52 +372,47 @@ async def uninstall_package(
     ctx: Context,
     user: CurrentSuperuser,
 ) -> dict:
-    """
-    Uninstall a Python package.
+    """Uninstall a package: drop it from requirements.txt and recycle workers.
 
-    In production, this would queue a RabbitMQ job for background uninstall.
-    For now, it attempts direct uninstallation using async subprocess.
-
-    Args:
-        package_name: Name of the package to uninstall
-
-    Returns:
-        Confirmation message
+    Mirrors `install_package` — workers re-pip-install from requirements.txt on
+    recycle, and any package removed from requirements is gone after the next
+    process spawn.
     """
     try:
         logger.info(f"Uninstalling package: {log_safe(package_name)}")
 
-        # In production, this would be queued as a job
-        # For now, attempt direct uninstallation using async subprocess
-        proc = await asyncio.create_subprocess_exec(
-            "pip", "uninstall", "-y", package_name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        cached = await get_requirements()
+        if not cached:
+            await warm_requirements_cache()
+            cached = await get_requirements()
+        current_content = cached["content"] if cached else ""
+        updated_content, was_present = remove_package_from_requirements(
+            current_content, package_name
         )
 
-        try:
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
-            logger.error(f"Package uninstallation timed out: {log_safe(package_name)}")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Package uninstallation timed out",
-            )
+        if was_present:
+            await save_requirements(updated_content)
+            logger.info(f"Removed {log_safe(package_name)} from requirements.txt")
 
-        if proc.returncode != 0:
-            logger.error(f"pip uninstall failed: {stderr.decode()}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Package uninstallation failed: {stderr.decode()}",
-            )
-
-        logger.info(f"Successfully uninstalled package: {log_safe(package_name)}")
+        # Tell workers to pip uninstall and recycle. The "action" field
+        # is what distinguishes install from uninstall in the consumer.
+        await publish_broadcast(
+            exchange_name="package-installations",
+            message={
+                "type": "recycle_workers",
+                "action": "uninstall",
+                "package": package_name,
+                "version": None,
+                "is_update": True,
+            },
+        )
 
         return {
-            "message": f"Package '{package_name}' uninstalled successfully",
+            "message": (
+                f"Package '{package_name}' removed from requirements; workers recycling."
+            ),
             "status": "uninstalled",
+            "was_present": was_present,
         }
 
     except HTTPException:

--- a/api/src/services/file_backend.py
+++ b/api/src/services/file_backend.py
@@ -4,47 +4,50 @@ File Backend Abstraction
 Provides unified interface for file operations with two backends:
 - LocalBackend: Local filesystem (for CLI mode)
 - S3Backend: S3 storage (for cloud/platform mode)
+
+S3 key resolution is delegated to `shared.file_paths.resolve_s3_key`.
 """
 
 import asyncio
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from shared.file_paths import resolve_s3_key
 from src.core.paths import TEMP_PATH, UPLOADS_PATH
 from src.services.file_storage import FileStorageService
-from src.services.repo_storage import REPO_PREFIX
 
-Location = Literal["workspace", "temp", "uploads"]
+# Location is now a free string validated by `shared.file_paths`. Keep the type
+# alias for callers that want documentation, but allow any string at runtime.
+Location = str
 
 
 class FileBackend(ABC):
     """Abstract backend for file operations."""
 
     @abstractmethod
-    async def read(self, path: str, location: Location) -> bytes:
+    async def read(self, path: str, location: Location, scope: str | None = None) -> bytes:
         """Read file content."""
         ...
 
     @abstractmethod
-    async def write(self, path: str, content: bytes, location: Location, updated_by: str = "system") -> None:
+    async def write(self, path: str, content: bytes, location: Location, updated_by: str = "system", scope: str | None = None) -> None:
         """Write file content."""
         ...
 
     @abstractmethod
-    async def delete(self, path: str, location: Location) -> None:
+    async def delete(self, path: str, location: Location, scope: str | None = None) -> None:
         """Delete a file."""
         ...
 
     @abstractmethod
-    async def list(self, directory: str, location: Location) -> list[str]:
+    async def list(self, directory: str, location: Location, scope: str | None = None) -> list[str]:
         """List files in a directory."""
         ...
 
     @abstractmethod
-    async def exists(self, path: str, location: Location) -> bool:
+    async def exists(self, path: str, location: Location, scope: str | None = None) -> bool:
         """Check if a file exists."""
         ...
 
@@ -63,13 +66,19 @@ class LocalBackend(FileBackend):
         self.uploads_root.mkdir(parents=True, exist_ok=True)
 
     def _resolve_path(self, path: str, location: Location) -> Path:
-        """Resolve path to absolute filesystem path with sandboxing."""
+        """Resolve path to absolute filesystem path with sandboxing.
+
+        Local mode is unscoped — used for CLI development without multi-tenancy.
+        """
         if location == "temp":
             base_dir = self.temp_root
         elif location == "uploads":
             base_dir = self.uploads_root
-        else:
+        elif location == "workspace":
             base_dir = self.workspace_root
+        else:
+            # Freeform local locations are siblings of workspace_root.
+            base_dir = self.workspace_root.parent / location
 
         # Resolve the path
         p = Path(path)
@@ -92,27 +101,27 @@ class LocalBackend(FileBackend):
 
         return p
 
-    async def read(self, path: str, location: Location) -> bytes:
-        """Read file from local filesystem."""
+    async def read(self, path: str, location: Location, scope: str | None = None) -> bytes:
+        """Read file from local filesystem. Scope is ignored in local mode."""
         resolved = self._resolve_path(path, location)
         if not resolved.exists():
             raise FileNotFoundError(f"File not found: {path}")
         return await asyncio.to_thread(resolved.read_bytes)
 
-    async def write(self, path: str, content: bytes, location: Location, updated_by: str = "system") -> None:
-        """Write file to local filesystem."""
+    async def write(self, path: str, content: bytes, location: Location, updated_by: str = "system", scope: str | None = None) -> None:
+        """Write file to local filesystem. Scope is ignored in local mode."""
         resolved = self._resolve_path(path, location)
         resolved.parent.mkdir(parents=True, exist_ok=True)
         await asyncio.to_thread(resolved.write_bytes, content)
 
-    async def delete(self, path: str, location: Location) -> None:
-        """Delete file from local filesystem."""
+    async def delete(self, path: str, location: Location, scope: str | None = None) -> None:
+        """Delete file from local filesystem. Scope is ignored in local mode."""
         resolved = self._resolve_path(path, location)
         if resolved.exists():
             await asyncio.to_thread(resolved.unlink)
 
-    async def list(self, directory: str, location: Location) -> list[str]:
-        """List files in a local directory."""
+    async def list(self, directory: str, location: Location, scope: str | None = None) -> list[str]:
+        """List files in a local directory. Scope is ignored in local mode."""
         resolved = self._resolve_path(directory, location)
         if not resolved.exists():
             return []
@@ -128,8 +137,8 @@ class LocalBackend(FileBackend):
 
         return await asyncio.to_thread(_list_dir)
 
-    async def exists(self, path: str, location: Location) -> bool:
-        """Check if file exists on local filesystem."""
+    async def exists(self, path: str, location: Location, scope: str | None = None) -> bool:
+        """Check if file exists on local filesystem. Scope is ignored in local mode."""
         try:
             resolved = self._resolve_path(path, location)
             return await asyncio.to_thread(resolved.exists)
@@ -144,36 +153,18 @@ class S3Backend(FileBackend):
         self.db = db
         self.storage = FileStorageService(db)
 
-    def _validate_path(self, path: str) -> None:
-        """Validate path doesn't contain traversal patterns."""
-        # Reject paths with .. or absolute paths
-        if ".." in path or path.startswith("/"):
-            raise ValueError(f"Invalid path: path traversal not allowed: {path}")
-
-    def _resolve_path(self, path: str, location: Location) -> str:
-        """Resolve path to S3 key with location prefix."""
-        self._validate_path(path)
-        if location == "temp":
-            return f"_tmp/{path}"
-        elif location == "uploads":
-            return f"uploads/{path}"
-        return f"{REPO_PREFIX}{path}"  # workspace: _repo/ prefix in bucket
-
-    async def read(self, path: str, location: Location) -> bytes:
+    async def read(self, path: str, location: Location, scope: str | None = None) -> bytes:
         """Read file from S3."""
-        self._validate_path(path)
         try:
-            if location in ("temp", "uploads"):
-                # Direct S3 read — temp/uploads don't go through workspace index
-                s3_path = self._resolve_path(path, location)
-                return await self.storage.read_uploaded_file(s3_path)
-            # Workspace: pass raw path — read_file adds _repo/ prefix internally
-            content, _ = await self.storage.read_file(path)
-            return content
+            if location == "workspace":
+                # Workspace goes through the indexed read path so file_index stays in sync.
+                content, _ = await self.storage.read_file(path)
+                return content
+            s3_path = resolve_s3_key(location, scope, path)
+            return await self.storage.read_uploaded_file(s3_path)
         except (FileNotFoundError, ValueError):
             raise
         except Exception as e:
-            # Convert S3 errors to appropriate exceptions
             error_msg = str(e).lower()
             if "not found" in error_msg or "nosuchkey" in error_msg:
                 raise FileNotFoundError(f"File not found: {path}")
@@ -181,43 +172,37 @@ class S3Backend(FileBackend):
                 raise ValueError(f"Invalid path: {path}")
             raise
 
-    async def write(self, path: str, content: bytes, location: Location, updated_by: str = "system") -> None:
+    async def write(self, path: str, content: bytes, location: Location, updated_by: str = "system", scope: str | None = None) -> None:
         """Write file to S3."""
-        self._validate_path(path)
-        if location in ("temp", "uploads"):
-            # No workspace indexing for temp/uploads - write directly to S3
-            s3_path = self._resolve_path(path, location)
-            await self.storage.write_raw_to_s3(s3_path, content)
-        else:
-            # Workspace: pass raw path — write_file adds _repo/ prefix internally
+        if location == "workspace":
             await self.storage.write_file(path, content, updated_by)
+            return
+        s3_path = resolve_s3_key(location, scope, path)
+        await self.storage.write_raw_to_s3(s3_path, content)
 
-    async def delete(self, path: str, location: Location) -> None:
+    async def delete(self, path: str, location: Location, scope: str | None = None) -> None:
         """Delete file from S3."""
-        self._validate_path(path)
-        if location in ("temp", "uploads"):
-            # Direct S3 delete for temp/uploads
-            s3_path = self._resolve_path(path, location)
-            await self.storage.delete_raw_from_s3(s3_path)
-        else:
-            # Workspace: pass raw path — delete_file adds _repo/ prefix internally
+        if location == "workspace":
             await self.storage.delete_file(path)
+            return
+        s3_path = resolve_s3_key(location, scope, path)
+        await self.storage.delete_raw_from_s3(s3_path)
 
-    async def list(self, directory: str, location: Location) -> list[str]:
+    async def list(self, directory: str, location: Location, scope: str | None = None) -> list[str]:
         """List files in S3 directory."""
-        self._validate_path(directory)
-        if location in ("temp", "uploads"):
-            # Direct S3 listing for temp/uploads
-            s3_dir = self._resolve_path(directory, location)
-            return await self.storage.list_raw_s3(s3_dir)
-        else:
-            # Workspace: pass raw path — list_files adds _repo/ prefix internally
+        if location == "workspace":
             files = await self.storage.list_files(directory)
             return [f.path for f in files]
+        s3_dir = resolve_s3_key(location, scope, directory)
+        return await self.storage.list_raw_s3(s3_dir)
 
-    async def exists(self, path: str, location: Location) -> bool:
+    async def exists(self, path: str, location: Location, scope: str | None = None) -> bool:
         """Check if file exists in S3."""
-        s3_path = self._resolve_path(path, location)
+        if location == "workspace":
+            from src.services.repo_storage import REPO_PREFIX
+            s3_path = f"{REPO_PREFIX}{path.lstrip('/')}"
+        else:
+            s3_path = resolve_s3_key(location, scope, path)
         return await self.storage.file_exists(s3_path)
 
 

--- a/api/src/services/mcp_server/tools/forms.py
+++ b/api/src/services/mcp_server/tools/forms.py
@@ -122,14 +122,14 @@ Use `list_workflows` to see available data providers. For `@data_provider` decor
     file_upload_docs = """
 ## File Upload Fields
 
-Use `type: "file"` to accept file uploads in forms. Uploaded files are stored in S3 and the workflow receives their paths as strings.
+Use `type: "file"` to accept file uploads in forms. Uploaded files are stored in S3 under `uploads/{scope}/{form_id}/{uuid}/{filename}`. The workflow receives the **location-relative** path — pass it straight to `files.read(..., location="uploads")` and the SDK adds `uploads/{scope}/`.
 
 ### What the workflow receives
 
 | Scenario | Parameter value |
 |----------|----------------|
-| Single file (`multiple: false`) | `"uploads/abc123/report.pdf"` (string) |
-| Multiple files (`multiple: true`) | `["uploads/abc123/a.pdf", "uploads/abc123/b.pdf"]` (list of strings) |
+| Single file (`multiple: false`) | `"abc123/uuid/report.pdf"` (string, relative to `uploads/`) |
+| Multiple files (`multiple: true`) | `["abc123/uuid/a.pdf", "abc123/uuid/b.pdf"]` (list of strings) |
 
 ### Reading uploaded files in a workflow
 
@@ -138,6 +138,7 @@ from bifrost import workflow, files
 
 @workflow
 async def process_upload(document: str) -> dict:
+    # SDK resolves to uploads/{your_scope}/{document}
     content = await files.read(document, location="uploads")
     return {"size": len(content)}
 ```

--- a/api/src/services/mcp_server/tools/sdk.py
+++ b/api/src/services/mcp_server/tools/sdk.py
@@ -16,6 +16,64 @@ from src.services.mcp_server.tool_result import error_result, success_result
 logger = logging.getLogger(__name__)
 
 
+_FILE_LOCATIONS_DOCS = """## File Locations
+
+The `files` module resolves every operation as `{location}/{scope}/{path}`,
+with `scope` derived from the current execution's organization. `workspace`
+is the only unscoped location.
+
+**Reserved locations:**
+
+| Location | Usage | Example |
+|----------|-------|---------|
+| `"workspace"` (default) | Platform codebase, shared across orgs | `files.read("data/report.csv")` |
+| `"uploads"` | Files uploaded via form file fields | `files.read(path, location="uploads")` |
+| `"temp"` | Ephemeral scratch space | `files.write("scratch.txt", content, location="temp")` |
+
+**Freeform locations** are user-defined (e.g. `"reports"`, `"exports"`) and
+resolve as `{location}/{scope}/{path}`. Names must match `^[a-z0-9][a-z0-9-]*$`.
+
+```python
+await files.write_bytes("q1.pdf", pdf, location="reports")
+# stored at reports/{your_org_id}/q1.pdf
+```
+
+### Form file upload pattern
+
+When a form has a `file` field, the workflow parameter receives a path that is
+relative to the `uploads` location (e.g. `{form_id}/{uuid}/{filename}`). Pass it
+straight to `files.read(..., location="uploads")` — the SDK adds the scope.
+
+```python
+from bifrost import workflow, files
+
+@workflow
+async def handle_upload(resume: str, cover_letters: list[str]) -> dict:
+    resume_bytes = await files.read(resume, location="uploads")
+    letters = []
+    for path in cover_letters:
+        letters.append(await files.read(path, location="uploads"))
+    return {"resume_size": len(resume_bytes), "letter_count": len(letters)}
+```
+
+### Signed URLs for direct browser access
+
+`files.get_signed_url(path, location=..., method="GET"|"PUT")` produces a
+presigned S3 URL targeting the same key as `files.read`/`files.write` for the
+same `(location, path)`. Useful for generating PDFs, CSVs, or other files in a
+workflow and handing the browser a direct download URL.
+
+```python
+await files.write_bytes("report.pdf", pdf_bytes, location="workspace")
+signed = await files.get_signed_url(
+    "report.pdf", method="GET", location="workspace",
+    content_type="application/pdf",
+)
+return {"download_url": signed["url"]}
+```
+"""
+
+
 def _extract_class_methods(cls: type) -> list[dict[str, Any]]:
     """Extract method signatures and docstrings from a class."""
     methods = []
@@ -356,34 +414,7 @@ async def get_sdk_schema(context: Any) -> ToolResult:  # noqa: ARG001
             if doc:
                 lines.append(doc)
 
-        # File locations documentation
-        lines.append("## File Locations")
-        lines.append("")
-        lines.append("The `files` module operates on three storage locations:")
-        lines.append("")
-        lines.append("| Location | Usage | Example |")
-        lines.append("|----------|-------|---------|")
-        lines.append('| `"workspace"` (default) | General-purpose file storage for workflows | `files.read("data/report.csv")` |')
-        lines.append('| `"temp"` | Temporary files scoped to a single execution | `files.write("scratch.txt", content, location="temp")` |')
-        lines.append('| `"uploads"` | Files uploaded via form file fields (read-only) | `files.read(path, location="uploads")` |')
-        lines.append("")
-        lines.append("### Form file upload pattern")
-        lines.append("")
-        lines.append("When a form has a `file` field, the workflow parameter receives the S3 path as a string")
-        lines.append("(or a list of strings if `multiple: true`). Read the file with `location=\"uploads\"`:")
-        lines.append("")
-        lines.append("```python")
-        lines.append("from bifrost import workflow, files")
-        lines.append("")
-        lines.append("@workflow")
-        lines.append("async def handle_upload(resume: str, cover_letters: list[str]) -> dict:")
-        lines.append('    resume_bytes = await files.read(resume, location="uploads")')
-        lines.append("    letters = []")
-        lines.append("    for path in cover_letters:")
-        lines.append('        letters.append(await files.read(path, location="uploads"))')
-        lines.append('    return {"resume_size": len(resume_bytes), "letter_count": len(letters)}')
-        lines.append("```")
-        lines.append("")
+        lines.append(_FILE_LOCATIONS_DOCS)
 
         # Generate models docs
         lines.append(_generate_models_docs())

--- a/api/tests/e2e/api/test_cli.py
+++ b/api/tests/e2e/api/test_cli.py
@@ -259,6 +259,7 @@ class TestCLIFileOperations:
                 "path": test_path,
                 "content": test_content,
                 "location": "temp",
+                "scope": "test-scope",
                 "mode": "cloud",
             },
             headers=headers,
@@ -271,6 +272,7 @@ class TestCLIFileOperations:
             json={
                 "path": test_path,
                 "location": "temp",
+                "scope": "test-scope",
                 "mode": "cloud",
             },
             headers=headers,
@@ -282,7 +284,7 @@ class TestCLIFileOperations:
         # Cleanup
         e2e_client.post(
             "/api/files/delete",
-            json={"path": test_path, "location": "temp", "mode": "cloud"},
+            json={"path": test_path, "location": "temp", "scope": "test-scope", "mode": "cloud"},
             headers=headers,
         )
 
@@ -301,6 +303,7 @@ class TestCLIFileOperations:
                 "path": "list-test.txt",
                 "content": "test content",
                 "location": "temp",
+                "scope": "test-scope",
                 "mode": "cloud",
             },
             headers=headers,
@@ -313,6 +316,7 @@ class TestCLIFileOperations:
             json={
                 "directory": "",
                 "location": "temp",
+                "scope": "test-scope",
                 "mode": "cloud",
             },
             headers=headers,
@@ -324,7 +328,7 @@ class TestCLIFileOperations:
         # Cleanup
         e2e_client.post(
             "/api/files/delete",
-            json={"path": "list-test.txt", "location": "temp", "mode": "cloud"},
+            json={"path": "list-test.txt", "location": "temp", "scope": "test-scope", "mode": "cloud"},
             headers=headers,
         )
 
@@ -344,6 +348,7 @@ class TestCLIFileOperations:
                 "path": test_path,
                 "content": "to be deleted",
                 "location": "temp",
+                "scope": "test-scope",
                 "mode": "cloud",
             },
             headers=headers,
@@ -353,7 +358,7 @@ class TestCLIFileOperations:
         # Delete file
         response = e2e_client.post(
             "/api/files/delete",
-            json={"path": test_path, "location": "temp", "mode": "cloud"},
+            json={"path": test_path, "location": "temp", "scope": "test-scope", "mode": "cloud"},
             headers=headers,
         )
         assert response.status_code == 204, f"Delete failed: {response.text}"
@@ -361,7 +366,7 @@ class TestCLIFileOperations:
         # Verify deleted
         response = e2e_client.post(
             "/api/files/read",
-            json={"path": test_path, "location": "temp", "mode": "cloud"},
+            json={"path": test_path, "location": "temp", "scope": "test-scope", "mode": "cloud"},
             headers=headers,
         )
         assert response.status_code == 404
@@ -379,6 +384,7 @@ class TestCLIFileOperations:
             json={
                 "path": "nonexistent-file-12345.txt",
                 "location": "temp",
+                "scope": "test-scope",
                 "mode": "cloud",
             },
             headers=headers,
@@ -399,6 +405,7 @@ class TestCLIFileOperations:
             json={
                 "path": "../../../etc/passwd",
                 "location": "temp",
+                "scope": "test-scope",
                 "mode": "cloud",
             },
             headers=headers,

--- a/api/tests/e2e/api/test_executions.py
+++ b/api/tests/e2e/api/test_executions.py
@@ -971,19 +971,41 @@ def get_value():
         workflow_name = "e2e_package_test_workflow"
         workflow_path = f"{workflow_name}.py"
 
-        # First, check if package is already installed and uninstall it
-        response = e2e_client.get(
-            "/api/packages",
-            headers=platform_admin.headers,
-        )
-        if response.status_code == 200:
+        def _ensure_package_uninstalled() -> None:
+            """Ensure `package_name` is not installed before the test runs.
+
+            DELETE /api/packages/{name} is async — pip uninstall + worker recycle
+            takes seconds. Without polling here, a leaked install from a prior
+            run (or a prior crashed test) leaves the package present and step 2
+            of this test fails because `import humanize` succeeds when we
+            expect `ModuleNotFoundError`.
+            """
+            response = e2e_client.get("/api/packages", headers=platform_admin.headers)
+            if response.status_code != 200:
+                return
             packages = response.json().get("packages", [])
-            if any(p.get("name", "").lower() == package_name for p in packages):
-                # Uninstall it first to ensure clean test
-                e2e_client.delete(
-                    f"/api/packages/{package_name}",
-                    headers=platform_admin.headers,
-                )
+            if not any(p.get("name", "").lower() == package_name for p in packages):
+                return
+            e2e_client.delete(
+                f"/api/packages/{package_name}",
+                headers=platform_admin.headers,
+            )
+
+            def check_gone():
+                r = e2e_client.get("/api/packages", headers=platform_admin.headers)
+                if r.status_code == 200:
+                    pkgs = r.json().get("packages", [])
+                    if not any(p.get("name", "").lower() == package_name for p in pkgs):
+                        return True
+                return None
+
+            assert poll_until(check_gone, max_wait=20.0), (
+                f"Package '{package_name}' still installed after uninstall — "
+                "worker recycle may have hung."
+            )
+
+        # Pre-test: clear any leaked install from a prior (possibly crashed) run.
+        _ensure_package_uninstalled()
 
         # Step 1: Create workflow that imports humanize
         workflow_content = f'''"""Package Test Workflow"""
@@ -1077,11 +1099,9 @@ async def {workflow_name}(number: int = 1000000):
                 f"/api/files/editor?path={workflow_path}",
                 headers=platform_admin.headers,
             )
-            # Cleanup: uninstall package
-            e2e_client.delete(
-                f"/api/packages/{package_name}",
-                headers=platform_admin.headers,
-            )
+            # Cleanup: uninstall package and wait for it to actually go away
+            # (DELETE returns before pip uninstall + worker recycle complete).
+            _ensure_package_uninstalled()
 
     def test_nested_module_package_update_reflected(self, e2e_client, platform_admin):
         """Updates to nested package modules are reflected immediately.

--- a/api/tests/e2e/api/test_file_uploads.py
+++ b/api/tests/e2e/api/test_file_uploads.py
@@ -74,9 +74,14 @@ class TestFileUploads:
         assert "expires_at" in data, "Missing expires_at"
         assert "file_metadata" in data, "Missing file_metadata"
 
-        # Verify blob_uri format
-        assert data["blob_uri"].startswith("uploads/"), (
+        # blob_uri is now the path relative to the uploads/ location:
+        # `{form_id}/{uuid}/{filename}`. The full S3 key is
+        # `uploads/{scope}/{blob_uri}` and the SDK handles that translation.
+        assert "/" in data["blob_uri"], (
             f"Invalid blob_uri: {data['blob_uri']}"
+        )
+        assert not data["blob_uri"].startswith("uploads/"), (
+            f"blob_uri should be location-relative, got: {data['blob_uri']}"
         )
 
         # Verify file metadata
@@ -142,7 +147,10 @@ class TestFileUploads:
         )
         upload_data = response.json()
         upload_url = upload_data["upload_url"]
-        blob_uri = upload_data["blob_uri"]
+        # blob_uri is the path relative to the `uploads` location — pass it
+        # straight to `files.read(..., location="uploads")` and the SDK adds
+        # the `uploads/{scope}/` prefix.
+        file_path_for_workflow = upload_data["blob_uri"]
 
         # Upload file content
         file_content = b"Test file content for E2E upload test.\nLine 2."
@@ -155,11 +163,6 @@ class TestFileUploads:
         assert s3_response.status_code in [200, 201, 204], (
             f"S3 upload failed: {s3_response.status_code}"
         )
-
-        # Strip the "uploads/" prefix since location="uploads" adds it
-        # blob_uri is like "uploads/form_id/uuid/filename.txt"
-        # but files.read with location="uploads" expects "form_id/uuid/filename.txt"
-        file_path_for_workflow = blob_uri.removeprefix("uploads/")
 
         # Create workflow that reads the file
         workflow_content = '''"""E2E File Read Test Workflow"""

--- a/api/tests/e2e/api/test_files_signed_url_roundtrip.py
+++ b/api/tests/e2e/api/test_files_signed_url_roundtrip.py
@@ -1,0 +1,190 @@
+"""
+E2E round-trip tests for /api/files/signed-url across all locations.
+
+The bug this issue fixed: signed URLs always pointed at `uploads/{scope}/{path}`
+regardless of where the file actually lived. Now signed URLs share the same
+path resolver as `read`/`write`, so a file written via
+`/api/files/write` with `location=workspace` is reachable via
+`/api/files/signed-url` with `location=workspace`.
+"""
+
+import base64
+import secrets
+import uuid
+
+import httpx
+import pytest
+
+
+@pytest.mark.e2e
+class TestSignedUrlRoundTrip:
+    """For every location, write-then-sign-then-fetch must return the same bytes."""
+
+    def _write(self, e2e_client, headers, path: str, location: str, content: bytes, scope: str | None = None):
+        body = {
+            "path": path,
+            "content": base64.b64encode(content).decode("ascii"),
+            "location": location,
+            "binary": True,
+            "scope": scope,
+        }
+        return e2e_client.post("/api/files/write", headers=headers, json=body)
+
+    def _sign(self, e2e_client, headers, path: str, location: str, scope: str | None = None):
+        body = {
+            "path": path,
+            "method": "GET",
+            "location": location,
+            "content_type": "application/octet-stream",
+            "scope": scope,
+        }
+        return e2e_client.post("/api/files/signed-url", headers=headers, json=body)
+
+    def test_workspace_roundtrip(self, e2e_client, platform_admin):
+        path = f"e2e/{uuid.uuid4().hex}.bin"
+        content = secrets.token_bytes(64)
+
+        write = self._write(e2e_client, platform_admin.headers, path, "workspace", content)
+        if write.status_code == 400 and "git" in write.text.lower():
+            pytest.skip("workspace is git-controlled; skipping write-side roundtrip")
+        assert write.status_code == 204, f"write failed: {write.text}"
+
+        sign = self._sign(e2e_client, platform_admin.headers, path, "workspace")
+        assert sign.status_code == 200, f"sign failed: {sign.text}"
+        signed = sign.json()
+        assert signed["path"] == f"_repo/{path}", (
+            f"workspace sign should target _repo/, got {signed['path']}"
+        )
+
+        with httpx.Client(timeout=30.0) as s3:
+            r = s3.get(signed["url"])
+        assert r.status_code == 200, f"download via signed URL failed: {r.status_code} {r.text[:200]}"
+        assert r.content == content, "downloaded bytes don't match what was written"
+
+        # Cleanup
+        e2e_client.post(
+            "/api/files/delete",
+            headers=platform_admin.headers,
+            json={"path": path, "location": "workspace"},
+        )
+
+    def test_temp_roundtrip(self, e2e_client, platform_admin):
+        path = f"e2e/{uuid.uuid4().hex}.bin"
+        content = secrets.token_bytes(64)
+        scope = "e2e-org"
+
+        write = self._write(e2e_client, platform_admin.headers, path, "temp", content, scope=scope)
+        assert write.status_code == 204, f"write failed: {write.text}"
+
+        sign = self._sign(e2e_client, platform_admin.headers, path, "temp", scope=scope)
+        assert sign.status_code == 200, f"sign failed: {sign.text}"
+        signed = sign.json()
+        assert signed["path"] == f"_tmp/{scope}/{path}", (
+            f"temp sign should target _tmp/{scope}/{path}, got {signed['path']}"
+        )
+
+        with httpx.Client(timeout=30.0) as s3:
+            r = s3.get(signed["url"])
+        assert r.status_code == 200, f"download failed: {r.status_code} {r.text[:200]}"
+        assert r.content == content
+
+    def test_uploads_roundtrip(self, e2e_client, platform_admin):
+        path = f"e2e-{uuid.uuid4().hex}/upload.bin"
+        content = secrets.token_bytes(64)
+        scope = "e2e-org"
+
+        write = self._write(e2e_client, platform_admin.headers, path, "uploads", content, scope=scope)
+        assert write.status_code == 204, f"write failed: {write.text}"
+
+        sign = self._sign(e2e_client, platform_admin.headers, path, "uploads", scope=scope)
+        assert sign.status_code == 200, f"sign failed: {sign.text}"
+        signed = sign.json()
+        assert signed["path"] == f"uploads/{scope}/{path}", (
+            f"uploads sign should target uploads/{scope}/{path}, got {signed['path']}"
+        )
+
+        with httpx.Client(timeout=30.0) as s3:
+            r = s3.get(signed["url"])
+        assert r.status_code == 200, f"download failed: {r.status_code} {r.text[:200]}"
+        assert r.content == content
+
+    def test_freeform_location_roundtrip(self, e2e_client, platform_admin):
+        path = f"e2e-{uuid.uuid4().hex}/q1.bin"
+        content = secrets.token_bytes(64)
+        location = "reports"
+        scope = "e2e-org"
+
+        write = self._write(e2e_client, platform_admin.headers, path, location, content, scope=scope)
+        assert write.status_code == 204, f"write failed: {write.text}"
+
+        sign = self._sign(e2e_client, platform_admin.headers, path, location, scope=scope)
+        assert sign.status_code == 200, f"sign failed: {sign.text}"
+        signed = sign.json()
+        assert signed["path"] == f"{location}/{scope}/{path}", (
+            f"freeform sign should target {location}/{scope}/{path}, got {signed['path']}"
+        )
+
+        with httpx.Client(timeout=30.0) as s3:
+            r = s3.get(signed["url"])
+        assert r.status_code == 200, f"download failed: {r.status_code} {r.text[:200]}"
+        assert r.content == content
+
+
+@pytest.mark.e2e
+class TestSignedUrlValidation:
+    def test_reserved_prefix_location_rejected(self, e2e_client, platform_admin):
+        r = e2e_client.post(
+            "/api/files/signed-url",
+            headers=platform_admin.headers,
+            json={
+                "path": "x.txt",
+                "method": "GET",
+                "location": "_repo",
+                "content_type": "text/plain",
+            },
+        )
+        assert r.status_code == 400
+        assert "reserved bucket prefix" in r.text
+
+    def test_invalid_freeform_name_rejected(self, e2e_client, platform_admin):
+        r = e2e_client.post(
+            "/api/files/signed-url",
+            headers=platform_admin.headers,
+            json={
+                "path": "x.txt",
+                "method": "GET",
+                "location": "Bad Name!",
+                "content_type": "text/plain",
+            },
+        )
+        assert r.status_code == 400
+        assert "must match" in r.text or "Invalid location name" in r.text
+
+    def test_path_traversal_rejected(self, e2e_client, platform_admin):
+        r = e2e_client.post(
+            "/api/files/signed-url",
+            headers=platform_admin.headers,
+            json={
+                "path": "../etc/passwd",
+                "method": "GET",
+                "location": "uploads",
+                "content_type": "text/plain",
+            },
+        )
+        assert r.status_code == 400
+        assert "traversal" in r.text.lower()
+
+    def test_temp_requires_scope(self, e2e_client, platform_admin):
+        r = e2e_client.post(
+            "/api/files/signed-url",
+            headers=platform_admin.headers,
+            json={
+                "path": "x.txt",
+                "method": "GET",
+                "location": "temp",
+                "content_type": "text/plain",
+                "scope": None,
+            },
+        )
+        assert r.status_code == 400
+        assert "scope" in r.text.lower()

--- a/api/tests/unit/routers/test_files_signed_url.py
+++ b/api/tests/unit/routers/test_files_signed_url.py
@@ -1,7 +1,8 @@
 """
 Unit tests for POST /api/files/signed-url endpoint.
 
-Tests path validation, scope resolution, and presigned URL generation.
+Tests path validation, location/scope handling, and presigned URL generation.
+Path resolution is delegated to `shared.file_paths.resolve_s3_key`.
 """
 
 import pytest
@@ -10,7 +11,6 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from src.routers.files import (
     SignedUrlRequest,
     SignedUrlResponse,
-    RESERVED_PREFIXES,
     get_signed_url,
 )
 
@@ -22,14 +22,19 @@ class TestSignedUrlRequestModel:
         req = SignedUrlRequest(path="invoices/report.pdf")
         assert req.method == "PUT"
         assert req.content_type == "application/octet-stream"
+        assert req.location == "uploads"  # backwards-compat default
         assert req.scope is None
 
     def test_explicit_get(self):
         req = SignedUrlRequest(path="data.csv", method="GET")
         assert req.method == "GET"
 
+    def test_explicit_location(self):
+        req = SignedUrlRequest(path="file.txt", location="workspace")
+        assert req.location == "workspace"
+
     def test_explicit_scope(self):
-        req = SignedUrlRequest(path="file.txt", scope="org-123")
+        req = SignedUrlRequest(path="file.txt", location="temp", scope="org-123")
         assert req.scope == "org-123"
 
 
@@ -37,121 +42,150 @@ class TestSignedUrlResponseModel:
     """Test SignedUrlResponse shape."""
 
     def test_fields(self):
-        resp = SignedUrlResponse(url="https://s3/presigned", path="uploads/global/file.txt")
+        resp = SignedUrlResponse(url="https://s3/presigned", path="uploads/org-a/file.txt")
         assert resp.url == "https://s3/presigned"
-        assert resp.path == "uploads/global/file.txt"
+        assert resp.path == "uploads/org-a/file.txt"
         assert resp.expires_in == 600
 
 
-class TestReservedPrefixes:
-    """Test reserved prefix constants."""
+class TestPathResolution:
+    """Test that the handler delegates to shared.file_paths.resolve_s3_key."""
 
-    def test_reserved_prefixes_includes_repo(self):
-        assert "_repo/" in RESERVED_PREFIXES
+    @pytest.mark.asyncio
+    @patch("src.routers.files.FileStorageService")
+    async def test_uploads_scoped(self, mock_fss_class):
+        mock_fss = MagicMock()
+        mock_fss.generate_presigned_upload_url = AsyncMock(return_value="https://s3/url")
+        mock_fss_class.return_value = mock_fss
 
-    def test_reserved_prefixes_includes_apps(self):
-        assert "_apps/" in RESERVED_PREFIXES
+        req = SignedUrlRequest(path="report.pdf", scope="org-a")
+        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert result.path == "uploads/org-a/report.pdf"
 
-    def test_reserved_prefixes_includes_tmp(self):
-        assert "_tmp/" in RESERVED_PREFIXES
+    @pytest.mark.asyncio
+    async def test_uploads_requires_scope(self):
+        from fastapi import HTTPException
+
+        req = SignedUrlRequest(path="report.pdf")  # default location=uploads, no scope
+        with pytest.raises(HTTPException) as exc_info:
+            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert exc_info.value.status_code == 400
+        assert "scope" in str(exc_info.value.detail).lower()
+
+    @pytest.mark.asyncio
+    @patch("src.routers.files._is_workspace_git_locked", new_callable=AsyncMock, return_value=False)
+    @patch("src.routers.files.FileStorageService")
+    async def test_workspace_unscoped(self, mock_fss_class, _git_lock):
+        mock_fss = MagicMock()
+        mock_fss.generate_presigned_upload_url = AsyncMock(return_value="https://s3/url")
+        mock_fss_class.return_value = mock_fss
+
+        req = SignedUrlRequest(path="report.pdf", location="workspace")
+        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert result.path == "_repo/report.pdf"
+
+    @pytest.mark.asyncio
+    @patch("src.routers.files.FileStorageService")
+    async def test_temp_scoped(self, mock_fss_class):
+        mock_fss = MagicMock()
+        mock_fss.generate_presigned_download_url = AsyncMock(return_value="https://s3/url")
+        mock_fss_class.return_value = mock_fss
+
+        req = SignedUrlRequest(path="x.bin", location="temp", scope="org-a", method="GET")
+        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert result.path == "_tmp/org-a/x.bin"
+
+    @pytest.mark.asyncio
+    @patch("src.routers.files.FileStorageService")
+    async def test_freeform_scoped(self, mock_fss_class):
+        mock_fss = MagicMock()
+        mock_fss.generate_presigned_download_url = AsyncMock(return_value="https://s3/url")
+        mock_fss_class.return_value = mock_fss
+
+        req = SignedUrlRequest(path="q1.pdf", location="reports", scope="org-a", method="GET")
+        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert result.path == "reports/org-a/q1.pdf"
 
 
 class TestPathValidation:
-    """Test path validation logic in the endpoint."""
+    """Test that handler returns 400 on resolver-rejected inputs."""
 
     @pytest.mark.asyncio
     async def test_rejects_path_traversal(self):
-        """Paths containing '..' should be rejected."""
         from fastapi import HTTPException
 
-        req = SignedUrlRequest(path="../etc/passwd")
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
+        req = SignedUrlRequest(path="../etc/passwd", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, ctx, user, db)
+            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
-        assert "must be relative" in str(exc_info.value.detail)
+        assert "traversal" in str(exc_info.value.detail).lower()
 
     @pytest.mark.asyncio
     async def test_rejects_absolute_path(self):
-        """Paths starting with '/' should be rejected."""
         from fastapi import HTTPException
 
-        req = SignedUrlRequest(path="/absolute/path")
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
+        req = SignedUrlRequest(path="/absolute/path", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, ctx, user, db)
+            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_rejects_reserved_prefix_repo(self):
-        """Paths starting with _repo/ should be rejected."""
+    async def test_rejects_reserved_location_name(self):
         from fastapi import HTTPException
 
-        req = SignedUrlRequest(path="_repo/secret.py")
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
+        req = SignedUrlRequest(path="x.txt", location="_repo", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, ctx, user, db)
+            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
-        assert "reserved prefix" in str(exc_info.value.detail)
+        assert "reserved bucket prefix" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_rejects_reserved_prefix_apps(self):
-        """Paths starting with _apps/ should be rejected."""
+    async def test_rejects_invalid_freeform_name(self):
         from fastapi import HTTPException
 
-        req = SignedUrlRequest(path="_apps/my-app/index.tsx")
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
+        req = SignedUrlRequest(path="x.txt", location="Bad Name!", scope="org-a")
         with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, ctx, user, db)
+            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_temp_requires_scope(self):
+        from fastapi import HTTPException
 
-class TestScopeResolution:
-    """Test scope resolution in S3 path construction."""
+        req = SignedUrlRequest(path="x.txt", location="temp", scope=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert exc_info.value.status_code == 400
+        assert "scope" in str(exc_info.value.detail).lower()
+
+
+class TestWorkspaceGitLock:
+    """Test that workspace PUTs are blocked when _repo/.git/ exists."""
 
     @pytest.mark.asyncio
+    @patch("src.routers.files._is_workspace_git_locked", new_callable=AsyncMock, return_value=True)
     @patch("src.routers.files.FileStorageService")
-    async def test_global_scope_when_none(self, mock_fss_class):
-        """Scope defaults to 'global' when not provided."""
+    async def test_workspace_put_rejected_when_git_locked(self, _fss, _git_lock):
+        from fastapi import HTTPException
+
+        req = SignedUrlRequest(path="x.txt", location="workspace", method="PUT")
+        with pytest.raises(HTTPException) as exc_info:
+            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert exc_info.value.status_code == 400
+        assert ".git" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    @patch("src.routers.files._is_workspace_git_locked", new_callable=AsyncMock, return_value=True)
+    @patch("src.routers.files.FileStorageService")
+    async def test_workspace_get_allowed_when_git_locked(self, mock_fss_class, _git_lock):
+        # GETs (downloads) of existing files shouldn't be blocked by the .git lock.
         mock_fss = MagicMock()
-        mock_fss.generate_presigned_upload_url = AsyncMock(return_value="https://s3/url")
+        mock_fss.generate_presigned_download_url = AsyncMock(return_value="https://s3/url")
         mock_fss_class.return_value = mock_fss
 
-        req = SignedUrlRequest(path="report.pdf", scope=None)
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
-        result = await get_signed_url(req, ctx, user, db)
-        assert result.path == "uploads/global/report.pdf"
-
-    @pytest.mark.asyncio
-    @patch("src.routers.files.FileStorageService")
-    async def test_explicit_scope(self, mock_fss_class):
-        """Explicit scope is used in path construction."""
-        mock_fss = MagicMock()
-        mock_fss.generate_presigned_upload_url = AsyncMock(return_value="https://s3/url")
-        mock_fss_class.return_value = mock_fss
-
-        req = SignedUrlRequest(path="report.pdf", scope="org-abc")
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
-        result = await get_signed_url(req, ctx, user, db)
-        assert result.path == "uploads/org-abc/report.pdf"
+        req = SignedUrlRequest(path="x.txt", location="workspace", method="GET")
+        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
+        assert result.url == "https://s3/url"
 
 
 class TestPresignedUrlGeneration:
@@ -160,38 +194,28 @@ class TestPresignedUrlGeneration:
     @pytest.mark.asyncio
     @patch("src.routers.files.FileStorageService")
     async def test_put_calls_upload(self, mock_fss_class):
-        """PUT method generates upload URL."""
         mock_fss = MagicMock()
         mock_fss.generate_presigned_upload_url = AsyncMock(return_value="https://s3/put-url")
         mock_fss_class.return_value = mock_fss
 
-        req = SignedUrlRequest(path="file.pdf", method="PUT", content_type="application/pdf")
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
-        result = await get_signed_url(req, ctx, user, db)
+        req = SignedUrlRequest(path="file.pdf", method="PUT", content_type="application/pdf", scope="org-a")
+        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
         assert result.url == "https://s3/put-url"
         mock_fss.generate_presigned_upload_url.assert_awaited_once_with(
-            path="uploads/global/file.pdf",
+            path="uploads/org-a/file.pdf",
             content_type="application/pdf",
         )
 
     @pytest.mark.asyncio
     @patch("src.routers.files.FileStorageService")
     async def test_get_calls_download(self, mock_fss_class):
-        """GET method generates download URL."""
         mock_fss = MagicMock()
         mock_fss.generate_presigned_download_url = AsyncMock(return_value="https://s3/get-url")
         mock_fss_class.return_value = mock_fss
 
-        req = SignedUrlRequest(path="file.pdf", method="GET")
-        ctx = MagicMock()
-        user = MagicMock()
-        db = AsyncMock()
-
-        result = await get_signed_url(req, ctx, user, db)
+        req = SignedUrlRequest(path="file.pdf", method="GET", scope="org-a")
+        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
         assert result.url == "https://s3/get-url"
         mock_fss.generate_presigned_download_url.assert_awaited_once_with(
-            path="uploads/global/file.pdf",
+            path="uploads/org-a/file.pdf",
         )

--- a/api/tests/unit/test_file_paths.py
+++ b/api/tests/unit/test_file_paths.py
@@ -1,0 +1,98 @@
+"""Unit tests for shared/file_paths.py — the single source of truth for S3 key resolution."""
+
+import pytest
+
+from shared.file_paths import resolve_s3_key, validate_location_name
+
+
+class TestReservedLocations:
+    def test_workspace_unscoped(self):
+        assert resolve_s3_key("workspace", None, "demo/hello.pdf") == "_repo/demo/hello.pdf"
+
+    def test_workspace_ignores_scope(self):
+        # Workspace is the codebase — scope is intentionally ignored.
+        assert resolve_s3_key("workspace", "org-a", "x.txt") == "_repo/x.txt"
+
+    def test_uploads_scoped(self):
+        assert resolve_s3_key("uploads", "org-a", "form_id/uuid/file.pdf") == "uploads/org-a/form_id/uuid/file.pdf"
+
+    def test_temp_scoped(self):
+        assert resolve_s3_key("temp", "org-a", "scratch.bin") == "_tmp/org-a/scratch.bin"
+
+
+class TestFreeformLocations:
+    def test_simple_freeform(self):
+        assert resolve_s3_key("reports", "org-a", "q1.pdf") == "reports/org-a/q1.pdf"
+
+    def test_freeform_with_hyphens(self):
+        assert resolve_s3_key("customer-data", "org-a", "x.csv") == "customer-data/org-a/x.csv"
+
+    def test_freeform_with_digits(self):
+        assert resolve_s3_key("exports2", "org-a", "x.zip") == "exports2/org-a/x.zip"
+
+
+class TestScopeRequirement:
+    @pytest.mark.parametrize("location", ["uploads", "temp", "reports"])
+    def test_missing_scope_rejected(self, location):
+        with pytest.raises(ValueError, match="Scope is required"):
+            resolve_s3_key(location, None, "x.txt")
+
+    @pytest.mark.parametrize("location", ["uploads", "temp", "reports"])
+    def test_empty_scope_rejected(self, location):
+        with pytest.raises(ValueError, match="Scope is required"):
+            resolve_s3_key(location, "", "x.txt")
+
+
+class TestPathValidation:
+    @pytest.mark.parametrize("bad_path", ["../etc/passwd", "a/../b", "../../x"])
+    def test_traversal_rejected(self, bad_path):
+        with pytest.raises(ValueError, match="path traversal"):
+            resolve_s3_key("workspace", None, bad_path)
+
+    def test_absolute_path_rejected(self):
+        with pytest.raises(ValueError, match="must be relative"):
+            resolve_s3_key("workspace", None, "/etc/passwd")
+
+    def test_subdirectory_paths(self):
+        assert resolve_s3_key("temp", "org-a", "sub/file.txt") == "_tmp/org-a/sub/file.txt"
+
+    def test_dotdot_in_filename_allowed(self):
+        # ".." as a path segment is rejected; ".." in a filename is fine.
+        assert resolve_s3_key("workspace", None, "file..bak") == "_repo/file..bak"
+
+
+class TestLocationNameValidation:
+    @pytest.mark.parametrize("reserved", ["_repo", "_tmp", "_apps"])
+    def test_reserved_prefix_names_rejected(self, reserved):
+        with pytest.raises(ValueError, match="reserved bucket prefix"):
+            validate_location_name(reserved)
+
+    @pytest.mark.parametrize("bad", ["UPPER", "with spaces", "with/slash", "_leading", "with_underscore"])
+    def test_freeform_regex_enforced(self, bad):
+        with pytest.raises(ValueError, match="must match"):
+            validate_location_name(bad)
+
+    @pytest.mark.parametrize("good", ["workspace", "uploads", "temp", "reports", "exports", "customer-data", "v2", "a"])
+    def test_valid_names_accepted(self, good):
+        # Should not raise.
+        validate_location_name(good)
+
+
+class TestResolverConsistency:
+    """Round-trip-style sanity: every (location, path) deterministically maps to one key."""
+
+    def test_idempotent(self):
+        a = resolve_s3_key("uploads", "org-a", "f.pdf")
+        b = resolve_s3_key("uploads", "org-a", "f.pdf")
+        assert a == b
+
+    def test_distinct_scopes_distinct_keys(self):
+        # Verified for a scoped location.
+        a = resolve_s3_key("temp", "org-a", "f.pdf")
+        b = resolve_s3_key("temp", "org-b", "f.pdf")
+        assert a != b
+
+    def test_distinct_locations_distinct_keys(self):
+        a = resolve_s3_key("temp", "org-a", "f.pdf")
+        b = resolve_s3_key("reports", "org-a", "f.pdf")
+        assert a != b

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -2365,6 +2365,11 @@ export interface paths {
         /**
          * Get Signed Url
          * @description Generate a presigned S3 URL for direct file upload or download.
+         *
+         *     Path resolution goes through `shared.file_paths.resolve_s3_key`, so the
+         *     URL targets the same key as a `files.read`/`files.write` to the same
+         *     `(location, scope, path)`. For workspace writes, requires the workspace
+         *     to not be a checked-out git repo (`_repo/.git/` absent).
          */
         post: operations["get_signed_url_api_files_signed_url_post"];
         delete?: never;
@@ -12425,11 +12430,15 @@ export interface components {
             path: string;
             /**
              * Location
-             * @description Storage location
+             * @description Storage location: reserved (workspace, temp, uploads) or freeform
              * @default workspace
-             * @enum {string}
              */
-            location: "workspace" | "temp" | "uploads";
+            location: string;
+            /**
+             * Scope
+             * @description Org scope. Required for non-workspace, non-uploads locations.
+             */
+            scope?: string | null;
             /**
              * Mode
              * @description Storage mode: local or cloud
@@ -12486,11 +12495,15 @@ export interface components {
             path: string;
             /**
              * Location
-             * @description Storage location
+             * @description Storage location: reserved (workspace, temp, uploads) or freeform
              * @default workspace
-             * @enum {string}
              */
-            location: "workspace" | "temp" | "uploads";
+            location: string;
+            /**
+             * Scope
+             * @description Org scope. Required for non-workspace, non-uploads locations.
+             */
+            scope?: string | null;
             /**
              * Mode
              * @description Storage mode: local or cloud
@@ -12537,11 +12550,15 @@ export interface components {
             directory: string;
             /**
              * Location
-             * @description Storage location
+             * @description Storage location: reserved (workspace, temp, uploads) or freeform
              * @default workspace
-             * @enum {string}
              */
-            location: "workspace" | "temp" | "uploads";
+            location: string;
+            /**
+             * Scope
+             * @description Org scope. Required for non-workspace, non-uploads locations.
+             */
+            scope?: string | null;
             /**
              * Mode
              * @description Storage mode: local or cloud
@@ -12681,11 +12698,15 @@ export interface components {
             path: string;
             /**
              * Location
-             * @description Storage location
+             * @description Storage location: reserved (workspace, temp, uploads) or freeform
              * @default workspace
-             * @enum {string}
              */
-            location: "workspace" | "temp" | "uploads";
+            location: string;
+            /**
+             * Scope
+             * @description Org scope. Required for non-workspace, non-uploads locations.
+             */
+            scope?: string | null;
             /**
              * Mode
              * @description Storage mode: local or cloud
@@ -12789,11 +12810,15 @@ export interface components {
             content: string;
             /**
              * Location
-             * @description Storage location
+             * @description Storage location: reserved (workspace, temp, uploads) or freeform
              * @default workspace
-             * @enum {string}
              */
-            location: "workspace" | "temp" | "uploads";
+            location: string;
+            /**
+             * Scope
+             * @description Org scope. Required for non-workspace, non-uploads locations.
+             */
+            scope?: string | null;
             /**
              * Mode
              * @description Storage mode: local or cloud
@@ -18318,7 +18343,7 @@ export interface components {
         SignedUrlRequest: {
             /**
              * Path
-             * @description File path (scoped automatically by org)
+             * @description File path relative to location root (NOT including scope segment)
              */
             path: string;
             /**
@@ -18335,8 +18360,14 @@ export interface components {
              */
             content_type: string;
             /**
+             * Location
+             * @description Storage location. Defaults to 'uploads' for backwards compatibility with form upload flows.
+             * @default uploads
+             */
+            location: string;
+            /**
              * Scope
-             * @description Organization scope (auto-resolved from context if None)
+             * @description Org scope. Required for non-workspace, non-uploads locations.
              */
             scope?: string | null;
         };
@@ -18884,7 +18915,11 @@ export interface components {
         };
         /**
          * UploadedFileMetadata
-         * @description Metadata for uploaded file that workflows can use to access the file
+         * @description Metadata for uploaded file that workflows can use to access the file.
+         *
+         *     `path` is relative to the `uploads` location: pass it directly to
+         *     `files.read(path, location="uploads")` in a workflow and the SDK handles
+         *     scoping. The full S3 key is `uploads/{scope}/{path}`.
          */
         UploadedFileMetadata: {
             /**
@@ -18899,7 +18934,7 @@ export interface components {
             container: string;
             /**
              * Path
-             * @description Blob path within container
+             * @description Path relative to uploads/ (e.g., '{form_id}/{uuid}/{filename}')
              */
             path: string;
             /**


### PR DESCRIPTION
## Summary

Closes #153.

- **Original bug:** `files.get_signed_url()` always targeted `uploads/{scope}/{path}`, so signed URLs for files written via `location="workspace"` returned NoSuchKey.
- **Fix:** all files endpoints (read/write/list/delete/exists/signed-url) now share one resolver — `shared.file_paths.resolve_s3_key(location, scope, path)`. Layout is universally `{location}/{scope}/{path}`; workspace is the only unscoped exception.
- **Scope:** required for everything except `workspace`. Provider-org override allowed via existing `resolve_scope` semantics.
- **Locations:** reserved (`workspace`, `uploads`, `temp`) plus freeform names (`reports`, `exports`, etc.) matching `^[a-z0-9][a-z0-9-]*$`.
- **Forms:** uploads now write to `uploads/{caller_scope}/{form_id}/{uuid}/{filename}`; `blob_uri` returns the location-relative path so workflows pass it straight to `files.read(..., location="uploads")` — no prefix-stripping.
- **Workspace `.git/` lock:** writes/PUT signed URLs rejected when `_repo/.git/` exists in storage.

## Bonus fix bundled in (was blocking E2E)

`DELETE /api/packages/{name}` only ran `pip uninstall` in the API container — never broadcast a worker recycle, so packages stayed alive in workers forever. `test_package_available_after_installation` was deterministically failing on any second run. The route now drops from requirements.txt and broadcasts `action="uninstall"`; the consumer was extended to handle it. Test gets tight polling assertions so a regression here fails loudly.

## Test plan

- [x] 38 new resolver unit tests (`tests/unit/test_file_paths.py`)
- [x] 8 round-trip E2E tests across all locations (`tests/e2e/api/test_files_signed_url_roundtrip.py`)
- [x] Workspace `.git/`-locked rejection (unit)
- [x] Full unit suite: 3192 passed, 0 failed
- [x] Full E2E suite: 1156 passed, 1 skipped, 0 failed
- [x] `pyright` clean repo-wide
- [x] `ruff` clean
- [x] `npm run tsc` / `npm run lint` clean
- [x] Frontend types regenerated; `npm run client unit` 777 passed

## Files

- New: `api/shared/file_paths.py`, `api/tests/unit/test_file_paths.py`, `api/tests/e2e/api/test_files_signed_url_roundtrip.py`
- Resolver wired into: `api/src/services/file_backend.py`, `api/src/routers/files.py`, `api/bifrost/files.py`, `api/src/routers/forms.py`
- Package uninstall fix: `api/src/routers/packages.py`, `api/src/jobs/consumers/package_install.py`, `api/src/core/requirements_cache.py`
- Docs/types: `api/src/services/mcp_server/tools/sdk.py` (rewritten as a single markdown constant instead of `lines.append()` cruft), `api/src/services/mcp_server/tools/forms.py`, `client/src/lib/v1.d.ts`
- Tests updated for new contract: `api/tests/unit/routers/test_files_signed_url.py`, `api/tests/e2e/api/test_file_uploads.py`, `api/tests/e2e/api/test_cli.py`, `api/tests/e2e/api/test_executions.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)