### PR TITLE
fix(cli): load .env from cwd, not pipx venv

### DIFF
--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -66,11 +66,14 @@ def raise_for_status_with_detail(response: httpx.Response) -> None:
 # and httpx.AsyncClient is bound to the event loop that created it.
 _thread_local = threading.local()
 
-# Auto-load .env file if present (for local development)
+# Auto-load .env file if present (for local development).
+# Walk upward from cwd, not from this file. With pipx-installed CLIs, __file__
+# lives in the pipx venv and the default upward walk never reaches the user's
+# workspace, so a .env in the project root is silently ignored.
 try:
-    from dotenv import load_dotenv
+    from dotenv import find_dotenv, load_dotenv
 
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
 except ImportError:
     pass  # dotenv not installed, rely on environment variables
 

--- a/api/bifrost/pyproject.toml
+++ b/api/bifrost/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "PyYAML>=6.0",
     "websockets>=12.0",
     "textual>=1.0.0",
+    "python-dotenv>=1.0.0",
+    "keyring>=24.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- `load_dotenv()` with no args walks up from `__file__`. For pipx-installed CLIs that's the venv (`~/.local/share/pipx/venvs/bifrost-sdk/...`), so the upward walk never reaches the user's workspace and a `.env` in the project root is silently ignored. Use `find_dotenv(usecwd=True)` so the search starts at cwd.
- Declare `python-dotenv` and `keyring` as runtime deps. Both were silently relied on; missing `keyring` forces `JsonBackend`, which hides keychain-stored credentials and makes `bifrost auth ls` report "No stored credentials" after a clean install.

## Symptom that surfaced this

`bifrost watch` running from a workspace dir with `.env` containing `BIFROST_API_URL=<prod>` was actually talking to whatever URL was first in the persistent backend (a stale debug stack). Every local file looked "new locally" because the diff was against the wrong server entirely. Once the env loads correctly, comparison logic behaves as expected (verified locally: 707/725 files match against prod, 18 are genuinely out of sync, no false positives from etag handling).

## Test plan

- [ ] In a directory with `.env` containing `BIFROST_API_URL=https://your-prod`, run `bifrost auth ls` — confirm the `.env` URL is marked `(current — from BIFROST_API_URL)`.
- [ ] In a directory without `.env`, run `bifrost auth ls` — confirm fallback behavior is unchanged.
- [ ] Fresh `pipx install --force /path/to/api` works without manual `pipx inject keyring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)