### PR TITLE
fix(cli): persist password-grant login to .env in CWD

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -287,10 +287,11 @@ async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool
 
 async def password_login_flow(api_url: str, email: str, password: str) -> tuple[int, dict | None]:
     """
-    Password-grant login. Tokens are returned to the caller; the caller decides
-    whether to persist them. The CLI's `bifrost login` command does NOT persist
-    them — the three BIFROST_* env-var lines printed to stdout are the entire
-    contract. Suitable only for isolated development stacks with MFA disabled.
+    Password-grant login. Tokens are returned to the caller; the caller
+    decides where to persist them. The CLI's `bifrost login` command writes
+    BIFROST_API_URL + the two tokens to .env in CWD so subsequent commands
+    in that directory inherit them. Suitable only for isolated development
+    stacks with MFA disabled.
 
     Returns (exit_code, payload). On success, payload is the parsed JSON
     response from /auth/login containing access_token / refresh_token.
@@ -367,6 +368,34 @@ def _read_env_file(path: pathlib.Path) -> list[str]:
         return []
 
 
+def _upsert_env_vars(updates: dict[str, str]) -> None:
+    """
+    Write or update KEY=VALUE pairs in CWD's .env.
+
+    For each key in ``updates``: replaces an existing ``KEY=`` (or
+    ``export KEY=``) line if present; otherwise appends.
+    """
+    cwd = pathlib.Path.cwd()
+    env_path = cwd / ".env"
+    lines = _read_env_file(env_path)
+
+    for key, value in updates.items():
+        new_line = f"{key}={value}\n"
+        found = False
+        for i, line in enumerate(lines):
+            stripped = line.lstrip()
+            if stripped.startswith(f"{key}=") or stripped.startswith(f"export {key}="):
+                lines[i] = new_line
+                found = True
+                break
+        if not found:
+            if lines and not lines[-1].endswith("\n"):
+                lines[-1] = lines[-1] + "\n"
+            lines.append(new_line)
+
+    env_path.write_text("".join(lines))
+
+
 def _write_env_url(api_url: str) -> None:
     """
     Write or update `BIFROST_API_URL=<api_url>` in CWD's .env.
