### PR TITLE
fix(apps): preserve local source on create + sync app.yaml deps + .env from cwd

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -2771,6 +2771,61 @@ def _collect_push_files(
 
 
 
+async def _sync_app_yaml_dependencies(
+    client: "BifrostClient",
+    slug: str,
+    local_yaml: pathlib.Path,
+) -> bool:
+    """Push app.yaml's `dependencies` block to Application.dependencies if changed.
+
+    Returns True iff a PUT was issued and accepted.
+
+    Behavior:
+    - Missing local file or missing/non-dict `dependencies` block → no-op.
+    - App not yet created (404) → no-op (the file push may have been the
+      first half of a create-then-deps flow).
+    - Server-side dependencies match the YAML → no-op.
+    - Otherwise: PUT /api/applications/{id}/dependencies and print a notice.
+
+    Raised exceptions are surfaced to the caller for one centralized error
+    line, so this function never silently swallows non-recoverable errors.
+    """
+    if not local_yaml.exists():
+        return False
+
+    try:
+        import yaml as _yaml
+    except ImportError as e:  # pragma: no cover - PyYAML ships with the SDK
+        raise RuntimeError(f"PyYAML not available: {e}") from e
+
+    parsed = _yaml.safe_load(local_yaml.read_text(encoding="utf-8")) or {}
+    yaml_deps = parsed.get("dependencies") if isinstance(parsed, dict) else None
+    if not isinstance(yaml_deps, dict):
+        return False
+    yaml_deps_str = {str(k): str(v) for k, v in yaml_deps.items()}
+
+    app_resp = await client.get(f"/api/applications/{slug}")
+    if app_resp.status_code == 404:
+        return False
+    if app_resp.status_code != 200:
+        raise RuntimeError(f"lookup HTTP {app_resp.status_code}")
+
+    app_data = app_resp.json()
+    app_id = app_data.get("id")
+    current_deps = app_data.get("dependencies") or {}
+    if not app_id or current_deps == yaml_deps_str:
+        return False
+
+    deps_resp = await client.put(
+        f"/api/applications/{app_id}/dependencies",
+        json=yaml_deps_str,
+    )
+    if deps_resp.status_code != 200:
+        raise RuntimeError(f"PUT HTTP {deps_resp.status_code}")
+    print(f"  ✓ Synced dependencies for '{slug}' from app.yaml")
+    return True
+
+
 async def _sync_files(
     local_path: str,
     repo_prefix: str = "",
@@ -3068,6 +3123,26 @@ async def _sync_files(
         print(f"\n  Errors ({len(errors)}):")
         for error in errors:
             print(textwrap.fill(f"- {error}", width=_cols, initial_indent="    ", subsequent_indent="      "))
+
+    # ── 6b. Sync app.yaml `dependencies` blocks to Application.dependencies ─
+    # File pushes don't automatically reflect into Application.dependencies (a
+    # model column read by the validator and bundler). Without this step,
+    # editing `dependencies:` in apps/<slug>/app.yaml updates the YAML on the
+    # server but leaves the model untouched, so the validator continues to
+    # see the old set and fails on newly-added imports.
+    pushed_app_yamls: list[tuple[str, pathlib.Path]] = []  # (slug, local_path)
+    for item in result.push:
+        rel = item.get("rel", "")
+        if rel.endswith("/app.yaml") and rel.startswith("apps/"):
+            slug = rel.split("/", 2)[1]
+            if slug:
+                pushed_app_yamls.append((slug, path / rel))
+
+    for slug, local_yaml in pushed_app_yamls:
+        try:
+            await _sync_app_yaml_dependencies(client, slug, local_yaml)
+        except Exception as e:
+            print(f"  Skipping deps sync for '{slug}': {e}", file=sys.stderr)
 
     # Validate if requested
     if validate and repo_prefix:

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -66,11 +66,14 @@ def raise_for_status_with_detail(response: httpx.Response) -> None:
 # and httpx.AsyncClient is bound to the event loop that created it.
 _thread_local = threading.local()
 
-# Auto-load .env file if present (for local development)
+# Auto-load .env file if present (for local development).
+# Walk upward from cwd, not from this file. With pipx-installed CLIs, __file__
+# lives in the pipx venv and the default upward walk never reaches the user's
+# workspace, so a .env in the project root is silently ignored.
 try:
-    from dotenv import load_dotenv
+    from dotenv import find_dotenv, load_dotenv
 
-    load_dotenv()
+    load_dotenv(find_dotenv(usecwd=True))
 except ImportError:
     pass  # dotenv not installed, rely on environment variables
 

--- a/api/bifrost/commands/apps.py
+++ b/api/bifrost/commands/apps.py
@@ -246,6 +246,17 @@ async def create_app(
 @apps_group.command("update")
 @click.argument("ref")
 @_apply_flags(_UPDATE_FLAGS)
+@click.option(
+    "--deps",
+    "deps_raw",
+    type=str,
+    default=None,
+    help=(
+        "Dependencies as a JSON literal or @path to a package.json / "
+        "{name: version} file. Triggers a follow-up PUT to /dependencies "
+        "after the metadata patch. Mirrors `apps create --deps`."
+    ),
+)
 @click.pass_context
 @pass_resolver
 @run_async
@@ -255,6 +266,7 @@ async def update_app(
     *,
     client: BifrostClient,
     resolver: RefResolver,
+    deps_raw: str | None,
     **fields: Any,
 ) -> None:
     """Update application metadata (patch-without-draft).
@@ -263,12 +275,52 @@ async def update_app(
     from the payload so the server only applies the fields the user
     explicitly passed. Per the audit this is PATCH directly on the live
     application — there's no draft-staging step.
+
+    When ``--deps`` is passed this runs the same two-call orchestration
+    as ``apps create --deps``: the metadata PATCH first, then a
+    ``PUT /dependencies`` applies the parsed dict. If the deps call
+    fails after the patch succeeded, the command prints both outcomes,
+    exits non-zero, and leaves the metadata change in place — there is
+    no rollback.
     """
     app_uuid = await resolver.resolve("app", ref)
     body = await assemble_body(ApplicationUpdate, fields, resolver=resolver)
     response = await client.patch(f"/api/applications/{app_uuid}", json=body)
     response.raise_for_status()
-    output_result(response.json(), ctx=ctx)
+    updated = response.json()
+
+    if deps_raw is None:
+        output_result(updated, ctx=ctx)
+        return
+
+    deps = _parse_deps(deps_raw)
+    deps_response = await client.put(
+        f"/api/applications/{app_uuid}/dependencies", json=deps
+    )
+    try:
+        deps_response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        error_body: Any
+        try:
+            error_body = deps_response.json()
+        except ValueError:
+            error_body = deps_response.text
+        output_result(
+            {
+                "application": updated,
+                "dependencies_error": {
+                    "status_code": deps_response.status_code,
+                    "body": error_body,
+                },
+            },
+            ctx=ctx,
+        )
+        raise exc
+
+    output_result(
+        {"application": updated, "dependencies": deps_response.json()},
+        ctx=ctx,
+    )
 
 
 @apps_group.command("set-deps")

--- a/api/bifrost/pyproject.toml
+++ b/api/bifrost/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "PyYAML>=6.0",
     "websockets>=12.0",
     "textual>=1.0.0",
+    "python-dotenv>=1.0.0",
+    "keyring>=24.0.0",
 ]
 
 [project.optional-dependencies]

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -460,8 +460,24 @@ class ApplicationRepository(OrgScopedRepository[Application]):
         Creates:
         - _layout.tsx: Root layout wrapper
         - pages/index.tsx: Home page
+
+        Skipped entirely if any file already exists under apps/{slug}/ — the
+        caller (e.g. `bifrost apps create` against a slug whose source dir
+        was authored locally first) is not expected to lose their work to
+        the default Welcome scaffold.
         """
+        from src.models.orm.file_index import FileIndex
         from src.services.file_storage import FileStorageService
+
+        prefix = f"apps/{slug}/"
+        existing = await self.session.execute(
+            select(FileIndex.path).where(FileIndex.path.startswith(prefix)).limit(1)
+        )
+        if existing.first() is not None:
+            logger.info(
+                f"Skipped scaffold for app {log_safe(slug)}: files already exist at {log_safe(prefix)}"
+            )
+            return
 
         file_storage = FileStorageService(self.session)
 
@@ -1207,8 +1223,15 @@ async def validate_application(
                         message=f"Workflow '{wf_ref}' not found or inactive",
                     ))
 
-    # Check for missing/unused dependencies
-    for dep in referenced_deps:
+    # Check for missing/unused dependencies. Host-provided modules
+    # (DEFAULT_EXTERNALS — react, lucide-react, sonner, etc.) are
+    # resolved by the host import map and never need to appear in
+    # `app.dependencies`, so subtract them before the missing check.
+    from src.services.app_bundler import DEFAULT_EXTERNALS
+
+    host_provided = set(DEFAULT_EXTERNALS)
+    user_referenced = referenced_deps - host_provided
+    for dep in user_referenced:
         if dep not in declared_deps:
             errors.append(AppValidationIssue(
                 severity="error",
@@ -1216,7 +1239,7 @@ async def validate_application(
                 message=f"Missing dependency: '{dep}' is imported but not declared in app dependencies",
             ))
     for dep in declared_deps:
-        if dep not in referenced_deps:
+        if dep not in user_referenced:
             warnings.append(AppValidationIssue(
                 severity="warning",
                 file="dependencies",

--- a/api/src/services/mcp_server/tools/apps.py
+++ b/api/src/services/mcp_server/tools/apps.py
@@ -145,10 +145,21 @@ async def create_app(
             db.add(app)
             await db.flush()
 
-            # Write scaffold files via FileStorageService
-            file_storage = FileStorageService(db)
+            # Write scaffold files via FileStorageService — but only if no
+            # files already exist under apps/{slug}/. Authors who created
+            # the source dir locally first should not lose their work to
+            # the default Welcome scaffold.
+            from src.models.orm.file_index import FileIndex
 
-            layout_source = '''import { Outlet } from "bifrost";
+            prefix = f"apps/{slug}/"
+            existing_files = await db.execute(
+                select(FileIndex.path).where(FileIndex.path.startswith(prefix)).limit(1)
+            )
+            scaffolded = 0
+            if existing_files.first() is None:
+                file_storage = FileStorageService(db)
+
+                layout_source = '''import { Outlet } from "bifrost";
 
 export default function RootLayout() {
   return (
@@ -158,7 +169,7 @@ export default function RootLayout() {
   );
 }
 '''
-            index_source = '''export default function HomePage() {
+                index_source = '''export default function HomePage() {
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold mb-4">Welcome</h1>
@@ -169,16 +180,17 @@ export default function RootLayout() {
   );
 }
 '''
-            await file_storage.write_file(
-                path=f"apps/{slug}/_layout.tsx",
-                content=layout_source.encode("utf-8"),
-                updated_by="system",
-            )
-            await file_storage.write_file(
-                path=f"apps/{slug}/pages/index.tsx",
-                content=index_source.encode("utf-8"),
-                updated_by="system",
-            )
+                await file_storage.write_file(
+                    path=f"apps/{slug}/_layout.tsx",
+                    content=layout_source.encode("utf-8"),
+                    updated_by="system",
+                )
+                await file_storage.write_file(
+                    path=f"apps/{slug}/pages/index.tsx",
+                    content=index_source.encode("utf-8"),
+                    updated_by="system",
+                )
+                scaffolded = 2
 
             await db.commit()
 
@@ -188,7 +200,7 @@ export default function RootLayout() {
                 "id": str(app.id),
                 "name": app.name,
                 "slug": app.slug,
-                "file_count": 2,
+                "file_count": scaffolded,
                 "url": f"/apps/{app.slug}",
             })
 
@@ -709,12 +721,19 @@ async def validate_app(context: Any, app_id: str) -> ToolResult:
                         except ValueError:
                             errors.append({"severity": "error", "file": rel_path, "message": f"'{wf_ref}' is not a valid UUID"})
 
-            # Check for missing/unused dependencies
-            for dep in referenced_deps:
+            # Check for missing/unused dependencies. Host-provided modules
+            # (DEFAULT_EXTERNALS — react, lucide-react, sonner, etc.) are
+            # resolved by the host import map and never need to appear in
+            # `app.dependencies`.
+            from src.services.app_bundler import DEFAULT_EXTERNALS
+
+            host_provided = set(DEFAULT_EXTERNALS)
+            user_referenced = referenced_deps - host_provided
+            for dep in user_referenced:
                 if dep not in declared_deps:
                     errors.append({"severity": "error", "file": "dependencies", "message": f"Missing dependency: '{dep}' is imported but not declared in app dependencies"})
             for dep in declared_deps:
-                if dep not in referenced_deps:
+                if dep not in user_referenced:
                     warnings.append({"severity": "warning", "file": "dependencies", "message": f"Unused dependency: '{dep}' is declared but not imported by any file"})
 
             # Build result

--- a/api/tests/e2e/api/test_applications.py
+++ b/api/tests/e2e/api/test_applications.py
@@ -655,3 +655,69 @@ class TestCodeEngineApps:
 
         # Cleanup
         _delete_app(e2e_client, platform_admin.headers, app["id"])
+
+    def test_app_create_preserves_existing_local_files(self, e2e_client, platform_admin):
+        """Creating an app whose source dir already has files must NOT clobber them with the default scaffold.
+
+        Repro: author writes apps/<slug>/_layout.tsx locally, pushes to S3,
+        then runs `bifrost apps create --slug <slug>`. The user-authored
+        layout must survive — losing it to the default Welcome scaffold is
+        the bug this guards against.
+        """
+        slug = "preserve-local-source"
+
+        # Pre-stage a user-authored file at apps/<slug>/_layout.tsx,
+        # mimicking a `bifrost watch` push that ran before `apps create`.
+        custom_layout = (
+            'import { Outlet } from "bifrost";\n\n'
+            'export default function RootLayout() {\n'
+            '  return <div data-test="user-authored"><Outlet /></div>;\n'
+            '}\n'
+        )
+        write_response = e2e_client.post(
+            "/api/files/write",
+            headers=platform_admin.headers,
+            json={
+                "path": f"apps/{slug}/_layout.tsx",
+                "content": custom_layout,
+                "location": "workspace",
+                "mode": "cloud",
+            },
+        )
+        assert write_response.status_code == 204, f"Pre-stage write failed: {write_response.text}"
+
+        try:
+            response = e2e_client.post(
+                "/api/applications",
+                headers=platform_admin.headers,
+                json={"name": "Preserve Local Source", "slug": slug},
+            )
+            assert response.status_code == 201, f"Create app failed: {response.text}"
+            app = response.json()
+
+            files_response = e2e_client.get(
+                f"/api/applications/{app['id']}/files",
+                headers=platform_admin.headers,
+            )
+            assert files_response.status_code == 200
+            files_by_path = {f["path"]: f for f in files_response.json()["files"]}
+
+            assert "_layout.tsx" in files_by_path, "Pre-staged _layout.tsx missing after create"
+            assert 'data-test="user-authored"' in files_by_path["_layout.tsx"]["source"], (
+                "Default scaffold clobbered the pre-staged user-authored _layout.tsx"
+            )
+            assert "pages/index.tsx" not in files_by_path, (
+                "Scaffold should be skipped entirely when prefix is non-empty"
+            )
+
+            _delete_app(e2e_client, platform_admin.headers, app["id"])
+        finally:
+            e2e_client.post(
+                "/api/files/delete",
+                headers=platform_admin.headers,
+                json={
+                    "path": f"apps/{slug}/_layout.tsx",
+                    "location": "workspace",
+                    "mode": "cloud",
+                },
+            )

--- a/api/tests/unit/test_app_validator_deps.py
+++ b/api/tests/unit/test_app_validator_deps.py
@@ -101,3 +101,22 @@ import { Real } from "real-pkg";
     deps = extract_external_deps(src)
     assert "real-pkg" in deps
     assert "fake-pkg" not in deps
+
+
+def test_default_externals_cover_host_provided_libs():
+    """The validator filters host-provided modules out of the
+    "missing dependency" check by subtracting the bundler's
+    DEFAULT_EXTERNALS from the referenced set. lucide-react and
+    react-router-dom MUST stay in that list, otherwise every app that
+    imports them will fail validation despite working at runtime
+    (regression: covi-design-system tripped this on first push).
+    """
+    from src.services.app_bundler import DEFAULT_EXTERNALS
+
+    externals = set(DEFAULT_EXTERNALS)
+    # The runtime import map serves these; users must not need to declare them.
+    for required in ("react", "react-dom", "react-router-dom", "lucide-react"):
+        assert required in externals, (
+            f"{required!r} missing from DEFAULT_EXTERNALS — apps that import "
+            f"it will fail validation while still running at runtime"
+        )

--- a/api/tests/unit/test_sync_app_yaml_dependencies.py
+++ b/api/tests/unit/test_sync_app_yaml_dependencies.py
@@ -1,0 +1,171 @@
+"""Unit tests for `_sync_app_yaml_dependencies` — the post-push step that
+mirrors `apps/<slug>/app.yaml::dependencies` into the Application model
+column the validator/bundler actually read.
+
+Regression context: pushing app.yaml via `bifrost sync` / `bifrost watch`
+updates the YAML file in S3 but leaves Application.dependencies stale, so
+the validator continues to flag newly-imported packages as missing
+dependencies even though the user updated the YAML.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bifrost.cli import _sync_app_yaml_dependencies
+
+
+def _mock_response(status_code: int, json_payload: dict | None = None) -> MagicMock:
+    """Build a stand-in for httpx.Response with status_code + .json()."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_payload or {}
+    return resp
+
+
+def _write_app_yaml(tmp: pathlib.Path, body: str) -> pathlib.Path:
+    p = tmp / "app.yaml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+@pytest.mark.asyncio
+async def test_changed_deps_get_pushed(tmp_path: pathlib.Path):
+    """Local YAML deps differ from server → PUT is issued and returns True."""
+    yaml_path = _write_app_yaml(
+        tmp_path,
+        'name: My App\ndependencies:\n  lodash: "4.17.21"\n  axios: "1.6.0"\n',
+    )
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_mock_response(200, {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "dependencies": {"lodash": "4.17.21"},  # missing axios
+    }))
+    client.put = AsyncMock(return_value=_mock_response(200, {}))
+
+    result = await _sync_app_yaml_dependencies(client, "my-app", yaml_path)
+
+    assert result is True
+    client.get.assert_awaited_once_with("/api/applications/my-app")
+    client.put.assert_awaited_once()
+    put_args, put_kwargs = client.put.call_args
+    assert put_args[0] == "/api/applications/11111111-1111-1111-1111-111111111111/dependencies"
+    assert put_kwargs["json"] == {"lodash": "4.17.21", "axios": "1.6.0"}
+
+
+@pytest.mark.asyncio
+async def test_unchanged_deps_skip_put(tmp_path: pathlib.Path):
+    """Local YAML deps match server exactly → no PUT, returns False."""
+    yaml_path = _write_app_yaml(
+        tmp_path,
+        'name: My App\ndependencies:\n  lodash: "4.17.21"\n',
+    )
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_mock_response(200, {
+        "id": "abc",
+        "dependencies": {"lodash": "4.17.21"},
+    }))
+    client.put = AsyncMock()
+
+    result = await _sync_app_yaml_dependencies(client, "my-app", yaml_path)
+
+    assert result is False
+    client.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_deps_block_is_noop(tmp_path: pathlib.Path):
+    """app.yaml without a `dependencies:` block → no-op, no GET, no PUT."""
+    yaml_path = _write_app_yaml(tmp_path, 'name: Bare App\n')
+
+    client = MagicMock()
+    client.get = AsyncMock()
+    client.put = AsyncMock()
+
+    result = await _sync_app_yaml_dependencies(client, "bare-app", yaml_path)
+
+    assert result is False
+    client.get.assert_not_awaited()
+    client.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_app_404_is_noop(tmp_path: pathlib.Path):
+    """App doesn't exist yet (e.g. mid create+push flow) → graceful no-op."""
+    yaml_path = _write_app_yaml(
+        tmp_path,
+        'dependencies:\n  lodash: "4.17.21"\n',
+    )
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_mock_response(404))
+    client.put = AsyncMock()
+
+    result = await _sync_app_yaml_dependencies(client, "missing-app", yaml_path)
+
+    assert result is False
+    client.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_local_yaml_is_noop(tmp_path: pathlib.Path):
+    """Local file deleted between push detection and helper call → no-op."""
+    yaml_path = tmp_path / "does-not-exist.yaml"
+
+    client = MagicMock()
+    client.get = AsyncMock()
+    client.put = AsyncMock()
+
+    result = await _sync_app_yaml_dependencies(client, "ghost", yaml_path)
+
+    assert result is False
+    client.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dep_values_are_coerced_to_strings(tmp_path: pathlib.Path):
+    """YAML may parse '0.469' as a float — the dependencies endpoint requires
+    str values, so coerce before PUT.
+    """
+    yaml_path = _write_app_yaml(
+        tmp_path,
+        'dependencies:\n  lucide-react: 0.469\n  some-pkg: 1\n',
+    )
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_mock_response(200, {
+        "id": "abc",
+        "dependencies": {},
+    }))
+    client.put = AsyncMock(return_value=_mock_response(200, {}))
+
+    result = await _sync_app_yaml_dependencies(client, "my-app", yaml_path)
+
+    assert result is True
+    put_kwargs = client.put.call_args.kwargs
+    for v in put_kwargs["json"].values():
+        assert isinstance(v, str)
+
+
+@pytest.mark.asyncio
+async def test_put_failure_raises(tmp_path: pathlib.Path):
+    """Non-200 PUT surfaces as an exception so the caller logs once."""
+    yaml_path = _write_app_yaml(
+        tmp_path,
+        'dependencies:\n  lodash: "4.17.21"\n',
+    )
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=_mock_response(200, {
+        "id": "abc",
+        "dependencies": {},
+    }))
+    client.put = AsyncMock(return_value=_mock_response(500))
+
+    with pytest.raises(RuntimeError, match="PUT HTTP 500"):
+        await _sync_app_yaml_dependencies(client, "my-app", yaml_path)


