### PR TITLE
feat(cli): add workflows execute (WS-streaming) + requirements group

### DIFF
--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -7,6 +7,19 @@ description: Build Bifrost workflows, forms, and apps. Use when user wants to cr
 
 Create and debug Bifrost artifacts.
 
+## Who Runs What (read this first)
+
+The skill draws a hard line between commands the agent runs and commands the user runs. Mixing them up is the #1 source of confusion.
+
+| Action | Who runs it | Why |
+|---|---|---|
+| `bifrost run <file>`, `bifrost workflows execute`, `bifrost <entity> create / update / delete / get / list`, `bifrost api GET/POST`, `bifrost requirements install` | **Agent** | Non-interactive, idempotent, scoped to the entity at hand |
+| Writing files into `apps/` and `workflows/` | **Agent** (after confirming `bifrost watch` is running) | Watch syncs them automatically |
+| `bifrost watch`, `bifrost sync`, `bifrost push`, `bifrost pull`, `bifrost git push` | **User** | Interactive TUI, broad blast radius, controls deployment cadence |
+| `bifrost requirements install <pkg>` (ONLY on a workflow that triggered `ModuleNotFoundError`) | **Agent** | Recycles workers — see "Python workflow dependencies" |
+
+When in doubt, the agent does the small entity mutation; the user does anything that watches files, deploys, or recycles infrastructure unsolicited.
+
 ## First: Check Prerequisites
 
 ```bash
@@ -15,6 +28,8 @@ echo "Source: $BIFROST_HAS_SOURCE | Path: $BIFROST_SOURCE_PATH | URL: $BIFROST_D
 ```
 
 **If SDK or Login is false/empty:** Direct user to run `/bifrost:setup` first.
+
+**If `BIFROST_DEV_URL` is empty:** Don't guess the URL. Ask the user: "I don't see `BIFROST_DEV_URL` set — what URL should I use for previews and platform links?" Then use that. Never invent a `*.gobifrost.com` / `*.musick.gg` / etc. host on your own; the user has been burned by this before.
 
 ## Step 1: Download Platform Docs (Once Per Session)
 
@@ -162,7 +177,9 @@ Example — Agent Tuning tools:
 |---------|---------|
 | `bifrost watch` | Primary dev command — starts interactive watch session, syncs file changes on save |
 | `bifrost sync` | One-shot bidirectional sync — **interactive TUI, user must run manually** |
-| `bifrost run <file> -w <name> --org <UUID>` | Execute workflow in specific org context |
+| `bifrost run <file> -w <name> --org <UUID>` | Execute workflow from a local `.py` file (no sync required). Best for active iteration. |
+| `bifrost workflows execute <ref> --params '{...}'` | Execute a registered workflow remotely; streams logs via WebSocket; exits on terminal status. |
+| `bifrost requirements install [pkg[==ver]] \| list \| remove <pkg>` | Manage workspace `requirements.txt` for Python workflow deps. Workers recycle async after install/remove. |
 | `bifrost api <METHOD> <path>` | Bifrost platform API client ONLY — inspect executions, validate apps, check platform state. NOT for third-party APIs. |
 | `bifrost push` | One-shot upload — **interactive TUI, user must run manually** |
 | `bifrost pull` | One-shot download — **interactive TUI, user must run manually** |
@@ -176,13 +193,40 @@ Example — Agent Tuning tools:
 
 | Need | Command |
 |------|---------|
-| Run a workflow | `bifrost run <file> -w <name> --org <UUID> --params '{...}'` |
-| Run a workflow (remote) | `bifrost api POST /api/workflows/{id}/execute '{"workflow_id":"...","input_data":{...},"sync":true}'` |
-| Check execution logs | `bifrost api GET /api/executions/{id}` |
+| Run a workflow (local file, fastest iteration) | `bifrost run <file> -w <name> --org <UUID> --params '{...}'` |
+| Run a registered workflow remotely (streams logs as it runs, exits on terminal status) | `bifrost workflows execute <ref> --params '{...}' [--org <ref>]` |
+| Check execution logs (one-shot) | `bifrost api GET /api/executions/{id}` |
 | List executions | `bifrost api GET /api/executions` |
 | List workflows / discover by id | `bifrost workflows list --json` / `bifrost workflows get <ref> --json` |
 | Validate an app | `bifrost api POST /api/applications/{id}/validate` |
 | Download platform docs | `bifrost api GET /api/llms.txt > /tmp/bifrost-docs/llms.txt` |
