### PR TITLE
feat(cli): access controls for forms/workflows on create/update + skill guidance

### DIFF
--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -45,11 +45,30 @@ Then use `Grep/Read` on `/tmp/bifrost-docs/llms.txt` whenever you need reference
 ### Before Building
 
 1. **Which organization?** Ask the user which organization they're building for (natural language — don't dump a list of UUIDs). Confirm the org name, then resolve the UUID with `bifrost orgs get <name> --json` (or `bifrost orgs list --json` and pick from the list).
-2. **What triggers this?** (webhook, form, schedule, manual)
-3. **If webhook:** Get sample payload from user
-4. **What integrations?** `bifrost integrations list --json` — drill into specific ones with `bifrost integrations get <ref> --json`.
-5. **If migrating from Rewst:** Use `/rewst-migration` skill
-6. **If building something new** (new integration, workflow, app, or shared module — not modifying existing):
+2. **Who should have access?** Confirm the access tuple `(organization, access_level, role_ids)` *before* you scaffold anything, and apply it consistently across the app and every workflow / form it depends on. Mismatched access is the most common reason a working app silently 403s for end users. Compatibility rule of thumb when an app is assigned to roles X (under Org A or global): every supporting workflow and form must satisfy at least one of —
+   - **Global** scope (any org, available to all roles), OR
+   - **Org A scoped + `access_level=authenticated`** (any logged-in user in Org A), OR
+   - **Same role(s) X** assigned to it.
+
+   Example: a Finance app for Org A, role-restricted to `finance`. Every workflow it calls must be either global, Org-A-scoped+authenticated, or role-assigned to `finance` — otherwise users with the `finance` role can't execute the workflows the app depends on. Discover roles with `bifrost roles list --json`. Pass the tuple through every subsequent create/register call so it doesn't drift:
+
+   ```bash
+   # Apps + forms support these flags directly on create/update.
+   bifrost apps create --name "Finance" --slug finance --organization "Org A" \
+     --access-level role_based --role-ids finance
+   bifrost forms create --name "..." --workflow ... --organization "Org A" \
+     --access-level role_based --role-ids finance
+
+   # Workflows: --access-level + --role-ids on register, or update later
+   # via `bifrost workflows update <ref> --role-ids ...` (bulk replace).
+   bifrost workflows register --path workflows/foo.py --function-name foo \
+     --org "Org A" --access-level role_based --role-ids finance
+   ```
+3. **What triggers this?** (webhook, form, schedule, manual)
+4. **If webhook:** Get sample payload from user
+5. **What integrations?** `bifrost integrations list --json` — drill into specific ones with `bifrost integrations get <ref> --json`.
+6. **If migrating from Rewst:** Use `/rewst-migration` skill
+7. **If building something new** (new integration, workflow, app, or shared module — not modifying existing):
    > "It sounds like we're building something new. Would you like me to clone the bifrost-workspace-community repo? It has working examples from the community and might already have what you need."
 
    If the user agrees:

--- a/api/bifrost/commands/workflows.py
+++ b/api/bifrost/commands/workflows.py
@@ -130,6 +130,23 @@ async def get_workflow(
     default=None,
     help="Organization ref (UUID or name) to scope the workflow to; omit for global.",
 )
+@click.option(
+    "--access-level",
+    "access_level",
+    type=click.Choice(["authenticated", "role_based"]),
+    default=None,
+    help="Access level for the workflow. Omit to leave at default.",
+)
+@click.option(
+    "--role-ids",
+    "role_ids",
+    type=str,
+    multiple=True,
+    help=(
+        "Role refs (UUID or name) for role_based access. Repeat the flag for "
+        "multiple, or pass a comma-separated list."
+    ),
+)
 @click.pass_context
 @pass_resolver
 @run_async
@@ -141,16 +158,35 @@ async def register_workflow(
     path: str,
     function_name: str,
     organization_id: str | None,
+    access_level: str | None,
+    role_ids: tuple[str, ...],
 ) -> None:
     """Register a decorated function from an existing workspace ``.py`` file.
 
     The file must already exist in the workspace (written via ``bifrost push``
     or the file editor). This command indexes a ``@workflow`` / ``@tool`` /
     ``@data_provider`` function so it becomes executable via the API.
+
+    ``--access-level`` and ``--role-ids`` set the workflow's access controls at
+    registration time, mirroring the create-time surface for forms and apps.
+    Role refs accept names or UUIDs and are resolved before the request.
     """
     body: dict[str, Any] = {"path": path, "function_name": function_name}
     if organization_id is not None:
         body["organization_id"] = await resolver.resolve("org", organization_id)
+    if access_level is not None:
+        body["access_level"] = access_level
+
+    # Flatten comma-separated role refs and resolve names → UUIDs.
+    flattened: list[str] = []
+    for raw in role_ids:
+        for piece in raw.split(","):
+            piece = piece.strip()
+            if piece:
+                flattened.append(piece)
+    if flattened:
+        body["role_ids"] = [await resolver.resolve("role", r) for r in flattened]
+
     response = await client.post("/api/workflows/register", json=body)
     response.raise_for_status()
     output_result(response.json(), ctx=ctx)