@@ -374,25 +403,9 @@ def _write_env_url(api_url: str) -> None:
     Updates an existing `BIFROST_API_URL=` line if present; otherwise appends.
     Adds `.env` to .gitignore if it isn't already gitignored.
     """
+    _upsert_env_vars({"BIFROST_API_URL": api_url})
     cwd = pathlib.Path.cwd()
     env_path = cwd / ".env"
-    lines = _read_env_file(env_path)
-
-    new_line = f"BIFROST_API_URL={api_url}\n"
-    found = False
-    for i, line in enumerate(lines):
-        stripped = line.lstrip()
-        if stripped.startswith("BIFROST_API_URL=") or stripped.startswith("export BIFROST_API_URL="):
-            lines[i] = new_line
-            found = True
-            break
-    if not found:
-        # Ensure file ends with newline before appending
-        if lines and not lines[-1].endswith("\n"):
-            lines[-1] = lines[-1] + "\n"
-        lines.append(new_line)
-
-    env_path.write_text("".join(lines))
     print(f"Updated {env_path} with BIFROST_API_URL={api_url}")
 
     # gitignore .env if we're in a git repo and it isn't already ignored
@@ -649,9 +662,11 @@ Browser (default): Device-code flow; tokens stored in OS keychain (with JSON
                    current directory so subsequent CLI commands target this
                    instance.
 Password: When --email and --password are passed, performs an ephemeral
-          password-grant login and prints BIFROST_* env-var lines to stdout.
-          Tokens are NOT persisted. For isolated dev stacks only — refuses
-          if MFA is enabled on the instance.
+          password-grant login and writes BIFROST_API_URL +
+          BIFROST_ACCESS_TOKEN + BIFROST_REFRESH_TOKEN to .env in the
+          current directory. Subsequent CLI commands from this directory
+          pick the tokens up automatically. For isolated dev stacks only
+          — refuses if MFA is enabled on the instance.
 
 Options:
   --url, -u URL         API URL (default: BIFROST_API_URL or http://localhost:8000)
@@ -695,9 +710,26 @@ Examples:
         assert password is not None
         rc, data = asyncio.run(password_login_flow(api_url, email, password))
         if rc == 0 and data is not None:
-            print(f"BIFROST_API_URL={api_url}")
-            print(f"BIFROST_ACCESS_TOKEN={data['access_token']}")
-            print(f"BIFROST_REFRESH_TOKEN={data['refresh_token']}")
+            # Persist URL + tokens to CWD's .env so subsequent `bifrost`
+            # commands from this directory just work — no shell-eval needed.
+            # Isolation is by directory: each sandbox dir has its own .env.
+            try:
+                _write_env_url(api_url)
+                _upsert_env_vars(
+                    {
+                        "BIFROST_ACCESS_TOKEN": data["access_token"],
+                        "BIFROST_REFRESH_TOKEN": data["refresh_token"],
+                    }
+                )
+            except OSError as e:
+                print(
+                    f"Warning: could not update .env in current directory: {e}",
+                    file=sys.stderr,
+                )
+                # Fall back to printing so the caller can eval them.
+                print(f"BIFROST_API_URL={api_url}")
+                print(f"BIFROST_ACCESS_TOKEN={data['access_token']}")
+                print(f"BIFROST_REFRESH_TOKEN={data['refresh_token']}")
         return rc
 
     # Browser device-code flow (persistent → keychain or JSON fallback).

--- a/api/tests/unit/test_cli_login_ephemeral.py
+++ b/api/tests/unit/test_cli_login_ephemeral.py
@@ -4,8 +4,10 @@ Two login modes:
   * Browser device-code (default) — token stored in keychain (or JSON
     fallback). On success, login also writes BIFROST_API_URL=<url> to the
     CWD .env so subsequent CLI commands in this folder target this stack.
-  * Password-grant (when --email and --password are passed) — tokens
-    printed to stdout, never persisted. Refuses MFA-enabled instances.
+  * Password-grant (when --email and --password are passed) — URL +
+    access + refresh tokens written to .env in CWD so subsequent CLI
+    commands from that directory inherit the session. Tokens are NOT
+    written to the OS keychain. Refuses MFA-enabled instances.
 """
 
 from bifrost import cli
@@ -63,13 +65,16 @@ class TestPasswordLoginFlagParsing:
 
 
 class TestPasswordLoginSuccess:
-    def test_prints_three_lines_and_warning(self, capsys, monkeypatch):
+    def test_writes_three_vars_to_env_and_warning_to_stderr(
+        self, capsys, monkeypatch, tmp_path,
+    ):
         stub = _stub_post({
             "access_token": "at_value",
             "refresh_token": "rt_value",
             "expires_in": 1800,
         })
         monkeypatch.setattr("httpx.AsyncClient", stub)
+        monkeypatch.chdir(tmp_path)
 
         rc = cli.handle_login([
             "--email", "dev@gobifrost.com",
@@ -78,17 +83,23 @@ class TestPasswordLoginSuccess:
         ])
         assert rc == 0
 
-        captured = capsys.readouterr()
-        out_lines = [line for line in captured.out.splitlines() if line.strip()]
-        assert "BIFROST_API_URL=http://localhost:38421" in out_lines
-        assert "BIFROST_ACCESS_TOKEN=at_value" in out_lines
-        assert "BIFROST_REFRESH_TOKEN=rt_value" in out_lines
+        env_text = (tmp_path / ".env").read_text()
+        assert "BIFROST_API_URL=http://localhost:38421" in env_text
+        assert "BIFROST_ACCESS_TOKEN=at_value" in env_text
+        assert "BIFROST_REFRESH_TOKEN=rt_value" in env_text
 
         # Warning to stderr
+        captured = capsys.readouterr()
         assert "MFA" in captured.err
         assert "ephemeral" in captured.err.lower()
 