+
+**`bifrost run` vs `bifrost workflows execute` — pick the right one:**
+
+- **`bifrost run <file> -w <name>`** — executes a `.py` file from the local workspace against the running platform. No sync required, no platform-side registration required. This is the default for iterating on a workflow you're actively editing.
+- **`bifrost workflows execute <ref>`** — executes an *already-registered* workflow on the platform by UUID/name/`path::func`. Use this when the workflow is already deployed and you want to test it as it would run in production (real org context, real triggers, real workers). Streams logs over WebSocket as the workflow runs.
+
+Do not use `bifrost api POST /api/workflows/execute` directly — it returns immediately without logs and forces a manual `GET /api/executions/{id}` follow-up. Use `bifrost workflows execute` instead.
+
+### Python Workflow Dependencies
+
+Workflow `.py` files run on platform workers, which install Python packages from a single workspace-wide `requirements.txt`. App `app.yaml` `dependencies:` are for npm packages only — they have nothing to do with Python imports.
+
+If a workflow imports a third-party Python package, that package must be in `requirements.txt` and the workers must have recycled to pick it up. Symptom of a missing dep: `ModuleNotFoundError: No module named 'reportlab'` (or whichever package).
+
+**Add a dependency:**
+
+```bash
+bifrost requirements install reportlab           # append, then recycle workers
+bifrost requirements install httpx==0.27.0       # pin version, then recycle
+bifrost requirements install                     # no arg = warm cache + recycle (after manual edit)
+bifrost requirements list                        # what's installed
+bifrost requirements remove reportlab            # drop from requirements.txt + recycle
+```
+
+`bifrost requirements install` returns immediately. Worker recycle happens asynchronously — give it a few seconds before re-running the workflow.
+
+**Stdlib and a small set of pre-installed packages** (httpx, pydantic, pyjwt, anthropic, openai, etc. — anything bundled into the worker image) are always available. Don't try to install those.
 
 ### `bifrost api` Boundaries (CRITICAL)
 
@@ -320,11 +364,15 @@ Common lookups:
 
 ### App Workflow (SDK-First)
 
-1. Write files in `apps/{slug}/`
-2. Create the app record: `bifrost apps create --name "My App" --slug my-app [--deps @package.json]` — the server assigns the UUID and returns it. Do NOT hand-edit `.bifrost/apps.yaml`.
+**Order matters.** `bifrost watch` ignores files under `apps/{slug}/` until an app record exists for that slug. Files written before `bifrost apps create` are silently dropped — the user opens the preview and sees the "Welcome / Start building your app" placeholder. Always create the app record FIRST.
+
+1. **Create the app record FIRST**: `bifrost apps create --name "My App" --slug my-app [--deps @package.json]` — the server assigns the UUID and returns it. Do NOT hand-edit `.bifrost/apps.yaml`. The agent runs this; do not ask the user to.
+2. Write files in `apps/{slug}/` (only after step 1).
 3. `bifrost watch` syncs file changes (triggers esbuild rebuild + validation after each push).
 4. Preview at `$BIFROST_DEV_URL/apps/{slug}/preview`
 5. Fix any validation errors shown in watch output. esbuild errors appear as a banner in the preview and in the diagnostics channel — the last good bundle keeps serving underneath until the error is fixed.
+
+If you've dispatched a sub-agent to write app files, the parent agent — not the user — runs `bifrost apps create` immediately when the sub-agent returns. Do not defer to the user "after review"; that's the failure mode where 30+ files exist on disk and the preview is empty.
 
 ### App Workflow (MCP-Only)
 
@@ -352,8 +400,8 @@ After writing all app files, verify:
 
 ## Testing
 
-- **Workflows (local):** `bifrost run <file> --workflow <name> --org <UUID> --params '{...}'`
-- **Workflows (remote):** `bifrost api POST /api/workflows/{id}/execute '{"workflow_id":"...","input_data":{...},"sync":true}'`
+- **Workflows (local file):** `bifrost run <file> --workflow <name> --org <UUID> --params '{...}'`
+- **Workflows (registered, remote):** `bifrost workflows execute <ref> --params '{...}'` — streams logs, exits on terminal status
 - **Forms:** `$BIFROST_DEV_URL/forms/{form_id}`
 - **Apps:** Preview at `$BIFROST_DEV_URL/apps/{slug}/preview`, publish with `publish_app`, live at `$BIFROST_DEV_URL/apps/{slug}`
 - **Webhooks:** `curl -X POST $BIFROST_DEV_URL/api/hooks/{source_id} -H 'Content-Type: application/json' -d '{...}'`

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -587,6 +587,7 @@ Entity mutation commands (see 'bifrost <entity> --help'):
   configs      Manage config values
   tables       Manage tables
   events       Manage event sources and subscriptions
+  requirements Manage workspace Python requirements.txt (install/list/remove)
 
 Examples:
   bifrost run workflow.py -w greet

--- a/api/bifrost/commands/__init__.py
+++ b/api/bifrost/commands/__init__.py
@@ -24,6 +24,7 @@ from .events import events_group
 from .forms import forms_group
 from .integrations import integrations_group
 from .orgs import orgs_group
+from .requirements import requirements_group
 from .roles import roles_group
 from .tables import tables_group
 from .workflows import workflows_group
@@ -41,6 +42,7 @@ ENTITY_GROUPS: dict[str, click.Group] = {
     "configs": configs_group,
     "tables": tables_group,
     "events": events_group,
+    "requirements": requirements_group,
 }
 
 