--- a/api/bifrost/contracts/forms.py
+++ b/api/bifrost/contracts/forms.py
@@ -28,6 +28,7 @@ class FormCreate(BaseModel):
     form_schema: dict
     access_level: FormAccessLevel | None = FormAccessLevel.ROLE_BASED
     organization_id: UUID | None = Field(default=None)
+    role_ids: list[UUID] = Field(default_factory=list)
 
 
 class FormUpdate(BaseModel):
@@ -44,3 +45,4 @@ class FormUpdate(BaseModel):
     access_level: FormAccessLevel | None = None
     organization_id: UUID | None = Field(default=None)
     clear_roles: bool = False
+    role_ids: list[UUID] | None = Field(default=None)

--- a/api/bifrost/contracts/workflows.py
+++ b/api/bifrost/contracts/workflows.py
@@ -17,6 +17,7 @@ class WorkflowUpdateRequest(BaseModel):
     organization_id: str | None = Field(default=None)
     access_level: str | None = Field(default=None)
     clear_roles: bool = Field(default=False)
+    role_ids: list[str] | None = Field(default=None)
     display_name: str | None = Field(default=None, max_length=200)
     description: str | None = Field(default=None, max_length=2000)
     category: str | None = Field(default=None, max_length=100)

--- a/api/src/models/contracts/forms.py
+++ b/api/src/models/contracts/forms.py
@@ -270,6 +270,10 @@ class FormCreate(BaseModel):
     organization_id: UUID | None = Field(
         default=None, description="Organization ID (null = global resource)"
     )
+    role_ids: list[UUID] = Field(
+        default_factory=list,
+        description="Role IDs for role_based access (ignored if access_level is 'authenticated')",
+    )
 
 class FormUpdate(BaseModel):
     """Input for updating a form."""
@@ -286,6 +290,10 @@ class FormUpdate(BaseModel):
         default=None, description="Organization ID (null = global resource)"
     )
     clear_roles: bool = False
+    role_ids: list[UUID] | None = Field(
+        default=None,
+        description="Role IDs for role_based access (replaces existing roles when provided)",
+    )
 
 
 class FormPublic(BaseModel):
@@ -302,6 +310,10 @@ class FormPublic(BaseModel):
     form_schema: dict | FormSchema | None = None
     access_level: FormAccessLevel | None = None
     organization_id: UUID | None = None
+    role_ids: list[UUID] = Field(
+        default_factory=list,
+        description="Role IDs assigned to this form (for role_based access)",
+    )
     is_active: bool
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -361,6 +373,12 @@ class FormPublic(BaseModel):
                 "created_at": data.created_at,
                 "updated_at": data.updated_at,
             }
+            # Forward an attached role_ids list when callers populate it
+            # (via a separate FormRole query). Falls back to default_factory
+            # when absent so reads that don't bother stay backwards-compatible.
+            attached_role_ids = getattr(data, "role_ids", None)
+            if attached_role_ids is not None:
+                data_dict["role_ids"] = list(attached_role_ids)
             return data_dict
 
         return data

--- a/api/src/models/contracts/workflows.py
+++ b/api/src/models/contracts/workflows.py
@@ -159,6 +159,17 @@ class RegisterWorkflowRequest(BaseModel):
     path: str = Field(..., description="Workspace-relative path to the .py file")
     function_name: str = Field(..., description="Name of the decorated function to register")
     organization_id: str | None = Field(default=None, description="Organization ID to scope the workflow to, or null for global scope")
+    access_level: str | None = Field(
+        default=None,
+        description="Access level: 'authenticated' (any logged-in user) or 'role_based' (specific roles required). Omit to leave at the schema default.",
+    )
+    role_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Role IDs for role_based access. Omit to leave unchanged when "
+            "reactivating; pass an empty list to clear."
+        ),
+    )
 
 
 class RegisterWorkflowResponse(BaseModel):
@@ -275,6 +286,14 @@ class WorkflowUpdateRequest(BaseModel):
     clear_roles: bool = Field(
         default=False,
         description="If true, clear all role assignments for this workflow (sets to role_based with no roles)"
+    )
+    role_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "Role IDs for role_based access (bulk replaces existing assignments "
+            "when provided). Mutually exclusive with clear_roles; if both are "
+            "set, role_ids wins."
+        ),
     )
 
     # New fields for UI management

--- a/api/src/routers/forms.py
+++ b/api/src/routers/forms.py
@@ -27,6 +27,7 @@ from src.models.enums import FormAccessLevel
 from src.repositories.forms import FormRepository
 from src.models import Execution as ExecutionORM
 from src.models import Form as FormORM, FormField as FormFieldORM, FormRole as FormRoleORM, UserRole as UserRoleORM
+from src.models import Role as RoleORM
 from src.models import Workflow as WorkflowORM
 from src.models import FormCreate, FormUpdate, FormPublic
 from src.models.contracts.forms import FormField, FormSchema
