### PR TITLE
fix(skill): only install plugin-public skills, not internal ones

### DIFF
--- a/api/bifrost/skill.py
+++ b/api/bifrost/skill.py
@@ -1,7 +1,12 @@
 """Implementation of ``bifrost skill`` — install/update/remove agent skills.
 
-Skills live in the bifrost repo at ``.claude/skills/<name>/`` and need to be
-copied into the user's workspace at:
+Skills live in the bifrost repo at ``.claude/skills/<name>/``. Only those
+exposed by the Claude Code plugin manifest (i.e. symlinked from the top-level
+``skills/`` directory) are considered public and installed by this command —
+internal maintainer skills like ``bifrost-debug``/``bifrost-secaudit`` stay
+in the repo where they belong.
+
+Public skills are copied into the user's workspace at:
 
 * ``<cwd>/.claude/skills/<name>/`` — picked up by Claude Code.
 * ``<cwd>/.agents/skills/<name>/`` — the cross-harness portable convention
@@ -40,7 +45,7 @@ work across Claude Code, Copilot CLI, Cursor, Codex, and Gemini CLI:
 
 Subcommands:
   list                    List installed skills in the current workspace
-  update                  Install / update ALL Bifrost skills from GitHub
+  update                  Install / update all public Bifrost skills from GitHub
   remove <name>           Remove an installed skill from both locations
 
 Options for update:
@@ -193,12 +198,18 @@ def _handle_update(args: list[str]) -> int:
 
 
 def _fetch_skill_files(repo: str, ref: str) -> dict[str, bytes]:
-    """Fetch the repo tarball and return ``{relpath: contents}`` for skill files.
+    """Fetch the repo tarball and return ``{relpath: contents}`` for public skill files.
 
     ``relpath`` is repo-relative under ``.claude/skills/`` (e.g.
-    ``bifrost-build/SKILL.md``). Excludes ``.claude/`` siblings (commands,
-    agents, hooks) — those install via the Claude Code plugin, not via this
-    command.
+    ``bifrost-build/SKILL.md``).
+
+    Only skills exposed by the repo's Claude Code plugin manifest are returned —
+    determined by the symlinks in the top-level ``skills/`` directory. Internal
+    skills under ``.claude/skills/`` that are NOT symlinked from ``skills/`` are
+    excluded so end users don't end up with maintainer-only skills like
+    ``bifrost-debug`` or ``bifrost-secaudit``. The ``skills/`` symlinks are the
+    same allowlist consumed by the plugin loader, so the CLI and the plugin stay
+    in lockstep automatically.
     """
     url = f"https://codeload.github.com/{repo}/tar.gz/refs/heads/{ref}"
     # Try the branch URL first, fall back to tag URL on 404.
@@ -208,12 +219,35 @@ def _fetch_skill_files(repo: str, ref: str) -> dict[str, bytes]:
         response = httpx.get(url, timeout=60.0, follow_redirects=True)
     response.raise_for_status()
 
+    public_skills: set[str] = set()
     files: dict[str, bytes] = {}
     with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz") as tar:
-        for member in tar.getmembers():
+        members = tar.getmembers()
+
+        # First pass: read top-level skills/ symlinks to build the allowlist.
+        for member in members:
+            parts = member.name.split("/", 1)
+            if len(parts) != 2:
+                continue
+            inner = parts[1]
+            if not inner.startswith("skills/") or inner == "skills/":
+                continue
+            name = inner[len("skills/"):].rstrip("/")
+            if not name or "/" in name:
+                continue
+            if member.issym() or member.islnk():
+                public_skills.add(name)
+
+        if not public_skills:
+            raise ValueError(
+                f"No public skills found under skills/ in {repo}@{ref}. "
+                "The repo may not expose a Claude Code plugin manifest."
+            )
+
+        # Second pass: extract content for allowlisted skills only.
+        for member in members:
             if not member.isfile():
                 continue
-            # Member names start with "<repo>-<sha>/...", strip that prefix.
             parts = member.name.split("/", 1)
             if len(parts) != 2:
                 continue
@@ -223,6 +257,9 @@ def _fetch_skill_files(repo: str, ref: str) -> dict[str, bytes]:
                 continue
             relpath = inner[len(prefix):]
             if not relpath:
+                continue
+            skill_name = relpath.split("/", 1)[0]
+            if skill_name not in public_skills:
                 continue
             extracted = tar.extractfile(member)
             if extracted is None:

--- a/api/tests/unit/test_cli_skill.py
+++ b/api/tests/unit/test_cli_skill.py
@@ -17,14 +17,32 @@ import pytest
 from bifrost import skill as skill_module
 
 
-def _make_tarball(repo: str, ref: str, files: dict[str, bytes]) -> bytes:
+def _make_tarball(
+    repo: str,
+    ref: str,
+    files: dict[str, bytes],
+    public_skills: list[str] | None = None,
+) -> bytes:
     """Build a tarball mimicking what GitHub's codeload returns.
 
     GitHub wraps everything in a ``<repo-name>-<sha>/`` prefix, so we
-    simulate that.
+    simulate that. ``public_skills`` lists the names that should appear as
+    symlinks under the top-level ``skills/`` directory (the plugin allowlist).
+    Defaults to every skill seen under ``.claude/skills/`` so existing tests
+    that don't care about filtering keep their current shape.
     """
     repo_name = repo.split("/")[-1]
     prefix = f"{repo_name}-{ref}"