--- a/api/bifrost/commands/requirements.py
+++ b/api/bifrost/commands/requirements.py
@@ -1,0 +1,106 @@
+"""CLI commands for managing the workspace's Python requirements.txt.
+
+Maps to ``/api/packages/*`` on the platform:
+
+* ``bifrost requirements list`` → ``GET /api/packages``
+* ``bifrost requirements install [pkg[==ver]]`` → ``POST /api/packages/install``
+  (no arg: warm the Redis cache from S3 + recycle workers; pkg arg: append/update
+  the package in requirements.txt + recycle workers)
+* ``bifrost requirements remove <pkg>`` → ``DELETE /api/packages/{pkg}``
+
+Workers recycle their process pools after install/remove; new processes pip
+install from requirements.txt on startup. The CLI returns immediately —
+recycling happens asynchronously on the platform side.
+"""
+
+from __future__ import annotations
+
+import click
+
+from bifrost.client import BifrostClient
+from bifrost.refs import RefResolver
+
+from .base import entity_group, output_result, pass_resolver, run_async
+
+
+requirements_group = entity_group(
+    "requirements",
+    "Manage the workspace's Python requirements.txt (workers auto-recycle).",
+)
+
+
+def _split_spec(spec: str) -> tuple[str, str | None]:
+    """Split ``pkg`` or ``pkg==1.2`` into (name, version|None)."""
+    if "==" in spec:
+        name, version = spec.split("==", 1)
+        return name.strip(), version.strip() or None
+    return spec.strip(), None
+
+
+@requirements_group.command("list")
+@click.pass_context
+@pass_resolver
+@run_async
+async def list_requirements(
+    ctx: click.Context,
+    *,
+    client: BifrostClient,
+    resolver: RefResolver,  # noqa: ARG001 - kept for signature parity
+) -> None:
+    """List installed Python packages on the platform."""
+    response = await client.get("/api/packages")
+    response.raise_for_status()
+    output_result(response.json(), ctx=ctx)
+
+
+@requirements_group.command("install")
+@click.argument("spec", required=False)
+@click.pass_context
+@pass_resolver
+@run_async
+async def install_requirements(
+    ctx: click.Context,
+    spec: str | None,
+    *,
+    client: BifrostClient,
+    resolver: RefResolver,  # noqa: ARG001 - kept for signature parity
+) -> None:
+    """Install a package or recycle workers from current requirements.txt.
+
+    Examples:
+
+      bifrost requirements install                  # warm cache + recycle workers
+      bifrost requirements install reportlab        # append, then recycle
+      bifrost requirements install httpx==0.27.0    # pin version, then recycle
+    """
+    body: dict = {}
+    if spec:
+        name, version = _split_spec(spec)
+        body["package_name"] = name
+        if version:
+            body["version"] = version
+
+    response = await client.post("/api/packages/install", json=body)
+    response.raise_for_status()
+    output_result(response.json(), ctx=ctx)
+
+
+@requirements_group.command("remove")
+@click.argument("package_name")
+@click.pass_context
+@pass_resolver
+@run_async
+async def remove_requirement(
+    ctx: click.Context,
+    package_name: str,
+    *,
+    client: BifrostClient,
+    resolver: RefResolver,  # noqa: ARG001 - kept for signature parity
+) -> None:
+    """Remove a package from requirements.txt and recycle workers."""
+    response = await client.delete(f"/api/packages/{package_name}")
+    response.raise_for_status()
+    output_result(response.json(), ctx=ctx)
+
+
+__all__ = ["requirements_group"]

