### PR TITLE
feat(workflow-hooks): add errorMessage as canonical alias, deprecate error

### DIFF
--- a/client/src/lib/app-code-platform.d.ts
+++ b/client/src/lib/app-code-platform.d.ts
@@ -59,7 +59,15 @@ export interface UseWorkflowQueryResult<T> {
 	isLoading: boolean;
 	/** True if the workflow failed. */
 	isError: boolean;
-	/** Error message if the workflow failed. */
+	/**
+	 * Error message string if the workflow failed, otherwise null.
+	 * Already a string — do NOT access `.message` on this value.
+	 */
+	errorMessage: string | null;
+	/**
+	 * @deprecated Use `errorMessage` — this is a string alias kept for
+	 * backward compatibility. Reading `error.message` returns undefined.
+	 */
 	error: string | null;
 	/** Streaming logs array that updates in real-time. */
 	logs: StreamingLog[];
@@ -84,13 +92,13 @@ export interface UseWorkflowQueryResult<T> {
  * @example
  * ```tsx
  * // Load data on mount
- * const { data, isLoading, error } = useWorkflowQuery<Customer[]>(
+ * const { data, isLoading, errorMessage } = useWorkflowQuery<Customer[]>(
  *   "workflow-uuid",
  *   { limit: 10 }
  * );
  *
  * if (isLoading) return <Skeleton />;
- * if (error) return <Alert>{error}</Alert>;
+ * if (errorMessage) return <Alert>{errorMessage}</Alert>;
  * return <CustomerList data={data} />;
  * ```
  *
@@ -120,7 +128,15 @@ export interface UseWorkflowMutationResult<T> {
 	isLoading: boolean;
 	/** True if the last execution failed. */
 	isError: boolean;
-	/** Error message from the last execution. */
+	/**
+	 * Error message string from the last execution, otherwise null.
+	 * Already a string — do NOT access `.message` on this value.
+	 */
+	errorMessage: string | null;
+	/**
+	 * @deprecated Use `errorMessage` — this is a string alias kept for
+	 * backward compatibility. Reading `error.message` returns undefined.
+	 */
 	error: string | null;
 	/** Result data from the last execution. */
 	data: T | null;

--- a/client/src/lib/app-code-platform/useWorkflowMutation.ts
+++ b/client/src/lib/app-code-platform/useWorkflowMutation.ts
@@ -49,6 +49,16 @@ export interface UseWorkflowMutationResult<T> {
 	execute: (params?: Record<string, unknown>) => Promise<T>;
 	isLoading: boolean;
 	isError: boolean;
+	/**
+	 * Workflow execution error message, or null on success / before completion.
+	 * Already a string — do NOT access `.message` on this value.
+	 */
+	errorMessage: string | null;
+	/**
+	 * @deprecated Use `errorMessage` — this is a string alias kept for
+	 * backward compatibility. Reading `error.message` returns undefined and
+	 * is the source of "Unknown error" fallbacks in app code.
+	 */
 	error: string | null;
 	data: T | null;
 	logs: StreamingLog[];
@@ -390,6 +400,7 @@ export function useWorkflowMutation<T = unknown>(
 		execute,
 		isLoading,
 		isError,
+		errorMessage: error,
 		error,
 		data,
 		logs,

--- a/client/src/lib/app-code-platform/useWorkflowQuery.test.ts
+++ b/client/src/lib/app-code-platform/useWorkflowQuery.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { UseWorkflowMutationResult } from "./useWorkflowMutation";
+import type { UseWorkflowQueryResult } from "./useWorkflowQuery";
+
+// These tests exist to catch a specific historical regression: app code
+// reaching for `error.message` because every other React-Query-shaped hook
+// returns an Error object. Our `error` field is a plain string. We expose
+// the new canonical name `errorMessage` (also a string) so the shape is
+// self-documenting; `error` is kept as a deprecated alias.
+//
+// The tests are type-level + a tiny runtime shape assertion to guard the
+// alias against accidental drift.
+
+describe("useWorkflowQuery / useWorkflowMutation result shape", () => {
+	it("exposes errorMessage as a string-or-null and keeps error as the same value", () => {
+		const fakeMutation: UseWorkflowMutationResult<unknown> = {
+			execute: async () => undefined,
+			isLoading: false,
+			isError: true,
+			errorMessage: "boom",
+			error: "boom",
+			data: null,
+			logs: [],
+			reset: () => undefined,
+			executionId: null,
+			status: null,
+		};
+
+		expect(fakeMutation.errorMessage).toBe("boom");
+		expect(fakeMutation.error).toBe(fakeMutation.errorMessage);
+		expect(typeof fakeMutation.errorMessage).toBe("string");
+	});
+
+	it("Query result shape exposes the same alias", () => {
+		const fakeQuery: UseWorkflowQueryResult<unknown> = {
+			data: null,
+			isLoading: false,
+			isError: true,
+			errorMessage: "kaboom",
+			error: "kaboom",
+			logs: [],
+			refetch: async () => undefined,
+			executionId: null,
+			status: null,
+		};
+
+		expect(fakeQuery.errorMessage).toBe("kaboom");
+		expect(fakeQuery.error).toBe(fakeQuery.errorMessage);
+	});
+});
+
+// Type-level: assigning a non-string-or-null to errorMessage must fail to
+// compile. The `void` here keeps this an unused-but-not-tree-shaken assertion.
+type _ErrorMessageIsStringOrNull =
+	UseWorkflowQueryResult<unknown>["errorMessage"] extends string | null
+		? true
+		: false;
+const _check: _ErrorMessageIsStringOrNull = true;
+void _check;

--- a/client/src/lib/app-code-platform/useWorkflowQuery.ts
+++ b/client/src/lib/app-code-platform/useWorkflowQuery.ts
@@ -20,6 +20,16 @@ export interface UseWorkflowQueryResult<T> {
 	data: T | null;
 	isLoading: boolean;
 	isError: boolean;
+	/**
+	 * Workflow execution error message, or null on success / before completion.
+	 * Already a string — do NOT access `.message` on this value.
+	 */
+	errorMessage: string | null;
+	/**
+	 * @deprecated Use `errorMessage` — this is a string alias kept for
+	 * backward compatibility. Reading `error.message` returns undefined and
+	 * is the source of "Unknown error" fallbacks in app code.
+	 */
 	error: string | null;
 	logs: StreamingLog[];
 	refetch: () => Promise<T>;
@@ -59,7 +69,8 @@ export function useWorkflowQuery<T = unknown>(
 		data: mutation.data,
 		isLoading: mutation.isLoading,
 		isError: mutation.isError,
-		error: mutation.error,
+		errorMessage: mutation.errorMessage,
+		error: mutation.errorMessage,
 		logs: mutation.logs,
 		refetch: () => mutation.execute(params),
 		executionId: mutation.executionId,


### PR DESCRIPTION
## Summary
- Add \`errorMessage: string | null\` to \`useWorkflowQuery\` / \`useWorkflowMutation\` results as the canonical name for what \`error\` already returned.
- Mark \`error\` \`@deprecated\` with a JSDoc explaining that the value is already a string — readers reaching for \`.message\` will see the deprecation in their editor.
- Update the user-facing \`app-code-platform.d.ts\` declarations to surface both fields with matching docstrings; update the \`@example\` to model the recommended pattern.
- Add a vitest spec pinning the alias contract.

## Why
\`useWorkflowQuery\`'s result already returned a plain string for \`error\`, but every React-Query-shaped hook in the wider ecosystem returns an \`Error\`. App code (and AI codegen) reflexively reaches for \`error.message\` and falls back to a generic \"Unknown error\" UI when \`.message\` is undefined — silently hiding the real failure. JIT-Accounts hit this in production (\`(error as any)?.message || \"Unknown error\"\`) and we caught it on a debug stack: the platform was handing back the actual Python exception message verbatim, but the app's fallback ate it.

\`errorMessage\` makes the contract self-documenting at the call site: a name like that nudges code generators and humans toward the right access. \`error\` stays as a non-breaking alias with a deprecation marker; nothing existing breaks.

## What's not in scope
- No deletion of \`error\` (keeps existing apps working).
- No change to \`error\` semantics (still a string, still null on success).
- No backend change.

## Test plan
- [x] \`useWorkflowQuery.test.ts\` — pins the alias (errorMessage === error, both string-or-null).
- [x] Vitest: 115 files / 779 tests pass.
- [x] \`npm run tsc\` clean.
- [x] \`npm run lint\` clean (one pre-existing warning unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)