### PR DESCRIPTION
## Summary

Five fixes from a workspace build session — authoring an app locally and registering with `bifrost apps create` was losing user source to the default Welcome scaffold, then the validator was rejecting every `lucide-react` import on the freshly-created app. Plus the prior fix on this branch for `.env` resolution under pipx.

- **`apps create` no longer overwrites local source.** Both REST and MCP create paths now skip the default scaffold entirely if any file exists at `apps/<slug>/`. Authors who push source before registering keep their layout.
- **`bifrost watch` / `sync` now mirrors `app.yaml::dependencies` to the model column.** After pushing `apps/<slug>/app.yaml`, parses `dependencies:` and PUTs to `/api/applications/{id}/dependencies` if it diverges. Previously the YAML round-tripped to S3 but `Application.dependencies` (read by validator + bundler) stayed stale, requiring a manual `bifrost api PUT` to unblock validation.
- **`bifrost apps update --deps`.** Same two-call orchestration as `apps create --deps`, so authors don't have to remember `bifrost apps set-deps` exists as a separate command.
- **Validator no longer flags host-provided libs as missing.** Subtracts `DEFAULT_EXTERNALS` (react, react-dom, react-router-dom, lucide-react, sonner, date-fns, clsx, tailwind-merge) before the missing-deps check in both REST and MCP. The bundler resolves these via the host import map at runtime; requiring manifest declarations was a false positive that broke every new app importing icons.
- **(Prior commit on branch)** `bifrost` CLI loads `.env` from cwd, not the pipx venv directory.

## Tests

- E2E: `test_app_create_preserves_existing_local_files` pre-stages a user-authored `_layout.tsx`, runs `POST /api/applications`, asserts it survives and the scaffold is skipped.
- Unit: 7 cases for `_sync_app_yaml_dependencies` covering changed / unchanged / missing block / app 404 / missing local file / YAML float coercion / PUT failure.
- Unit: drift guard asserting `react`, `react-dom`, `react-router-dom`, `lucide-react` stay in `DEFAULT_EXTERNALS` so the validator filter keeps working.
- Full unit suite: 3308 passed locally.
- `ruff check` clean.

## Test plan

- [ ] CI: full unit + e2e green
- [ ] Manual: in a workspace, write `apps/test-app/_layout.tsx`, run `bifrost apps create --slug test-app --name "Test"`, confirm the layout file is preserved
- [ ] Manual: edit `dependencies:` in `apps/<slug>/app.yaml`, run `bifrost watch` (or `bifrost sync`), confirm console prints "Synced dependencies for '<slug>' from app.yaml" and validation no longer flags the new package
- [ ] Manual: `bifrost apps update <slug> --deps @package.json` applies metadata + deps in one call

🤖 Generated with [Claude Code](https://claude.com/claude-code)