--- a/api/bifrost/commands/workflows.py
+++ b/api/bifrost/commands/workflows.py
@@ -347,6 +347,9 @@ async def _stream_execution_logs(
                             break
                     # Ignore connected / pong / unrelated message types.
             except ConnectionClosed:
+                # Server closes the WS after the terminal execution_update
+                # — expected end of stream, not an error. The final GET below
+                # picks up the result.
                 pass
     except OSError as exc:
         raise click.ClickException(

--- a/api/bifrost/commands/workflows.py
+++ b/api/bifrost/commands/workflows.py
@@ -8,6 +8,9 @@ Implements Task 5c of the CLI mutation surface plan:
   UUID, then the row is located in the list payload).
 * ``bifrost workflows register`` → ``POST /api/workflows/register`` (registers
   a decorated function from an existing workspace ``.py`` file).
+* ``bifrost workflows execute <ref>`` → ``POST /api/workflows/execute`` plus
+  WebSocket tail of ``/ws/execution/{id}`` so logs stream as the workflow
+  runs and the command exits when the execution reaches a terminal status.
 * ``bifrost workflows update <ref>`` → ``PATCH /api/workflows/{uuid}`` (body
   from :class:`WorkflowUpdateRequest`).
 * ``bifrost workflows delete <ref>`` → ``DELETE /api/workflows/{uuid}``
@@ -35,6 +38,9 @@ contract by iterating role refs and aggregating per-role outcomes.
 
 from __future__ import annotations
 
+import asyncio
+import json
+import sys
 from typing import Any
 
 import click
@@ -50,6 +56,11 @@ from bifrost.refs import RefResolver
 from bifrost.contracts import WorkflowUpdateRequest
 
 from .base import _apply_flags, entity_group, output_result, pass_resolver, run_async
+
+
+_TERMINAL_STATUSES = frozenset(
+    {"Success", "Failed", "CompletedWithErrors", "Timeout", "Cancelled"}
+)
 
 workflows_group = entity_group("workflows", "Manage workflows.")
 
@@ -190,6 +201,181 @@ async def register_workflow(
     response = await client.post("/api/workflows/register", json=body)
     response.raise_for_status()
     output_result(response.json(), ctx=ctx)
+
+
+@workflows_group.command("execute")
+@click.argument("ref")
+@click.option(
+    "--params",
+    "params",
+    type=str,
+    default=None,
+    help="JSON object of input parameters (e.g. --params '{\"name\":\"World\"}').",
+)
+@click.option(
+    "--params-file",
+    "params_file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    default=None,
+    help="Path to a JSON file with input parameters. Mutually exclusive with --params.",
+)
+@click.option(
+    "--org",
+    "org_ref",
+    type=str,
+    default=None,
+    help=(
+        "Override execution org context (UUID or name). Requires platform "
+        "admin. Omit to use the caller's default org."
+    ),
+)
+@click.pass_context
+@pass_resolver
+@run_async
+async def execute_workflow(
+    ctx: click.Context,
+    ref: str,
+    *,
+    client: BifrostClient,
+    resolver: RefResolver,
+    params: str | None,
+    params_file: str | None,
+    org_ref: str | None,
+) -> None:
+    """Execute a registered workflow remotely and stream logs as it runs.
+
+    ``REF`` is a workflow UUID, name, or ``path::func`` locator. The command:
+
+    1. Resolves ``REF`` and posts to ``/api/workflows/execute`` (async — does
+       not block the platform).
+    2. Connects to ``/ws/execution/{id}`` and prints log lines as they arrive.
+    3. Exits when the execution reaches a terminal status, after a final GET
+       to backfill any logs that emitted before the WebSocket connected and
+       to fetch the final result.
+
+    Use ``bifrost run <file> --workflow <name>`` for local-file iteration —
+    ``execute`` targets workflows already registered on the platform.
+    """
+    if params and params_file:
+        raise click.UsageError("--params and --params-file are mutually exclusive")
+
+    input_data: dict[str, Any] = {}
+    if params:
+        try:
+            input_data = json.loads(params)
+        except json.JSONDecodeError as exc:
+            raise click.UsageError(f"--params is not valid JSON: {exc}")
+    elif params_file:
+        with open(params_file, "r", encoding="utf-8") as fh:
+            input_data = json.load(fh)
+    if not isinstance(input_data, dict):
+        raise click.UsageError("Input parameters must be a JSON object")
+
+    workflow_uuid = await resolver.resolve("workflow", ref)
+
+    body: dict[str, Any] = {
+        "workflow_id": workflow_uuid,
+        "input_data": input_data,
+        "sync": False,
+    }
+    if org_ref:
+        body["org_id"] = await resolver.resolve("org", org_ref)
+
+    post_response = await client.post("/api/workflows/execute", json=body)
+    post_response.raise_for_status()
+    initial = post_response.json()
+    execution_id = initial.get("execution_id")
+    if not execution_id:
+        raise click.ClickException(
+            f"Execution response missing execution_id: {initial!r}"
+        )
+
+    if initial.get("status") in _TERMINAL_STATUSES:
+        # Server already finished (e.g., data provider, or sync override) —
+        # nothing to stream. Print the result and exit.
+        output_result(initial, ctx=ctx)
+        sys.exit(0 if initial.get("status") == "Success" else 1)
+
+    click.echo(f"execution_id: {execution_id}", err=True)
+
+    final_status = await _stream_execution_logs(client, execution_id)
+    final = await _fetch_final_execution(client, execution_id)
+    output_result(final, ctx=ctx)
+    sys.exit(0 if final_status == "Success" else 1)
+
+
+async def _stream_execution_logs(
+    client: BifrostClient, execution_id: str
+) -> str:
+    """Connect to /ws/execution/{id} and print log lines until terminal status.
+
+    Returns the terminal status string. The websockets dependency is imported
+    lazily so the rest of the CLI stays usable when websockets is missing
+    from a partial install.
+    """
+    try:
+        from websockets.asyncio.client import connect as ws_connect
+        from websockets.exceptions import ConnectionClosed
+    except ImportError as exc:
+        raise click.ClickException(
+            "websockets is required for `bifrost workflows execute` "
+            "but is not installed. Install with: pip install websockets"
+        ) from exc
+
+    ws_scheme = "wss" if client.api_url.startswith("https") else "ws"
+    host = client.api_url.split("://", 1)[1].rstrip("/")
+    ws_url = f"{ws_scheme}://{host}/ws/execution/{execution_id}"
+    headers = {"Authorization": f"Bearer {client._access_token}"}
+
+    final_status: str = "Failed"
+    try:
+        async with ws_connect(ws_url, additional_headers=headers) as websocket:
+            try:
+                while True:
+                    raw = await websocket.recv()
+                    msg = json.loads(raw)
+                    msg_type = msg.get("type")
+
+                    if msg_type == "execution_log":
+                        level = (msg.get("level") or "info").upper()
+                        message = msg.get("message") or ""
+                        click.echo(f"[{level}] {message}")
+                    elif msg_type == "execution_update":
+                        status_val = msg.get("status")
+                        if status_val in _TERMINAL_STATUSES:
+                            final_status = status_val
+                            break
+                    # Ignore connected / pong / unrelated message types.
+            except ConnectionClosed:
+                pass
+    except OSError as exc:
+        raise click.ClickException(
+            f"WebSocket connection to {ws_url} failed: {exc}"
+        ) from exc
+
+    return final_status
+
+
+async def _fetch_final_execution(
+    client: BifrostClient, execution_id: str
+) -> dict[str, Any]:
+    """Fetch the final execution record (logs + result) once it has terminated.
+
+    Backfills any logs that emitted between POST and WS connect, and surfaces
+    the final result/error/duration that the websocket update doesn't carry.
+    Retries briefly to absorb the small lag between the worker writing the
+    terminal status and the API serving it.
+    """
+    record: dict[str, Any] = {}
+    for delay in (0.0, 0.25, 0.5, 1.0):
+        if delay:
+            await asyncio.sleep(delay)
+        response = await client.get(f"/api/executions/{execution_id}")
+        response.raise_for_status()
+        record = response.json()
+        if record.get("status") in _TERMINAL_STATUSES:
+            return record
+    return record
 
 
 @workflows_group.command("update")

--- a/api/tests/e2e/api/test_cli.py
+++ b/api/tests/e2e/api/test_cli.py
@@ -771,7 +771,7 @@ assert isinstance(WorkflowMetadata, type)
 # from ``bifrost.contracts``). If the tarball ever drops a file that
 # the commands depend on, this import explodes.
 from bifrost.commands import ENTITY_GROUPS
-assert len(ENTITY_GROUPS) == 10, f"expected 10 entity groups, got {{len(ENTITY_GROUPS)}}"
+assert len(ENTITY_GROUPS) == 11, f"expected 11 entity groups, got {{len(ENTITY_GROUPS)}}"
 
 # And the mirrored DTO package must itself be importable.
 from bifrost import contracts as _contracts

--- a/api/tests/unit/cli/test_cli_base.py
+++ b/api/tests/unit/cli/test_cli_base.py
@@ -178,7 +178,7 @@ class TestRunAsyncErrorSurfacing:
 
 
 class TestSubgroupRegistration:
-    def test_all_ten_entity_subgroups_registered(self) -> None:
+    def test_all_entity_subgroups_registered(self) -> None:
         from bifrost.commands import ENTITY_GROUPS
 
         assert set(ENTITY_GROUPS) == {
@@ -192,6 +192,7 @@ class TestSubgroupRegistration:
             "configs",
             "tables",
             "events",
+            "requirements",
         }
 
     def test_dispatch_unknown_subgroup_exits_1(self) -> None:

--- a/api/tests/unit/test_cli_requirements.py
+++ b/api/tests/unit/test_cli_requirements.py
@@ -1,0 +1,120 @@
+"""Unit tests for the ``bifrost requirements`` CLI group.
+
+The group wraps ``/api/packages/*`` (install / list / remove). These tests
+mock :class:`BifrostClient` so we can assert on the URL/body the CLI sends
+without needing the full platform stack.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from bifrost import client as bifrost_client_module
+from bifrost.commands.requirements import requirements_group
+
+
+class _FakeClient:
+    """Minimal stand-in for BifrostClient used in CLI unit tests."""
+
+    def __init__(self) -> None:
+        self.api_url = "http://test.local"
+        self._access_token = "test-token"
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+        self._next_response: tuple[int, Any] = (200, {})
+
+    def queue_response(self, status: int, body: Any) -> None:
+        self._next_response = (status, body)
+
+    def _build_response(self, method: str, path: str) -> httpx.Response:
+        status, body = self._next_response
+        request = httpx.Request(method, f"{self.api_url}{path}")
+        if isinstance(body, (dict, list)):
+            return httpx.Response(status, json=body, request=request)
+        return httpx.Response(status, text=str(body), request=request)
+
+    async def get(self, path: str, **_kwargs) -> httpx.Response:
+        self.calls.append(("GET", path, None))
+        return self._build_response("GET", path)
+
+    async def post(self, path: str, *, json: dict | None = None, **_kwargs) -> httpx.Response:
+        self.calls.append(("POST", path, json))
+        return self._build_response("POST", path)
+
+    async def delete(self, path: str, **_kwargs) -> httpx.Response:
+        self.calls.append(("DELETE", path, None))
+        return self._build_response("DELETE", path)
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+    """Replace BifrostClient.get_instance with one returning a FakeClient."""
+    fake = _FakeClient()
+    monkeypatch.setattr(
+        bifrost_client_module.BifrostClient,
+        "get_instance",
+        classmethod(lambda cls, require_auth=False: fake),
+    )
+    return fake
+
+
+def _invoke(args: list[str]):
+    return CliRunner().invoke(
+        requirements_group, args, standalone_mode=False, catch_exceptions=False
+    )
+
+
+class TestRequirementsInstall:
+    def test_install_no_args_warms_cache(self, fake_client: _FakeClient) -> None:
+        fake_client.queue_response(200, {"status": "success", "message": "warmed"})
+        result = _invoke(["install"])
+        assert result.exit_code == 0, result.output
+        assert fake_client.calls == [("POST", "/api/packages/install", {})]
+
+    def test_install_bare_package(self, fake_client: _FakeClient) -> None:
+        fake_client.queue_response(200, {"status": "success", "message": "ok"})
+        result = _invoke(["install", "reportlab"])
+        assert result.exit_code == 0, result.output
+        method, path, body = fake_client.calls[0]
+        assert method == "POST" and path == "/api/packages/install"
+        assert body == {"package_name": "reportlab"}
+
+    def test_install_pinned_version(self, fake_client: _FakeClient) -> None:
+        fake_client.queue_response(200, {"status": "success", "message": "ok"})
+        result = _invoke(["install", "httpx==0.27.0"])
+        assert result.exit_code == 0, result.output
+        _, _, body = fake_client.calls[0]
+        assert body == {"package_name": "httpx", "version": "0.27.0"}
+
+    def test_install_emits_json_when_flag_set(
+        self, fake_client: _FakeClient
+    ) -> None:
+        fake_client.queue_response(
+            200, {"status": "success", "message": "ok", "package_name": "reportlab"}
+        )
+        result = _invoke(["--json", "install", "reportlab"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["package_name"] == "reportlab"
+
+
+class TestRequirementsList:
+    def test_list_hits_packages_endpoint(self, fake_client: _FakeClient) -> None:
+        fake_client.queue_response(
+            200, {"packages": [{"name": "httpx", "version": "0.27.0"}], "total_count": 1}
+        )
+        result = _invoke(["list"])
+        assert result.exit_code == 0, result.output
+        assert fake_client.calls == [("GET", "/api/packages", None)]
+
+
+class TestRequirementsRemove:
+    def test_remove_hits_delete_endpoint(self, fake_client: _FakeClient) -> None:
+        fake_client.queue_response(200, {"status": "success"})
+        result = _invoke(["remove", "reportlab"])
+        assert result.exit_code == 0, result.output
+        assert fake_client.calls == [("DELETE", "/api/packages/reportlab", None)]

--- a/api/tests/unit/test_cli_workflows_execute.py
+++ b/api/tests/unit/test_cli_workflows_execute.py
@@ -1,0 +1,301 @@
+"""Unit tests for ``bifrost workflows execute``.
+
+Mocks ``BifrostClient`` and the websockets stream so the CLI is exercised
+end-to-end (POST → WS log tail → final GET) without a live platform.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from bifrost import client as bifrost_client_module
+from bifrost.commands.workflows import workflows_group
+
+
+_WORKFLOW_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.api_url = "http://test.local"
+        self._access_token = "test-token"
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+        self._responses: dict[tuple[str, str], list[tuple[int, Any]]] = {}
+
+    def queue(self, method: str, path: str, status: int, body: Any) -> None:
+        self._responses.setdefault((method, path), []).append((status, body))
+
+    def _next(self, method: str, path: str) -> tuple[int, Any]:
+        queue = self._responses.get((method, path), [])
+        if not queue:
+            raise AssertionError(f"Unexpected {method} {path}")
+        if len(queue) == 1:
+            return queue[0]
+        return queue.pop(0)
+
+    def _build(self, method: str, path: str) -> httpx.Response:
+        status, body = self._next(method, path)
+        request = httpx.Request(method, f"{self.api_url}{path}")
+        if isinstance(body, (dict, list)):
+            return httpx.Response(status, json=body, request=request)
+        return httpx.Response(status, text=str(body), request=request)
+
+    async def get(self, path: str, **_kwargs) -> httpx.Response:
+        self.calls.append(("GET", path, None))
+        return self._build("GET", path)
+
+    async def post(
+        self, path: str, *, json: dict | None = None, **_kwargs
+    ) -> httpx.Response:
+        self.calls.append(("POST", path, json))
+        return self._build("POST", path)
+
+
+class _FakeWebSocket:
+    """Simulates the WS connection by yielding pre-canned JSON messages."""
+
+    def __init__(self, messages: list[dict[str, Any]]) -> None:
+        self._messages = list(messages)
+
+    async def __aenter__(self) -> "_FakeWebSocket":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def recv(self) -> str:
+        if not self._messages:
+            raise AssertionError(
+                "Test ran out of WS messages — execute should have exited "
+                "after the terminal execution_update"
+            )
+        return json.dumps(self._messages.pop(0))
+
+
+def _ws_connect_factory(messages: list[dict[str, Any]]):
+    captured: dict[str, Any] = {}
+
+    def _connect(uri: str, *, additional_headers=None, **_kwargs):
+        captured["uri"] = uri
+        captured["headers"] = dict(additional_headers or {})
+        return _FakeWebSocket(messages)
+
+    return _connect, captured
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+    fake = _FakeClient()
+    monkeypatch.setattr(
+        bifrost_client_module.BifrostClient,
+        "get_instance",
+        classmethod(lambda cls, require_auth=False: fake),
+    )
+    return fake
+
+
+@pytest.fixture
+def stub_resolver(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Make resolver.resolve() return whatever the test pre-registered.
+
+    Defaults to mapping {"my-workflow": _WORKFLOW_UUID}.
+    """
+    mapping = {"my-workflow": _WORKFLOW_UUID}
+
+    async def _resolve(self, kind: str, value: str) -> str:
+        if value in mapping:
+            return mapping[value]
+        return value
+
+    from bifrost import refs as refs_module
+    monkeypatch.setattr(refs_module.RefResolver, "resolve", _resolve)
+    return mapping
+
+
+def _invoke(args: list[str]):
+    return CliRunner().invoke(
+        workflows_group, args, standalone_mode=False, catch_exceptions=False
+    )
+
+
+class TestWorkflowsExecute:
+    def test_streams_logs_then_exits_on_terminal_status(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_client: _FakeClient,
+        stub_resolver: dict[str, str],
+    ) -> None:
+        # POST returns immediately with PENDING status + execution_id.
+        fake_client.queue(
+            "POST",
+            "/api/workflows/execute",
+            200,
+            {"execution_id": "exec-1", "status": "Pending"},
+        )
+        # Final GET returns the completed record.
+        fake_client.queue(
+            "GET",
+            "/api/executions/exec-1",
+            200,
+            {
+                "execution_id": "exec-1",
+                "status": "Success",
+                "result": {"answer": 42},
+                "duration_ms": 150,
+            },
+        )
+
+        ws_messages = [
+            {"type": "connected", "executionId": "exec-1"},
+            {
+                "type": "execution_log",
+                "executionId": "exec-1",
+                "level": "info",
+                "message": "Starting work",
+            },
+            {
+                "type": "execution_log",
+                "executionId": "exec-1",
+                "level": "info",
+                "message": "Done",
+            },
+            {
+                "type": "execution_update",
+                "executionId": "exec-1",
+                "status": "Success",
+            },
+        ]
+        connect, captured = _ws_connect_factory(ws_messages)
+        # Patch the lazy import target inside _stream_execution_logs.
+        import websockets.asyncio.client as ws_client_module
+        monkeypatch.setattr(ws_client_module, "connect", connect)
+
+        result = _invoke(["--json", "execute", "my-workflow"])
+
+        assert result.exit_code == 0, (result.output, result.stderr)
+        # POST was called with sync=False and resolved UUID.
+        post_call = next(c for c in fake_client.calls if c[0] == "POST")
+        assert post_call[2] == {
+            "workflow_id": _WORKFLOW_UUID,
+            "input_data": {},
+            "sync": False,
+        }
+        # WS URL is correctly derived from api_url.
+        assert captured["uri"] == "ws://test.local/ws/execution/exec-1"
+        assert captured["headers"]["Authorization"] == "Bearer test-token"
+        # Final result payload was emitted as JSON. The execute command also
+        # writes ``[INFO] ...`` lines for log messages on stdout above the
+        # JSON body, so split on the first ``{`` at column 0 to isolate the
+        # JSON block.
+        stdout = result.stdout
+        json_start = stdout.find("\n{")
+        assert json_start != -1, f"no JSON block found in stdout: {stdout!r}"
+        payload = json.loads(stdout[json_start + 1:])
+        assert payload["status"] == "Success"
+        assert payload["result"] == {"answer": 42}
+        # Logs surfaced on stdout (between execution_id stderr and JSON body).
+        assert "[INFO] Starting work" in result.output
+        assert "[INFO] Done" in result.output
+
+    def test_failure_status_returns_exit_1(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_client: _FakeClient,
+        stub_resolver: dict[str, str],
+    ) -> None:
+        fake_client.queue(
+            "POST",
+            "/api/workflows/execute",
+            200,
+            {"execution_id": "exec-2", "status": "Pending"},
+        )
+        fake_client.queue(
+            "GET",
+            "/api/executions/exec-2",
+            200,
+            {
+                "execution_id": "exec-2",
+                "status": "Failed",
+                "error": "boom",
+            },
+        )
+        ws_messages = [
+            {
+                "type": "execution_update",
+                "executionId": "exec-2",
+                "status": "Failed",
+            },
+        ]
+        connect, _ = _ws_connect_factory(ws_messages)
+        import websockets.asyncio.client as ws_client_module
+        monkeypatch.setattr(ws_client_module, "connect", connect)
+
+        result = _invoke(["--json", "execute", "my-workflow"])
+        assert result.exit_code == 1, result.output
+
+    def test_terminal_status_in_initial_post_skips_websocket(
+        self,
+        fake_client: _FakeClient,
+        stub_resolver: dict[str, str],
+    ) -> None:
+        # If the platform returned a terminal status synchronously (sync=True
+        # was overridden, or the workflow ran inline), we should not even
+        # attempt to open a WebSocket.
+        fake_client.queue(
+            "POST",
+            "/api/workflows/execute",
+            200,
+            {
+                "execution_id": "exec-3",
+                "status": "Success",
+                "result": {"x": 1},
+            },
+        )
+        result = _invoke(["--json", "execute", "my-workflow"])
+        assert result.exit_code == 0, result.output
+        # No GET happened — the inline result was used.
+        methods = [c[0] for c in fake_client.calls]
+        assert methods == ["POST"]
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "Success"
+
+    def test_invalid_params_json_is_usage_error(
+        self,
+        fake_client: _FakeClient,
+        stub_resolver: dict[str, str],
+    ) -> None:
+        # standalone_mode=False re-raises UsageError instead of converting it
+        # to an exit code, so we use the default standalone_mode for this case.
+        result = CliRunner().invoke(
+            workflows_group, ["execute", "my-workflow", "--params", "{not json}"]
+        )
+        assert result.exit_code != 0
+        # UsageError text lands on stderr; CliRunner mixes it into output.
+        assert "not valid JSON" in result.output
+
+    def test_params_and_params_file_are_mutually_exclusive(
+        self,
+        fake_client: _FakeClient,
+        stub_resolver: dict[str, str],
+        tmp_path,
+    ) -> None:
+        params_file = tmp_path / "p.json"
+        params_file.write_text("{}")
+        result = CliRunner().invoke(
+            workflows_group,
+            [
+                "execute",
+                "my-workflow",
+                "--params",
+                "{}",
+                "--params-file",
+                str(params_file),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output

--- a/docs/llm.txt
+++ b/docs/llm.txt
@@ -37,7 +37,7 @@ Run `bifrost roles <verb> --help` for the complete flag list.
 
 Registered Python functions available for execution by forms / agents / events / HTTP endpoints.
 
-Commands: `workflows list / get / register / update / delete / grant-role / revoke-role`.
+Commands: `workflows list / get / register / execute / update / delete / grant-role / revoke-role`.
 
 Example: `bifrost workflows register --path workflows/foo.py --function-name foo`.
 
@@ -45,6 +45,7 @@ Non-obvious semantics:
 - `<workflow-ref>` accepts UUID, name, or `path::func` (e.g. `workflows/sales.py::close_deal`).
 - `get` is served by list-and-filter (the API has no per-id GET endpoint).
 - `register` is how workflows come into existence — workflows are never "created" in the CLI sense because they're defined by a `@workflow`-decorated Python function. Write the `.py` file first, then `register` it (or sync it via `bifrost watch`).
+- `execute <ref> --params '{...}'` runs a registered workflow remotely; opens a WebSocket to `/ws/execution/{id}` and prints log lines as they arrive, then exits 0/1 based on terminal status. Use `bifrost run <file>` for local-file iteration; `execute` is for workflows already on the platform.
 - `delete --force-deactivation` bypasses the 409-on-history guard.
 
 ### Renaming or moving a workflow
@@ -180,6 +181,22 @@ Non-obvious semantics:
 - `subscribe` accepts exactly one of `--workflow` or `--agent`; target type is inferred.
 
 Run `bifrost events <verb> --help` for the complete flag list.
+
+## Requirements (Python workflow deps)
+
+Workspace-wide `requirements.txt` for Python packages workers install at process spawn. Wraps `/api/packages/*`.
+
+Commands: `requirements list / install / remove`.
+
+Examples:
+- `bifrost requirements install reportlab` — append package to requirements.txt + recycle workers (async).
+- `bifrost requirements install httpx==0.27.0` — pin a version.
+- `bifrost requirements install` (no arg) — warm cache from S3 + recycle workers (use after a manual `requirements.txt` edit).
+- `bifrost requirements remove reportlab` — drop from requirements.txt + recycle.
+
+Non-obvious semantics:
+- All install/remove operations recycle workers asynchronously; returns immediately. Wait a few seconds before re-running the workflow that needed the package.
+- App `app.yaml` `dependencies:` are unrelated — those are npm packages bundled into the app, not Python deps.
 
 ---
 


### PR DESCRIPTION
## Summary

Two new top-level CLI surfaces and skill content fixes uncovered by auditing recent build sessions in `~/GitHub/bifrost-workspace`.

### New CLI commands

- **`bifrost workflows execute <ref> --params '{...}'`** — runs a registered workflow remotely. POSTs `/api/workflows/execute` with `sync=False`, opens a WebSocket to `/ws/execution/{id}`, prints log lines as they arrive, and exits 0/1 on terminal status. Replaces the awkward two-step `bifrost api POST /api/workflows/execute` + `bifrost api GET /api/executions/{id}` pattern.
- **`bifrost requirements install [pkg[==ver]] | list | remove <pkg>`** — wraps `/api/packages/*`. Closes the documentation gap where workflows hitting `ModuleNotFoundError: reportlab` had no documented path forward.

### Skill content fixes (`.claude/skills/bifrost-build/SKILL.md`)

- New **Who Runs What** table — distinguishes agent-runs-it commands from user-runs-it ones (fixes the "ask user to run `apps create`" failure mode).
- New **Python Workflow Dependencies** section.
- Reframe `bifrost run` (local file) vs `bifrost workflows execute` (registered, remote).
- Explicit ordering warning: `bifrost apps create` must come BEFORE `bifrost watch` syncs files.
- `BIFROST_DEV_URL` empty-fallback guidance — ask, don't invent.

### Out of scope (follow-up PR)

- `bifrost skill update` CLI (pulls skill content from GitHub into `.claude/skills/` + `.agents/skills/`).
- `.claude-plugin/plugin.json` for Claude Code plugin distribution.

## Test plan

- [x] `pytest tests/unit/test_cli_requirements.py tests/unit/test_cli_workflows_execute.py tests/unit/test_cli_surface_smoke.py tests/unit/test_dto_flags.py tests/unit/test_cli_json_errors.py` (155 passed)
- [x] `pyright bifrost/` (0 errors)
- [x] `ruff check bifrost/` (clean)
- [x] `bifrost workflows execute --help` and `bifrost requirements --help` render correctly
- [ ] Smoke test against a live dev stack: `bifrost workflows execute <some-workflow>` and `bifrost requirements install reportlab` in a workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)