### PR TITLE
fix(files): remove workspace .git/ write gate

### DIFF
--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -206,15 +206,6 @@ async def write_file(
             content = request.content.encode("utf-8")
 
         updated_by = user.email if user else "system"
-        if request.location == "workspace" and request.mode == "cloud":
-            if await _is_workspace_git_locked():
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        "Workspace contains a .git directory; writes are blocked when the "
-                        "workspace is git-controlled."
-                    ),
-                )
         await backend.write(request.path, content, request.location, updated_by, scope=request.scope)
 
         logger.info(f"Wrote file: {log_safe(request.path)} ({len(content)} bytes, mode={log_safe(request.mode)}, location={log_safe(request.location)})")
@@ -338,8 +329,7 @@ async def get_signed_url(
 
     Path resolution goes through `shared.file_paths.resolve_s3_key`, so the
     URL targets the same key as a `files.read`/`files.write` to the same
-    `(location, scope, path)`. For workspace writes, requires the workspace
-    to not be a checked-out git repo (`_repo/.git/` absent).
+    `(location, scope, path)`.
     """
     from shared.file_paths import resolve_s3_key
 
@@ -347,16 +337,6 @@ async def get_signed_url(
         s3_path = resolve_s3_key(request.location, request.scope, request.path)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-
-    if request.location == "workspace" and request.method == "PUT":
-        if await _is_workspace_git_locked():
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "Workspace contains a .git directory; signed-url uploads to workspace "
-                    "are blocked when the workspace is git-controlled."
-                ),
-            )
 
     file_storage = FileStorageService(db)
 
@@ -374,14 +354,6 @@ async def get_signed_url(
         url=url,
         path=s3_path,
     )
-
-
-async def _is_workspace_git_locked() -> bool:
-    """Return True if `_repo/.git/` exists in the bucket — workspace is git-controlled."""
-    from src.services.repo_storage import RepoStorage
-    repo = RepoStorage()
-    children = await repo.list(".git/")
-    return len(children) > 0
 
 
 # =============================================================================

--- a/api/tests/e2e/api/test_files_signed_url_roundtrip.py
+++ b/api/tests/e2e/api/test_files_signed_url_roundtrip.py
@@ -45,8 +45,6 @@ class TestSignedUrlRoundTrip:
         content = secrets.token_bytes(64)
 
         write = self._write(e2e_client, platform_admin.headers, path, "workspace", content)
-        if write.status_code == 400 and "git" in write.text.lower():
-            pytest.skip("workspace is git-controlled; skipping write-side roundtrip")
         assert write.status_code == 204, f"write failed: {write.text}"
 
         sign = self._sign(e2e_client, platform_admin.headers, path, "workspace")

--- a/api/tests/unit/routers/test_files_signed_url.py
+++ b/api/tests/unit/routers/test_files_signed_url.py
@@ -73,9 +73,8 @@ class TestPathResolution:
         assert "scope" in str(exc_info.value.detail).lower()
 
     @pytest.mark.asyncio
-    @patch("src.routers.files._is_workspace_git_locked", new_callable=AsyncMock, return_value=False)
     @patch("src.routers.files.FileStorageService")
-    async def test_workspace_unscoped(self, mock_fss_class, _git_lock):
+    async def test_workspace_unscoped(self, mock_fss_class):
         mock_fss = MagicMock()
         mock_fss.generate_presigned_upload_url = AsyncMock(return_value="https://s3/url")
         mock_fss_class.return_value = mock_fss
@@ -157,35 +156,6 @@ class TestPathValidation:
             await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
         assert exc_info.value.status_code == 400
         assert "scope" in str(exc_info.value.detail).lower()
-
-
-class TestWorkspaceGitLock:
-    """Test that workspace PUTs are blocked when _repo/.git/ exists."""
-
-    @pytest.mark.asyncio
-    @patch("src.routers.files._is_workspace_git_locked", new_callable=AsyncMock, return_value=True)
-    @patch("src.routers.files.FileStorageService")
-    async def test_workspace_put_rejected_when_git_locked(self, _fss, _git_lock):
-        from fastapi import HTTPException
-
-        req = SignedUrlRequest(path="x.txt", location="workspace", method="PUT")
-        with pytest.raises(HTTPException) as exc_info:
-            await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
-        assert exc_info.value.status_code == 400
-        assert ".git" in str(exc_info.value.detail)
-
-    @pytest.mark.asyncio
-    @patch("src.routers.files._is_workspace_git_locked", new_callable=AsyncMock, return_value=True)
-    @patch("src.routers.files.FileStorageService")
-    async def test_workspace_get_allowed_when_git_locked(self, mock_fss_class, _git_lock):
-        # GETs (downloads) of existing files shouldn't be blocked by the .git lock.
-        mock_fss = MagicMock()
-        mock_fss.generate_presigned_download_url = AsyncMock(return_value="https://s3/url")
-        mock_fss_class.return_value = mock_fss
-
-        req = SignedUrlRequest(path="x.txt", location="workspace", method="GET")
-        result = await get_signed_url(req, MagicMock(), MagicMock(), AsyncMock())
-        assert result.url == "https://s3/url"
 
 
 class TestPresignedUrlGeneration:


### PR DESCRIPTION
## Summary

PR #155 added a server-side gate that rejected `POST /api/files/write` and `POST /api/files/signed-url` (PUT) to `location=workspace` when `_repo/.git/` existed in storage. The intent was to block *files-SDK writes from workflows*; in practice the gate also blocked `bifrost watch`, `sync`, `push`, `import`, and the web code editor — every legitimate developer-driven write to the workspace.

The "don't clobber a pending `bifrost git pull`" guarantee already lives in `bifrost git` itself (it refuses to merge over a dirty `_repo/`), so this data-plane gate was a duplicate guard with broken aim.

Closes #158.

## Changes

- Drop `_is_workspace_git_locked()` and both gate sites in `api/src/routers/files.py`.
- Drop `TestWorkspaceGitLock` from `test_files_signed_url.py`.
- Drop the `.git`-skip branch in `test_files_signed_url_roundtrip.py` — the workspace roundtrip e2e now actually exercises the write path end-to-end instead of skipping when git-controlled.

## Out of scope

A future "this workspace is git-controlled" warning surfaced by `bifrost watch` startup and the web code editor — separate change once we have a concrete UX for it.

## Test plan

- [x] `./test.sh tests/unit/routers/test_files_signed_url.py` — 17/17 pass
- [x] `./test.sh tests/e2e/api/test_files_signed_url_roundtrip.py` — 8/8 pass (workspace roundtrip now covers the write path)
- [x] `./test.sh tests/unit/routers/` — 194/194 pass (full router unit suite, no regressions)
- [x] `./test.sh tests/e2e/api/ -k "files"` — 29/29 pass
- [x] `ruff check` on changed files — clean