+    if public_skills is None:
+        derived: set[str] = set()
+        for relpath in files:
+            if not relpath.startswith(".claude/skills/"):
+                continue
+            tail = relpath[len(".claude/skills/"):]
+            name = tail.split("/", 1)[0]
+            if name:
+                derived.add(name)
+        public_skills = sorted(derived)
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
         for relpath, contents in files.items():
@@ -32,6 +50,11 @@ def _make_tarball(repo: str, ref: str, files: dict[str, bytes]) -> bytes:
             info = tarfile.TarInfo(name=f"{prefix}/{relpath}")
             info.size = len(data)
             tar.addfile(info, io.BytesIO(data))
+        for name in public_skills:
+            info = tarfile.TarInfo(name=f"{prefix}/skills/{name}")
+            info.type = tarfile.SYMTYPE
+            info.linkname = f"../.claude/skills/{name}"
+            tar.addfile(info)
     return buf.getvalue()
 
 
@@ -43,7 +66,7 @@ def stub_github(monkeypatch: pytest.MonkeyPatch):
     wants the "repo" to ship.
     """
 
-    state: dict[str, object] = {"calls": []}
+    state: dict[str, object] = {"calls": [], "public_skills": None}
 
     def install(files: dict[str, bytes], repo: str = "jackmusick/bifrost") -> None:
         def _get(url: str, **_kwargs):
@@ -53,7 +76,13 @@ def stub_github(monkeypatch: pytest.MonkeyPatch):
                 ref = url.rsplit("/refs/heads/", 1)[1]
             elif "/refs/tags/" in url:
                 ref = url.rsplit("/refs/tags/", 1)[1]
-            tarball = _make_tarball(repo, ref, files)
+            public = state["public_skills"]
+            tarball = _make_tarball(
+                repo,
+                ref,
+                files,
+                public_skills=public,  # type: ignore[arg-type]
+            )
             request = httpx.Request("GET", url)
             return httpx.Response(200, content=tarball, request=request)
 
@@ -156,6 +185,54 @@ class TestSkillUpdate:
         skill_module.handle_skill(["update", "--repo", "jackmusick/other-repo"])
         urls = stub_github["calls"]  # type: ignore[index]
         assert any("jackmusick/other-repo" in u for u in urls), urls
+
+    def test_only_public_skills_are_installed(
+        self,
+        workspace: Path,
+        stub_github,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        # Mirror the real repo: bifrost-build is symlinked from skills/ (public);
+        # bifrost-debug only exists under .claude/skills/ (internal).
+        stub_github["install"](
+            {
+                ".claude/skills/bifrost-build/SKILL.md": b"public\n",
+                ".claude/skills/bifrost-debug/SKILL.md": b"internal\n",
+                ".claude/skills/bifrost-secaudit/SKILL.md": b"internal\n",
+            },
+        )
+        # Override the auto-derived allowlist to only expose bifrost-build.
+        stub_github["public_skills"] = ["bifrost-build"]  # type: ignore[index]
+
+        rc = skill_module.handle_skill(["update"])
+        assert rc == 0
+
+        for root in (".claude/skills", ".agents/skills"):
+            assert (workspace / root / "bifrost-build/SKILL.md").is_file()
+            assert not (workspace / root / "bifrost-debug").exists()
+            assert not (workspace / root / "bifrost-secaudit").exists()
+        out = capsys.readouterr().out
+        assert "Installed bifrost-build" in out
+        assert "bifrost-debug" not in out
+        assert "bifrost-secaudit" not in out
+
+    def test_repo_with_no_public_skills_errors(
+        self,
+        workspace: Path,
+        stub_github,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        # Repo has skills under .claude/skills/ but none symlinked from skills/.
+        # That's the shape of any fork/repo without a Claude Code plugin manifest.
+        stub_github["install"](
+            {".claude/skills/private/SKILL.md": b"x"},
+        )
+        stub_github["public_skills"] = []  # type: ignore[index]
+
+        rc = skill_module.handle_skill(["update"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "No public skills" in err
 
 
 class TestSkillList:


### PR DESCRIPTION
## Summary
- `bifrost skill update` was pulling every entry under `.claude/skills/` from the repo tarball — including internal-only skills (`bifrost-debug`, `bifrost-secaudit`, `bifrost-secupdate`, `bifrost-release`, `bifrost-issues`, `bifrost-testing`, `bifrost-documentation`).
- Those skills are excluded from the Claude Code plugin manifest by design (#169) because they're about working *on* bifrost, not building *with* it.
- Use the top-level `skills/` symlinks as the allowlist — same source of truth as the plugin loader, no second manifest to drift.
- Smoke-tested against the real `jackmusick/bifrost@main` tarball: returns `['bifrost-build', 'bifrost-setup']` exactly.

Closes #172.

## Test plan
- [x] `test_only_public_skills_are_installed` — internal skills with no `skills/` symlink are excluded
- [x] `test_repo_with_no_public_skills_errors` — empty allowlist fails loudly instead of silently
- [x] Existing 9 `bifrost skill` tests still pass with the synthetic-tarball helper extended to emit symlinks
- [x] `ruff check` clean
- [x] `pyright` clean
- [x] End-to-end smoke against real GitHub tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)