@@ -282,6 +283,53 @@ async def list_forms(
     return result
 
 
+async def _replace_form_roles(
+    db: AsyncSession,
+    form_id: UUID,
+    role_ids: list[UUID],
+    assigned_by: str,
+) -> None:
+    """Bulk-replace role assignments on a form.
+
+    Validates every role exists, then deletes existing FormRole rows for the
+    form and inserts the new set. Empty list clears all assignments.
+    """
+    if role_ids:
+        existing = await db.execute(
+            select(RoleORM.id).where(RoleORM.id.in_(role_ids))
+        )
+        found = set(existing.scalars().all())
+        missing = [str(rid) for rid in role_ids if rid not in found]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Role(s) not found: {', '.join(missing)}",
+            )
+
+    await db.execute(
+        delete(FormRoleORM).where(FormRoleORM.form_id == form_id)
+    )
+    now = datetime.now(timezone.utc)
+    for role_id in role_ids:
+        db.add(
+            FormRoleORM(
+                form_id=form_id,
+                role_id=role_id,
+                assigned_by=assigned_by,
+                assigned_at=now,
+            )
+        )
+    await db.flush()
+
+
+async def _load_form_role_ids(db: AsyncSession, form_id: UUID) -> list[UUID]:
+    """Return the role IDs currently assigned to a form."""
+    result = await db.execute(
+        select(FormRoleORM.role_id).where(FormRoleORM.form_id == form_id)
+    )
+    return list(result.scalars().all())
+
+
 @router.post(
     "",
     response_model=FormPublic,
@@ -342,6 +390,10 @@ async def create_form(
 
     await db.flush()
 
+    # Apply role assignments before reloading so the response reflects them
+    if request.role_ids:
+        await _replace_form_roles(db, form.id, request.role_ids, ctx.user.email)
+
     # Reload form with fields eager-loaded
     result = await db.execute(
         select(FormORM)
@@ -360,6 +412,7 @@ async def create_form(
         org_id = str(form.organization_id) if form.organization_id else None
         await invalidate_form(org_id, str(form.id))
 
+    form.role_ids = await _load_form_role_ids(db, form.id)  # type: ignore[attr-defined]
     return FormPublic.model_validate(form)
 
 
@@ -392,9 +445,13 @@ async def get_form(
             detail="Form not found",
         )
 
+    async def _to_public(orm_form: FormORM) -> FormPublic:
+        orm_form.role_ids = await _load_form_role_ids(db, orm_form.id)  # type: ignore[attr-defined]
+        return FormPublic.model_validate(orm_form)
+
     # Check access - admins and embed users can see all forms
     if ctx.user.is_superuser or ctx.user.embed:
-        return FormPublic.model_validate(form)
+        return await _to_public(form)
 
     # Non-admins can only see active forms
     if not form.is_active:
@@ -413,7 +470,7 @@ async def get_form(
     # Check access level
     access_level = form.access_level or "role_based"
     if access_level == "authenticated":
-        return FormPublic.model_validate(form)
+        return await _to_public(form)
 
     # Role-based: check if user has a role assigned to this form
     role_query = select(UserRoleORM.role_id).where(UserRoleORM.user_id == ctx.user.user_id)
@@ -427,7 +484,7 @@ async def get_form(
         )
         form_role_result = await db.execute(form_role_query)
         if form_role_result.scalar_one_or_none() is not None:
-            return FormPublic.model_validate(form)
+            return await _to_public(form)
 
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
@@ -518,11 +575,19 @@ async def update_form(
     if "organization_id" in request.model_fields_set:
         form.organization_id = request.organization_id
 
-    # Clear all role assignments if requested
-    if request.clear_roles:
-        from src.models.orm.forms import FormRole
+    # Role assignment edits. ``role_ids`` (when explicitly provided) bulk-replaces
+    # the assignment set; ``clear_roles`` is the legacy single-purpose flag and
+    # wipes assignments when ``role_ids`` was not supplied. If both are provided,
+    # ``role_ids`` wins because it carries the more specific intent.
+    if request.role_ids is not None:
+        await _replace_form_roles(db, form_id, request.role_ids, ctx.user.email)
+        logger.info(
+            f"Replaced role assignments for form '{log_safe(form.name)}' "
+            f"({len(request.role_ids)} role(s))"
+        )
+    elif request.clear_roles:
         await db.execute(
-            delete(FormRole).where(FormRole.form_id == form_id)
+            delete(FormRoleORM).where(FormRoleORM.form_id == form_id)
         )
         # Also set to role_based access level (effectively no access)
         form.access_level = FormAccessLevel.ROLE_BASED
@@ -550,6 +615,7 @@ async def update_form(
         org_id = str(form.organization_id) if form.organization_id else None
         await invalidate_form(org_id, str(form_id))
 
+    form.role_ids = await _load_form_role_ids(db, form_id)  # type: ignore[attr-defined]
     return FormPublic.model_validate(form)
 
 

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -1179,6 +1179,35 @@ async def register_workflow(
     # Parse organization_id if provided
     org_uuid = UUID(request.organization_id) if request.organization_id else None
 
+    # Validate access_level early so we don't half-register on a typo
+    if request.access_level is not None and request.access_level not in ("authenticated", "role_based"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid access_level: '{request.access_level}'. Must be 'authenticated' or 'role_based'",
+        )
+
+    # Parse role_ids and verify they exist before any DB mutation
+    role_uuids: list[UUID] = []
+    if request.role_ids:
+        for rid_str in request.role_ids:
+            try:
+                role_uuids.append(UUID(rid_str))
+            except (ValueError, AttributeError):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid role ID: '{rid_str}' (expected a UUID)",
+                )
+        role_check = await db.execute(
+            select(Role.id).where(Role.id.in_(role_uuids))
+        )
+        found_role_ids = set(role_check.scalars().all())
+        missing_roles = [str(rid) for rid in role_uuids if rid not in found_role_ids]
+        if missing_roles:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Role(s) not found: {', '.join(missing_roles)}",
+            )
+
     if existing_wf and existing_wf.is_active:
         raise HTTPException(status_code=409, detail="Workflow already registered")
     elif existing_wf and not existing_wf.is_active:
@@ -1188,6 +1217,8 @@ async def register_workflow(
         existing_wf.is_orphaned = False
         existing_wf.type = wf_type
         existing_wf.organization_id = org_uuid
+        if request.access_level is not None:
+            existing_wf.access_level = request.access_level
         existing_wf.updated_at = datetime.now(timezone.utc)
         await db.flush()
     else:
@@ -1201,8 +1232,27 @@ async def register_workflow(
             type=wf_type,
             is_active=True,
             organization_id=org_uuid,
+            access_level=request.access_level if request.access_level is not None else "role_based",
         )
         db.add(new_wf)
+        await db.flush()
+
+    # Apply role assignments. Replaces any pre-existing rows when reactivating
+    # an inactive workflow, so the caller's role list is authoritative.
+    if request.role_ids is not None:
+        await db.execute(
+            delete(WorkflowRole).where(WorkflowRole.workflow_id == workflow_id)
+        )
+        now = datetime.now(timezone.utc)
+        for role_uuid in role_uuids:
+            db.add(
+                WorkflowRole(
+                    workflow_id=workflow_id,
+                    role_id=role_uuid,
+                    assigned_by=user.email,
+                    assigned_at=now,
+                )
+            )
         await db.flush()
 
     # 5. Run indexer to enrich with content-derived fields
@@ -1303,15 +1353,57 @@ async def update_workflow(
                 )
             workflow.access_level = request.access_level
 
-        # Clear all role assignments if requested
-        if request.clear_roles:
-            from src.models.orm.workflow_roles import WorkflowRole
+        # Role assignment edits. ``role_ids`` (when explicitly provided) bulk-replaces
+        # the assignment set; ``clear_roles`` is the legacy single-purpose flag and
+        # wipes assignments when ``role_ids`` was not supplied. If both are provided,
+        # ``role_ids`` wins because it carries the more specific intent.
+        if request.role_ids is not None:
+            target_role_uuids: list[UUID] = []
+            for rid_str in request.role_ids:
+                try:
+                    target_role_uuids.append(UUID(rid_str))
+                except (ValueError, AttributeError):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Invalid role ID: '{rid_str}' (expected a UUID)",
+                    )
+
+            if target_role_uuids:
+                role_check = await db.execute(
+                    select(Role.id).where(Role.id.in_(target_role_uuids))
+                )
+                found_role_ids = set(role_check.scalars().all())
+                missing_roles = [str(rid) for rid in target_role_uuids if rid not in found_role_ids]
+                if missing_roles:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Role(s) not found: {', '.join(missing_roles)}",
+                    )
+
+            await db.execute(
+                delete(WorkflowRole).where(WorkflowRole.workflow_id == workflow_id)
+            )
+            now = datetime.now(timezone.utc)
+            for role_uuid in target_role_uuids:
+                db.add(
+                    WorkflowRole(
+                        workflow_id=workflow_id,
+                        role_id=role_uuid,
+                        assigned_by=user.email,
+                        assigned_at=now,
+                    )
+                )
+            logger.info(
+                f"Replaced role assignments for workflow '{log_safe(workflow.name)}' "
+                f"({len(target_role_uuids)} role(s))"
+            )
+        elif request.clear_roles:
             await db.execute(
                 delete(WorkflowRole).where(WorkflowRole.workflow_id == workflow_id)
             )
             # Also set to role_based access level (effectively no access)
             workflow.access_level = "role_based"
-            logger.info(f"Cleared all role assignments for workflow '{workflow.name}'")
+            logger.info(f"Cleared all role assignments for workflow '{log_safe(workflow.name)}'")
 
         # Update display_name if provided
         if "display_name" in request.model_fields_set:

--- a/api/src/services/mcp_server/tools/workflow.py
+++ b/api/src/services/mcp_server/tools/workflow.py
@@ -433,6 +433,7 @@ async def update_workflow(
     organization_id: str | None = None,
     access_level: str | None = None,
     clear_roles: bool | None = None,
+    role_ids: list[str] | None = None,
     description: str | None = None,
     category: str | None = None,
     timeout_seconds: int | None = None,
@@ -443,11 +444,13 @@ async def update_workflow(
     """Update a workflow — ``PATCH /api/workflows/{uuid}``.
 
     ``workflow_ref`` is a UUID, workflow name, or ``path::func``.
-    Only the parameters the user supplies are sent. Fields marked as
-    UI/code-managed in :data:`bifrost.dto_flags.DTO_EXCLUDES`
-    (``display_name``, ``tool_description``, ``time_saved``, ``value``,
-    ``cache_ttl_seconds``, ``allowed_methods``, ``execution_mode``,
-    ``disable_global_key``) are not surfaced here.
+    ``role_ids`` bulk-replaces the workflow's role assignments when supplied
+    (an empty list clears them); pair with ``clear_roles=True`` only when no
+    list is provided. Fields marked as UI/code-managed in
+    :data:`bifrost.dto_flags.DTO_EXCLUDES` (``display_name``,
+    ``tool_description``, ``time_saved``, ``value``, ``cache_ttl_seconds``,
+    ``allowed_methods``, ``execution_mode``, ``disable_global_key``) are not
+    surfaced here.
     """
     if not workflow_ref:
         return error_result("workflow_ref is required")
@@ -472,6 +475,7 @@ async def update_workflow(
             "organization_id": organization_id,
             "access_level": access_level,
             "clear_roles": clear_roles,
+            "role_ids": role_ids,
             "description": description,
             "category": category,
             "timeout_seconds": timeout_seconds,

--- a/api/tests/e2e/api/test_forms.py
+++ b/api/tests/e2e/api/test_forms.py
@@ -1043,3 +1043,154 @@ class TestFormDBStorage:
 
         # Cleanup
         e2e_client.delete(f"/api/forms/{form_id}", headers=platform_admin.headers)
+
+
+@pytest.mark.e2e
+class TestFormRoleIdsAtCreateUpdate:
+    """``role_ids`` on ``FormCreate`` / ``FormUpdate`` (issue #162).
+
+    Forms previously could not be assigned to roles via the CLI/SDK at all —
+    role assignments only existed via ``POST /api/roles/{id}/forms``. Bulk
+    ``role_ids`` on the create/update DTOs closes that gap.
+    """
+
+    def _make_role(self, e2e_client, platform_admin, name: str) -> dict:
+        resp = e2e_client.post(
+            "/api/roles",
+            headers=platform_admin.headers,
+            json={"name": name, "description": f"role for {name}"},
+        )
+        assert resp.status_code == 201, resp.text
+        return resp.json()
+
+    def test_create_form_with_role_ids_persists_assignments(
+        self, e2e_client, platform_admin
+    ):
+        role_a = self._make_role(e2e_client, platform_admin, "Issue162 RoleA")
+        role_b = self._make_role(e2e_client, platform_admin, "Issue162 RoleB")
+        try:
+            create_resp = e2e_client.post(
+                "/api/forms",
+                headers=platform_admin.headers,
+                json={
+                    "name": "Issue162 Role-Assigned Form",
+                    "workflow_id": None,
+                    "form_schema": {"fields": [{"name": "x", "type": "text", "label": "X"}]},
+                    "access_level": "role_based",
+                    "role_ids": [role_a["id"], role_b["id"]],
+                },
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            form = create_resp.json()
+            # Response surfaces the assigned role IDs.
+            returned = set(form.get("role_ids", []))
+            assert returned == {role_a["id"], role_b["id"]}, form
+
+            # Re-fetch and confirm the platform persisted them.
+            get_resp = e2e_client.get(
+                f"/api/forms/{form['id']}",
+                headers=platform_admin.headers,
+            )
+            assert get_resp.status_code == 200
+            assert set(get_resp.json().get("role_ids", [])) == {
+                role_a["id"], role_b["id"]
+            }
+
+            # Cleanup
+            e2e_client.delete(f"/api/forms/{form['id']}", headers=platform_admin.headers)
+        finally:
+            e2e_client.delete(f"/api/roles/{role_a['id']}", headers=platform_admin.headers)
+            e2e_client.delete(f"/api/roles/{role_b['id']}", headers=platform_admin.headers)
+
+    def test_update_form_role_ids_replaces_existing(self, e2e_client, platform_admin):
+        role_a = self._make_role(e2e_client, platform_admin, "Issue162 ReplaceA")
+        role_b = self._make_role(e2e_client, platform_admin, "Issue162 ReplaceB")
+        role_c = self._make_role(e2e_client, platform_admin, "Issue162 ReplaceC")
+        try:
+            create_resp = e2e_client.post(
+                "/api/forms",
+                headers=platform_admin.headers,
+                json={
+                    "name": "Issue162 Replace Form",
+                    "workflow_id": None,
+                    "form_schema": {"fields": [{"name": "x", "type": "text", "label": "X"}]},
+                    "access_level": "role_based",
+                    "role_ids": [role_a["id"], role_b["id"]],
+                },
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            form = create_resp.json()
+
+            # Bulk-replace: pass only role_c. role_a and role_b should be removed.
+            patch_resp = e2e_client.patch(
+                f"/api/forms/{form['id']}",
+                headers=platform_admin.headers,
+                json={"role_ids": [role_c["id"]]},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            assert set(patch_resp.json().get("role_ids", [])) == {role_c["id"]}
+
+            # Empty list explicitly clears.
+            clear_resp = e2e_client.patch(
+                f"/api/forms/{form['id']}",
+                headers=platform_admin.headers,
+                json={"role_ids": []},
+            )
+            assert clear_resp.status_code == 200, clear_resp.text
+            assert clear_resp.json().get("role_ids", []) == []
+
+            e2e_client.delete(f"/api/forms/{form['id']}", headers=platform_admin.headers)
+        finally:
+            for r in (role_a, role_b, role_c):
+                e2e_client.delete(f"/api/roles/{r['id']}", headers=platform_admin.headers)
+
+    def test_update_form_omitting_role_ids_leaves_assignments_alone(
+        self, e2e_client, platform_admin
+    ):
+        """Patching unrelated fields must not touch role assignments."""
+        role_a = self._make_role(e2e_client, platform_admin, "Issue162 KeepA")
+        try:
+            create_resp = e2e_client.post(
+                "/api/forms",
+                headers=platform_admin.headers,
+                json={
+                    "name": "Issue162 Keep Form",
+                    "workflow_id": None,
+                    "form_schema": {"fields": [{"name": "x", "type": "text", "label": "X"}]},
+                    "access_level": "role_based",
+                    "role_ids": [role_a["id"]],
+                },
+            )
+            assert create_resp.status_code == 201, create_resp.text
+            form = create_resp.json()
+
+            # PATCH only ``description`` — role_ids must be untouched.
+            patch_resp = e2e_client.patch(
+                f"/api/forms/{form['id']}",
+                headers=platform_admin.headers,
+                json={"description": "renamed"},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            assert set(patch_resp.json().get("role_ids", [])) == {role_a["id"]}
+
+            e2e_client.delete(f"/api/forms/{form['id']}", headers=platform_admin.headers)
+        finally:
+            e2e_client.delete(f"/api/roles/{role_a['id']}", headers=platform_admin.headers)
+
+    def test_create_form_with_unknown_role_id_returns_404(
+        self, e2e_client, platform_admin
+    ):
+        bogus = "00000000-0000-0000-0000-000000000000"
+        resp = e2e_client.post(
+            "/api/forms",
+            headers=platform_admin.headers,
+            json={
+                "name": "Issue162 Bogus Role Form",
+                "workflow_id": None,
+                "form_schema": {"fields": []},
+                "access_level": "role_based",
+                "role_ids": [bogus],
+            },
+        )
+        assert resp.status_code == 404, resp.text
+        assert bogus in resp.text

--- a/api/tests/e2e/api/test_register_workflow.py
+++ b/api/tests/e2e/api/test_register_workflow.py
@@ -241,3 +241,228 @@ def test_reactivate_wf(message: str):
             "/api/files/editor?path=workflows/readme.md",
             headers=platform_admin.headers,
         )
+
+
+@pytest.mark.e2e
+class TestRegisterWorkflowAccess:
+    """``access_level`` + ``role_ids`` on workflow registration (issue #162)."""
+
+    def _write_wf(self, e2e_client, platform_admin, path: str, func: str) -> None:
+        e2e_client.delete(
+            f"/api/files/editor?path={path}",
+            headers=platform_admin.headers,
+        )
+        write_resp = e2e_client.put(
+            "/api/files/editor/content",
+            headers=platform_admin.headers,
+            json={
+                "path": path,
+                "content": (
+                    "from bifrost import workflow\n\n"
+                    f"@workflow(name='{func}')\n"
+                    f"def {func}(message: str):\n"
+                    "    return {'ok': True}\n"
+                ),
+                "encoding": "utf-8",
+            },
+        )
+        assert write_resp.status_code == 200, write_resp.text
+
+    def _make_role(self, e2e_client, platform_admin, name: str) -> dict:
+        resp = e2e_client.post(
+            "/api/roles",
+            headers=platform_admin.headers,
+            json={"name": name, "description": f"role for {name}"},
+        )
+        assert resp.status_code == 201, resp.text
+        return resp.json()
+
+    def test_register_with_access_level_and_role_ids_persists(
+        self, e2e_client, platform_admin
+    ):
+        path = "workflows/test_reg_access.py"
+        func = "test_reg_access"
+        self._write_wf(e2e_client, platform_admin, path, func)
+        role = self._make_role(e2e_client, platform_admin, "Issue162 RegRoleA")
+        try:
+            reg_resp = e2e_client.post(
+                "/api/workflows/register",
+                headers=platform_admin.headers,
+                json={
+                    "path": path,
+                    "function_name": func,
+                    "access_level": "role_based",
+                    "role_ids": [role["id"]],
+                },
+            )
+            assert reg_resp.status_code == 201, reg_resp.text
+            wf_id = reg_resp.json()["id"]
+
+            # Confirm via the workflow's roles endpoint that the assignment landed.
+            roles_resp = e2e_client.get(
+                f"/api/workflows/{wf_id}/roles",
+                headers=platform_admin.headers,
+            )
+            assert roles_resp.status_code == 200, roles_resp.text
+            assert role["id"] in roles_resp.json().get("role_ids", [])
+
+            # Cleanup workflow
+            e2e_client.delete(
+                f"/api/workflows/{wf_id}",
+                headers=platform_admin.headers,
+            )
+        finally:
+            e2e_client.delete(
+                f"/api/files/editor?path={path}",
+                headers=platform_admin.headers,
+            )
+            e2e_client.delete(
+                f"/api/roles/{role['id']}",
+                headers=platform_admin.headers,
+            )
+
+    def test_register_with_invalid_access_level_returns_400(
+        self, e2e_client, platform_admin
+    ):
+        path = "workflows/test_reg_bad_access.py"
+        func = "test_reg_bad_access"
+        self._write_wf(e2e_client, platform_admin, path, func)
+        try:
+            resp = e2e_client.post(
+                "/api/workflows/register",
+                headers=platform_admin.headers,
+                json={
+                    "path": path,
+                    "function_name": func,
+                    "access_level": "public",  # invalid
+                },
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            e2e_client.delete(
+                f"/api/files/editor?path={path}",
+                headers=platform_admin.headers,
+            )
+
+    def test_register_with_unknown_role_returns_404(self, e2e_client, platform_admin):
+        path = "workflows/test_reg_bad_role.py"
+        func = "test_reg_bad_role"
+        self._write_wf(e2e_client, platform_admin, path, func)
+        bogus = "00000000-0000-0000-0000-000000000000"
+        try:
+            resp = e2e_client.post(
+                "/api/workflows/register",
+                headers=platform_admin.headers,
+                json={
+                    "path": path,
+                    "function_name": func,
+                    "role_ids": [bogus],
+                },
+            )
+            assert resp.status_code == 404, resp.text
+            assert bogus in resp.text
+        finally:
+            e2e_client.delete(
+                f"/api/files/editor?path={path}",
+                headers=platform_admin.headers,
+            )
+
+
+@pytest.mark.e2e
+class TestWorkflowUpdateRoleIds:
+    """``role_ids`` bulk-replace on PATCH /api/workflows/{id} (issue #162)."""
+
+    def _write_and_register(self, e2e_client, platform_admin, path: str, func: str) -> str:
+        e2e_client.delete(
+            f"/api/files/editor?path={path}",
+            headers=platform_admin.headers,
+        )
+        write_resp = e2e_client.put(
+            "/api/files/editor/content",
+            headers=platform_admin.headers,
+            json={
+                "path": path,
+                "content": (
+                    "from bifrost import workflow\n\n"
+                    f"@workflow(name='{func}')\n"
+                    f"def {func}(message: str):\n"
+                    "    return {'ok': True}\n"
+                ),
+                "encoding": "utf-8",
+            },
+        )
+        assert write_resp.status_code == 200, write_resp.text
+        reg_resp = e2e_client.post(
+            "/api/workflows/register",
+            headers=platform_admin.headers,
+            json={"path": path, "function_name": func},
+        )
+        assert reg_resp.status_code == 201, reg_resp.text
+        return reg_resp.json()["id"]
+
+    def _make_role(self, e2e_client, platform_admin, name: str) -> dict:
+        resp = e2e_client.post(
+            "/api/roles",
+            headers=platform_admin.headers,
+            json={"name": name, "description": f"role for {name}"},
+        )
+        assert resp.status_code == 201, resp.text
+        return resp.json()
+
+    def test_update_role_ids_replaces_assignments(self, e2e_client, platform_admin):
+        path = "workflows/test_wf_replace.py"
+        func = "test_wf_replace"
+        wf_id = self._write_and_register(e2e_client, platform_admin, path, func)
+        role_a = self._make_role(e2e_client, platform_admin, "Issue162 WfReplaceA")
+        role_b = self._make_role(e2e_client, platform_admin, "Issue162 WfReplaceB")
+        try:
+            # Seed via the existing batch assign endpoint.
+            seed = e2e_client.post(
+                f"/api/workflows/{wf_id}/roles",
+                headers=platform_admin.headers,
+                json={"role_ids": [role_a["id"]]},
+            )
+            assert seed.status_code == 204, seed.text
+
+            # Bulk-replace with role_b only.
+            patch_resp = e2e_client.patch(
+                f"/api/workflows/{wf_id}",
+                headers=platform_admin.headers,
+                json={"role_ids": [role_b["id"]]},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+
+            roles_resp = e2e_client.get(
+                f"/api/workflows/{wf_id}/roles",
+                headers=platform_admin.headers,
+            )
+            assert roles_resp.status_code == 200
+            assigned = set(roles_resp.json().get("role_ids", []))
+            assert assigned == {role_b["id"]}
+
+            # Empty list clears.
+            clear_resp = e2e_client.patch(
+                f"/api/workflows/{wf_id}",
+                headers=platform_admin.headers,
+                json={"role_ids": []},
+            )
+            assert clear_resp.status_code == 200, clear_resp.text
+            roles_resp = e2e_client.get(
+                f"/api/workflows/{wf_id}/roles",
+                headers=platform_admin.headers,
+            )
+            assert roles_resp.json().get("role_ids", []) == []
+        finally:
+            e2e_client.delete(
+                f"/api/workflows/{wf_id}",
+                headers=platform_admin.headers,
+            )
+            e2e_client.delete(
+                f"/api/files/editor?path={path}",
+                headers=platform_admin.headers,
+            )
+            for r in (role_a, role_b):
+                e2e_client.delete(
+                    f"/api/roles/{r['id']}",
+                    headers=platform_admin.headers,
+                )

--- a/api/tests/unit/test_dto_body_assembly.py
+++ b/api/tests/unit/test_dto_body_assembly.py
@@ -292,6 +292,61 @@ async def test_role_ids_comma_split_accepted() -> None:
 
 
 @pytest.mark.asyncio
+async def test_form_create_resolves_role_ids() -> None:
+    """``--role-ids admin,ops`` on form create resolves names → UUIDs."""
+    resolver = _resolver()
+    body = await assemble_body(
+        FormCreate,
+        _parsed(
+            FormCreate,
+            {
+                "name": "F",
+                "workflow_id": "MyWorkflow",
+                "form_schema": '{"fields":[]}',
+                "role_ids": ("admin", "ops"),
+            },
+        ),
+        resolver=resolver,  # type: ignore[arg-type]
+    )
+    assert body["role_ids"] == [ROLE_UUID, ROLE_UUID_2]
+
+
+@pytest.mark.asyncio
+async def test_form_update_resolves_role_ids_comma_split() -> None:
+    resolver = _resolver()
+    body = await assemble_body(
+        FormUpdate,
+        _parsed(FormUpdate, {"role_ids": ("admin,ops",)}),
+        resolver=resolver,  # type: ignore[arg-type]
+    )
+    assert body["role_ids"] == [ROLE_UUID, ROLE_UUID_2]
+
+
+@pytest.mark.asyncio
+async def test_form_update_omits_role_ids_when_unset() -> None:
+    """No ``--role-ids`` → field absent from body (not ``[]``)."""
+    resolver = _resolver()
+    body = await assemble_body(
+        FormUpdate,
+        _parsed(FormUpdate, {"name": "Renamed"}),
+        resolver=resolver,  # type: ignore[arg-type]
+    )
+    assert "role_ids" not in body
+    assert body == {"name": "Renamed"}
+
+
+@pytest.mark.asyncio
+async def test_workflow_update_resolves_role_ids() -> None:
+    resolver = _resolver()
+    body = await assemble_body(
+        WorkflowUpdateRequest,
+        _parsed(WorkflowUpdateRequest, {"role_ids": ("admin", "ops")}),
+        resolver=resolver,  # type: ignore[arg-type]
+    )
+    assert body["role_ids"] == [ROLE_UUID, ROLE_UUID_2]
+
+
+@pytest.mark.asyncio
 async def test_repeatable_list_str_passthrough() -> None:
     resolver = _resolver()
     body = await assemble_body(


### PR DESCRIPTION
## Summary

Closes #162.

Mirrors the apps create/update access surface across forms and workflows so contributors don't have to drop into the UI to assign access:

- **Forms**: `role_ids` on `FormCreate` / `FormUpdate` (bulk replace on update). The new `GET /api/forms/{id}` payload returns the role IDs so the CLI can verify the assignment landed.
- **Workflows**: `role_ids` on `WorkflowUpdateRequest` for bulk replace; `--access-level` + `--role-ids` on `bifrost workflows register` so workflows can be created with the right access in one call (no more register → update → grant-role-per-role dance). The existing `grant-role` / `revoke-role` per-role primitive stays as-is.
- **`bifrost-build` skill**: Adds an access-compatibility checkpoint that fires before scaffolding, prompting the user to confirm `(organization, access_level, role_ids)` once and reuse it across the app + every supporting workflow/form. The compatibility rule: every dependency must be global, org-scoped+`authenticated`, or assigned the same role(s) as the consuming app.

## Test plan

- [x] `./test.sh tests/unit/test_dto_flags.py tests/unit/test_dto_body_assembly.py` — DTO field-parity catches the new fields automatically; new asserts cover `--role-ids` name → UUID resolution for `FormCreate`, `FormUpdate`, and `WorkflowUpdateRequest`, plus omit-unset semantics.
- [x] `./test.sh tests/e2e/api/test_forms.py` — new `TestFormRoleIdsAtCreateUpdate` covers create-with-roles, bulk-replace on update, leave-assignments-alone when role_ids omitted, and 404 on unknown role.
- [x] `./test.sh tests/e2e/api/test_register_workflow.py` — new `TestRegisterWorkflowAccess` covers register with access_level + role_ids, invalid access_level → 400, unknown role → 404. New `TestWorkflowUpdateRoleIds` covers PATCH bulk-replace and clear-via-empty-list.
- [x] `./test.sh tests/e2e/api/test_workflows.py tests/e2e/api/test_roles.py` — no regressions.
- [x] `pyright` and `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)