-    def test_does_not_write_to_disk(self, capsys, monkeypatch, tmp_path):
+    def test_does_not_write_to_keychain(self, capsys, monkeypatch, tmp_path):
+        """Password-grant must not touch the persistent (keychain/JSON) store.
+
+        The session is per-directory via .env; persistence is intentionally
+        excluded so a password-grant login on a dev machine doesn't end up
+        in the long-lived auth list visible to `bifrost auth list`.
+        """
         stub = _stub_post({
             "access_token": "at",
             "refresh_token": "rt",
@@ -99,7 +110,6 @@ class TestPasswordLoginSuccess:
             "bifrost.credentials.get_credentials_path",
             lambda: tmp_path / "credentials.json",
         )
-        # Run from tmp_path so any inadvertent .env write also goes there
         monkeypatch.chdir(tmp_path)
 
         cli.handle_login([
@@ -108,8 +118,10 @@ class TestPasswordLoginSuccess:
             "--url", "http://localhost:38421",
         ])
 
+        # No keychain / JSON-fallback record was written.
         assert not (tmp_path / "credentials.json").exists()
-        assert not (tmp_path / ".env").exists()
+        # .env IS written (that's the new contract).
+        assert (tmp_path / ".env").exists()
 
 
 class TestPasswordLoginMfaRefusal:
@@ -139,7 +151,7 @@ class TestPasswordLoginMfaRefusal:
 
 
 class TestPasswordLoginUsesBifrostApiUrl:
-    def test_falls_back_to_env_var_for_url(self, capsys, monkeypatch):
+    def test_falls_back_to_env_var_for_url(self, capsys, monkeypatch, tmp_path):
         stub = _stub_post({
             "access_token": "at",
             "refresh_token": "rt",
@@ -147,14 +159,15 @@ class TestPasswordLoginUsesBifrostApiUrl:
         })
         monkeypatch.setattr("httpx.AsyncClient", stub)
         monkeypatch.setenv("BIFROST_API_URL", "http://localhost:38421")
+        monkeypatch.chdir(tmp_path)
 
         rc = cli.handle_login([
             "--email", "dev@gobifrost.com",
             "--password", "password",
         ])
         assert rc == 0
-        out_lines = capsys.readouterr().out.splitlines()
-        assert "BIFROST_API_URL=http://localhost:38421" in out_lines
+        env_text = (tmp_path / ".env").read_text()
+        assert "BIFROST_API_URL=http://localhost:38421" in env_text
 
 
 class TestBrowserLoginWritesEnv:


### PR DESCRIPTION
## Summary
- `bifrost login --email --password` now writes `BIFROST_API_URL` + access + refresh tokens to `.env` in CWD instead of just printing them to stdout
- Subsequent `bifrost <anything>` from that directory authenticates automatically — no shell-eval gymnastics
- Per-directory dev sandboxes are now genuinely self-contained: `cd /tmp/sandbox-A && bifrost login --email --password` and `cd /tmp/sandbox-B && bifrost login ...` can target different stacks in parallel without global-state collisions

Pairs with #160's `find_dotenv(usecwd=True)` — that change made the CLI *read* `.env` from CWD; this change makes the CLI *write* to it on password-grant login so there's actually something to read.

Discovered while spinning up an isolated debug stack (`/tmp/jit-sandbox`) to repro a JIT-Accounts bug — `bifrost login --email --password` succeeded but `bifrost api ...` from the same shell failed with "Not logged in" because tokens never landed anywhere persistent.

Refactored `_write_env_url()` to use a new `_upsert_env_vars()` helper so URL and tokens go through the same upsert path.

## Test plan
- [x] Manually verified end-to-end: `rm .env && bifrost login --url X --email Y --password Z` writes the three vars; a fresh `env -i` shell can then run `bifrost api GET /api/auth/me` from that directory and authenticate
- [x] Two parallel sandboxes (different `.env` per dir) work independently
- [ ] CI: existing tests pass (no test currently covers password-grant persistence — could add one if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)