### PR TITLE
Zero-downtime deploys: API rolling, worker drain, client banner + retry

### DIFF
--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -12,7 +12,9 @@ import logging
 import os
 import sys
 import threading
+import time
 import webbrowser
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
@@ -29,6 +31,61 @@ logger = logging.getLogger(__name__)
 
 # Global client injection for platform mode
 _injected_client: Optional["BifrostClient"] = None
+
+# Retry config for transient 5xx — see workstream E of issue #171.
+# SDK is machine-to-machine, so the retry budget is more generous than
+# the user-facing client.
+TRANSIENT_5XX_STATUS_CODES: frozenset[int] = frozenset({502, 503, 504})
+IDEMPOTENT_METHODS: frozenset[str] = frozenset({"GET", "PUT", "DELETE", "HEAD", "OPTIONS"})
+SDK_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (0.5, 1.5, 4.0, 10.0, 20.0)
+
+
+def _is_idempotent(method: str) -> bool:
+    return method.upper() in IDEMPOTENT_METHODS
+
+
+def _is_transient_5xx(status_code: int) -> bool:
+    return status_code in TRANSIENT_5XX_STATUS_CODES
+
+
+async def _send_with_5xx_retry(
+    method: str,
+    do_send: Callable[[], Awaitable[httpx.Response]],
+) -> httpx.Response:
+    """Retry transient 5xx on idempotent methods.
+
+    The do_send callable must be safe to invoke multiple times; it should
+    re-issue the request fresh each call (httpx Request objects with bodies
+    are single-use, so callers either pass simple methods or rebuild the
+    request inside the closure).
+    """
+    response = await do_send()
+    if not _is_idempotent(method):
+        return response
+
+    for delay in SDK_RETRY_BACKOFF_SECONDS:
+        if not _is_transient_5xx(response.status_code):
+            return response
+        await asyncio.sleep(delay)
+        response = await do_send()
+    return response
+
+
+def _send_sync_with_5xx_retry(
+    method: str,
+    do_send: Callable[[], httpx.Response],
+) -> httpx.Response:
+    """Sync counterpart of _send_with_5xx_retry."""
+    response = do_send()
+    if not _is_idempotent(method):
+        return response
+
+    for delay in SDK_RETRY_BACKOFF_SECONDS:
+        if not _is_transient_5xx(response.status_code):
+            return response
+        time.sleep(delay)
+        response = do_send()
+    return response
 
 
 def raise_for_status_with_detail(response: httpx.Response) -> None:
@@ -448,14 +505,23 @@ class BifrostClient:
         return False
 
     async def _request_with_refresh(self, method: str, path: str, **kwargs) -> httpx.Response:
-        """Make an HTTP request, refreshing token on 401 and retrying once."""
-        http = self._get_async_client()
-        response = await getattr(http, method)(path, **kwargs)
-        if response.status_code == 401:
-            if await self._refresh_and_update():
-                http = self._get_async_client()
-                response = await getattr(http, method)(path, **kwargs)
-        return response
+        """Make an HTTP request, refreshing token on 401 and retrying once.
+
+        Wrapped with :func:`_send_with_5xx_retry` so idempotent methods retry
+        transient 502/503/504 during rolling API deploys. The 401-refresh-retry
+        fires inside each attempt, so a refresh-then-5xx still benefits from
+        the outer retry.
+        """
+        async def _send() -> httpx.Response:
+            http = self._get_async_client()
+            response = await getattr(http, method)(path, **kwargs)
+            if response.status_code == 401:
+                if await self._refresh_and_update():
+                    http = self._get_async_client()
+                    response = await getattr(http, method)(path, **kwargs)
+            return response
+
+        return await _send_with_5xx_retry(method, _send)
 
     async def get(self, path: str, **kwargs) -> httpx.Response:
         """Make GET request."""
@@ -486,13 +552,20 @@ class BifrostClient:
 
         Needed for verbs whose shortcut method on ``httpx.AsyncClient`` does
         not accept a body (DELETE) but whose REST endpoint expects one.
+
+        Wrapped with :func:`_send_with_5xx_retry` so idempotent methods retry
+        transient 502/503/504 during rolling API deploys.
         """
-        http = self._get_async_client()
-        response = await http.request(method.upper(), path, **kwargs)
-        if response.status_code == 401:
-            if await self._refresh_and_update():
-                response = await http.request(method.upper(), path, **kwargs)
-        return response
+        async def _send() -> httpx.Response:
+            http = self._get_async_client()
+            response = await http.request(method.upper(), path, **kwargs)
+            if response.status_code == 401:
+                if await self._refresh_and_update():
+                    http = self._get_async_client()
+                    response = await http.request(method.upper(), path, **kwargs)
+            return response
+
+        return await _send_with_5xx_retry(method, _send)
 
     def stream(self, method: str, path: str, **kwargs):
         """
@@ -506,12 +579,20 @@ class BifrostClient:
         return self._get_async_client().stream(method, path, **kwargs)
 
     def get_sync(self, path: str, **kwargs) -> httpx.Response:
-        """Make synchronous GET request."""
-        return self._sync_http.get(path, **kwargs)
+        """Make synchronous GET request.
+
+        Wrapped with :func:`_send_sync_with_5xx_retry` so transient 502/503/504
+        from rolling API deploys are retried.
+        """
+        return _send_sync_with_5xx_retry("GET", lambda: self._sync_http.get(path, **kwargs))
 
     def post_sync(self, path: str, **kwargs) -> httpx.Response:
-        """Make synchronous POST request."""
-        return self._sync_http.post(path, **kwargs)
+        """Make synchronous POST request.
+
+        Wrapped with :func:`_send_sync_with_5xx_retry` for signature uniformity;
+        POST is not idempotent so the retry gate will return immediately.
+        """
+        return _send_sync_with_5xx_retry("POST", lambda: self._sync_http.post(path, **kwargs))
 
     async def close(self):
         """Close HTTP clients."""

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -587,12 +587,8 @@ class BifrostClient:
         return _send_sync_with_5xx_retry("GET", lambda: self._sync_http.get(path, **kwargs))
 
     def post_sync(self, path: str, **kwargs) -> httpx.Response:
-        """Make synchronous POST request.
-
-        Wrapped with :func:`_send_sync_with_5xx_retry` for signature uniformity;
-        POST is not idempotent so the retry gate will return immediately.
-        """
-        return _send_sync_with_5xx_retry("POST", lambda: self._sync_http.post(path, **kwargs))
+        """Make synchronous POST request."""
+        return self._sync_http.post(path, **kwargs)
 
     async def close(self):
         """Close HTTP clients."""

--- a/api/src/jobs/rabbitmq.py
+++ b/api/src/jobs/rabbitmq.py
@@ -119,6 +119,9 @@ class BaseConsumer(ABC):
         self._channel: AbstractRobustChannel | None = None
         self._queue: aio_pika.Queue | None = None
         self._running = False
+        self._inflight: set[asyncio.Task] = set()
+        self._consumer_tag: str | None = None
+        self._draining: bool = False
 
     async def start(self) -> None:
         """Start consuming messages."""
@@ -160,11 +163,14 @@ class BaseConsumer(ABC):
 
         logger.info(f"Consumer started for queue: {self.queue_name}")
 
-        # Start consuming
-        await queue.consume(self._on_message)
+        # Start consuming, capturing the consumer tag so drain() can cancel it.
+        self._consumer_tag = await queue.consume(self._on_message)
 
     async def stop(self) -> None:
-        """Stop consuming messages."""
+        """Stop consuming messages (hard close — does NOT wait for in-flight).
+
+        For graceful shutdown, call drain() instead.
+        """
         self._running = False
         if self._channel:
             await self._channel.close()
@@ -172,15 +178,70 @@ class BaseConsumer(ABC):
             await self._connection_ctx.__aexit__(None, None, None)
         logger.info(f"Consumer stopped for queue: {self.queue_name}")
 
+    async def drain(self, deadline: float = 300.0) -> None:
+        """Stop new deliveries, wait on in-flight tasks, then close.
+
+        Cancels the consumer tag (RabbitMQ stops sending new messages on this
+        channel) but keeps the channel open so in-flight tasks can ack their
+        work. After the deadline expires (or all tasks finish), calls stop()
+        to close the channel + connection.
+
+        Idempotent — calling twice is a no-op on the second call.
+
+        Args:
+            deadline: Max seconds to wait for in-flight tasks before giving up.
+        """
+        if self._draining:
+            return  # idempotent
+        self._draining = True
+
+        # Cancel the consumer: stops new deliveries, keeps channel open.
+        if self._queue is not None and self._consumer_tag is not None:
+            try:
+                await self._queue.cancel(self._consumer_tag)
+                logger.info(f"Cancelled consumer for {self.queue_name}")
+            except Exception as e:
+                logger.warning(f"Error cancelling consumer for {self.queue_name}: {e}")
+
+        # Wait for in-flight tasks to finish.
+        if self._inflight:
+            logger.info(
+                f"Draining {len(self._inflight)} in-flight on {self.queue_name} "
+                f"(deadline={deadline}s)"
+            )
+            pending = list(self._inflight)
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*pending, return_exceptions=True),
+                    timeout=deadline,
+                )
+                logger.info(f"Drain complete for {self.queue_name}")
+            except asyncio.TimeoutError:
+                still_running = [t for t in pending if not t.done()]
+                logger.warning(
+                    f"Drain deadline exceeded on {self.queue_name}: "
+                    f"{len(still_running)} task(s) still running"
+                )
+
+        # Close channel + connection (the existing stop() logic).
+        await self.stop()
+
     async def _on_message(self, message: IncomingMessage) -> None:
         """
         Handle incoming message.
 
         Spawns a task to process each message concurrently, allowing
         multiple messages to be processed in parallel up to prefetch_count.
+        Tracks in-flight tasks so drain() can wait for them.
         """
-        # Create task for concurrent processing - don't await here
-        asyncio.create_task(self._process_message_with_ack(message))
+        if self._draining:
+            # Consumer was cancelled but a message slipped through; nack to
+            # requeue so another worker picks it up.
+            await message.nack(requeue=True)
+            return
+        task = asyncio.create_task(self._process_message_with_ack(message))
+        self._inflight.add(task)
+        task.add_done_callback(self._inflight.discard)
 
     async def _process_message_with_ack(self, message: IncomingMessage) -> None:
         """
@@ -256,6 +317,9 @@ class BroadcastConsumer(ABC):
         self._queue: aio_pika.Queue | None = None
         self._running = False
         self._connection_ctx = None
+        self._inflight: set[asyncio.Task] = set()
+        self._consumer_tag: str | None = None
+        self._draining: bool = False
 
     @property
     def queue_name(self) -> str:
@@ -297,11 +361,14 @@ class BroadcastConsumer(ABC):
 
         logger.info(f"Broadcast consumer started for exchange: {self.exchange_name}")
 
-        # Start consuming
-        await queue.consume(self._on_message)
+        # Start consuming, capturing the consumer tag so drain() can cancel it.
+        self._consumer_tag = await queue.consume(self._on_message)
 
     async def stop(self) -> None:
-        """Stop consuming messages."""
+        """Stop consuming messages (hard close — does NOT wait for in-flight).
+
+        For graceful shutdown, call drain() instead.
+        """
         self._running = False
         if self._channel:
             await self._channel.close()
@@ -309,9 +376,67 @@ class BroadcastConsumer(ABC):
             await self._connection_ctx.__aexit__(None, None, None)
         logger.info(f"Broadcast consumer stopped for exchange: {self.exchange_name}")
 
+    async def drain(self, deadline: float = 300.0) -> None:
+        """Stop new deliveries, wait on in-flight tasks, then close.
+
+        Cancels the consumer tag (RabbitMQ stops sending new messages on this
+        channel) but keeps the channel open so in-flight tasks can ack their
+        work. After the deadline expires (or all tasks finish), calls stop()
+        to close the channel + connection.
+
+        Idempotent — calling twice is a no-op on the second call.
+
+        Args:
+            deadline: Max seconds to wait for in-flight tasks before giving up.
+        """
+        if self._draining:
+            return  # idempotent
+        self._draining = True
+
+        # Cancel the consumer: stops new deliveries, keeps channel open.
+        if self._queue is not None and self._consumer_tag is not None:
+            try:
+                await self._queue.cancel(self._consumer_tag)
+                logger.info(f"Cancelled consumer for {self.queue_name}")
+            except Exception as e:
+                logger.warning(f"Error cancelling consumer for {self.queue_name}: {e}")
+
+        # Wait for in-flight tasks to finish.
+        if self._inflight:
+            logger.info(
+                f"Draining {len(self._inflight)} in-flight on {self.queue_name} "
+                f"(deadline={deadline}s)"
+            )
+            pending = list(self._inflight)
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*pending, return_exceptions=True),
+                    timeout=deadline,
+                )
+                logger.info(f"Drain complete for {self.queue_name}")
+            except asyncio.TimeoutError:
+                still_running = [t for t in pending if not t.done()]
+                logger.warning(
+                    f"Drain deadline exceeded on {self.queue_name}: "
+                    f"{len(still_running)} task(s) still running"
+                )
+
+        # Close channel + connection (the existing stop() logic).
+        await self.stop()
+
     async def _on_message(self, message: IncomingMessage) -> None:
-        """Handle incoming message."""
-        asyncio.create_task(self._process_message_with_ack(message))
+        """Handle incoming message.
+
+        Tracks in-flight tasks so drain() can wait for them. While draining,
+        slipped-through messages are nacked + requeued so another worker
+        picks them up.
+        """
+        if self._draining:
+            await message.nack(requeue=True)
+            return
+        task = asyncio.create_task(self._process_message_with_ack(message))
+        self._inflight.add(task)
+        task.add_done_callback(self._inflight.discard)
 
     async def _process_message_with_ack(self, message: IncomingMessage) -> None:
         """Process a message with proper acknowledgment handling."""

--- a/api/src/jobs/rabbitmq.py
+++ b/api/src/jobs/rabbitmq.py
@@ -195,36 +195,38 @@ class BaseConsumer(ABC):
             return  # idempotent
         self._draining = True
 
-        # Cancel the consumer: stops new deliveries, keeps channel open.
-        if self._queue is not None and self._consumer_tag is not None:
-            try:
-                await self._queue.cancel(self._consumer_tag)
-                logger.info(f"Cancelled consumer for {self.queue_name}")
-            except Exception as e:
-                logger.warning(f"Error cancelling consumer for {self.queue_name}: {e}")
+        try:
+            # Cancel the consumer: stops new deliveries, keeps channel open.
+            if self._queue is not None and self._consumer_tag is not None:
+                try:
+                    await self._queue.cancel(self._consumer_tag)
+                    logger.info(f"Cancelled consumer for {self.queue_name}")
+                except Exception as e:
+                    logger.warning(f"Error cancelling consumer for {self.queue_name}: {e}")
 
-        # Wait for in-flight tasks to finish.
-        if self._inflight:
-            logger.info(
-                f"Draining {len(self._inflight)} in-flight on {self.queue_name} "
-                f"(deadline={deadline}s)"
-            )
-            pending = list(self._inflight)
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*pending, return_exceptions=True),
-                    timeout=deadline,
+            # Snapshot is intentional: any message that races past the _draining
+            # flag gets nacked + requeued in _on_message and never enters _inflight.
+            if self._inflight:
+                pending = list(self._inflight)
+                logger.info(
+                    f"Draining {len(pending)} in-flight on {self.queue_name} "
+                    f"(deadline={deadline}s)"
                 )
-                logger.info(f"Drain complete for {self.queue_name}")
-            except asyncio.TimeoutError:
-                still_running = [t for t in pending if not t.done()]
-                logger.warning(
-                    f"Drain deadline exceeded on {self.queue_name}: "
-                    f"{len(still_running)} task(s) still running"
-                )
-
-        # Close channel + connection (the existing stop() logic).
-        await self.stop()
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*pending, return_exceptions=True),
+                        timeout=deadline,
+                    )
+                    logger.info(f"Drain complete for {self.queue_name}")
+                except asyncio.TimeoutError:
+                    still_running = [t for t in pending if not t.done()]
+                    logger.warning(
+                        f"Drain deadline exceeded on {self.queue_name}: "
+                        f"{len(still_running)} task(s) still running"
+                    )
+        finally:
+            # Always close channel + connection, even if cancelled mid-drain.
+            await self.stop()
 
     async def _on_message(self, message: IncomingMessage) -> None:
         """
@@ -393,36 +395,38 @@ class BroadcastConsumer(ABC):
             return  # idempotent
         self._draining = True
 
-        # Cancel the consumer: stops new deliveries, keeps channel open.
-        if self._queue is not None and self._consumer_tag is not None:
-            try:
-                await self._queue.cancel(self._consumer_tag)
-                logger.info(f"Cancelled consumer for {self.queue_name}")
-            except Exception as e:
-                logger.warning(f"Error cancelling consumer for {self.queue_name}: {e}")
+        try:
+            # Cancel the consumer: stops new deliveries, keeps channel open.
+            if self._queue is not None and self._consumer_tag is not None:
+                try:
+                    await self._queue.cancel(self._consumer_tag)
+                    logger.info(f"Cancelled consumer for {self.queue_name}")
+                except Exception as e:
+                    logger.warning(f"Error cancelling consumer for {self.queue_name}: {e}")
 
-        # Wait for in-flight tasks to finish.
-        if self._inflight:
-            logger.info(
-                f"Draining {len(self._inflight)} in-flight on {self.queue_name} "
-                f"(deadline={deadline}s)"
-            )
-            pending = list(self._inflight)
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*pending, return_exceptions=True),
-                    timeout=deadline,
+            # Snapshot is intentional: any message that races past the _draining
+            # flag gets nacked + requeued in _on_message and never enters _inflight.
+            if self._inflight:
+                pending = list(self._inflight)
+                logger.info(
+                    f"Draining {len(pending)} in-flight on {self.queue_name} "
+                    f"(deadline={deadline}s)"
                 )
-                logger.info(f"Drain complete for {self.queue_name}")
-            except asyncio.TimeoutError:
-                still_running = [t for t in pending if not t.done()]
-                logger.warning(
-                    f"Drain deadline exceeded on {self.queue_name}: "
-                    f"{len(still_running)} task(s) still running"
-                )
-
-        # Close channel + connection (the existing stop() logic).
-        await self.stop()
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*pending, return_exceptions=True),
+                        timeout=deadline,
+                    )
+                    logger.info(f"Drain complete for {self.queue_name}")
+                except asyncio.TimeoutError:
+                    still_running = [t for t in pending if not t.done()]
+                    logger.warning(
+                        f"Drain deadline exceeded on {self.queue_name}: "
+                        f"{len(still_running)} task(s) still running"
+                    )
+        finally:
+            # Always close channel + connection, even if cancelled mid-drain.
+            await self.stop()
 
     async def _on_message(self, message: IncomingMessage) -> None:
         """Handle incoming message.

--- a/api/src/worker/main.py
+++ b/api/src/worker/main.py
@@ -148,28 +148,45 @@ class Worker:
                 raise
 
     async def stop(self) -> None:
-        """Stop the worker gracefully."""
-        logger.info("Stopping Bifrost Worker...")
+        """Stop the worker gracefully (drain in-flight, then close).
+
+        Each consumer cancels its consumer tag (so RabbitMQ stops handing
+        it new messages), waits for in-flight tasks to finish (up to the
+        drain deadline), then closes its channel. The deadline is tunable
+        via BIFROST_DRAIN_DEADLINE_SECONDS (default 300s) and should be
+        less than the K8s terminationGracePeriodSeconds with margin for
+        connection cleanup.
+        """
+        logger.info("Stopping Bifrost Worker (graceful drain)...")
         self.running = False
 
-        # Stop consumers
-        for consumer in self._consumers:
-            try:
-                await consumer.stop()
-                logger.info(f"Stopped consumer: {consumer.queue_name}")
-            except Exception as e:
-                logger.error(f"Error stopping consumer {consumer.queue_name}: {e}")
+        # Drain consumers in parallel — each cancels its consumer tag, waits on
+        # its in-flight tasks, then closes its channel.
+        drain_deadline = float(os.environ.get("BIFROST_DRAIN_DEADLINE_SECONDS", "300"))
+        results = await asyncio.gather(
+            *(self._drain_consumer(consumer, drain_deadline) for consumer in self._consumers),
+            return_exceptions=True,
+        )
+        for consumer, result in zip(self._consumers, results):
+            if isinstance(result, Exception):
+                logger.error(f"Error draining consumer {consumer.queue_name}: {result}")
+            else:
+                logger.info(f"Drained consumer: {consumer.queue_name}")
 
-        # Close RabbitMQ connections
+        # Close RabbitMQ pools (idempotent if already closed).
         await rabbitmq.close()
         logger.info("RabbitMQ connections closed")
 
-        # Close database connections
+        # Close database connections.
         await close_db()
         logger.info("Database connections closed")
 
         self._shutdown_event.set()
         logger.info("Bifrost Worker stopped")
+
+    async def _drain_consumer(self, consumer, deadline: float) -> None:
+        """Helper: drain one consumer with the given deadline."""
+        await consumer.drain(deadline=deadline)
 
     def handle_signal(self, signum: int, frame) -> None:
         """Handle shutdown signals."""

--- a/api/src/worker/main.py
+++ b/api/src/worker/main.py
@@ -162,7 +162,17 @@ class Worker:
 
         # Drain consumers in parallel — each cancels its consumer tag, waits on
         # its in-flight tasks, then closes its channel.
-        drain_deadline = float(os.environ.get("BIFROST_DRAIN_DEADLINE_SECONDS", "300"))
+        deadline_str = os.environ.get("BIFROST_DRAIN_DEADLINE_SECONDS", "300")
+        try:
+            drain_deadline = float(deadline_str)
+            if drain_deadline <= 0:
+                raise ValueError(f"must be positive, got {drain_deadline}")
+        except ValueError as e:
+            logger.warning(
+                f"Invalid BIFROST_DRAIN_DEADLINE_SECONDS={deadline_str!r}: {e}; "
+                f"falling back to 300s"
+            )
+            drain_deadline = 300.0
         results = await asyncio.gather(
             *(self._drain_consumer(consumer, drain_deadline) for consumer in self._consumers),
             return_exceptions=True,

--- a/api/src/worker/main.py
+++ b/api/src/worker/main.py
@@ -66,6 +66,7 @@ class Worker:
         self.running = False
         self._shutdown_event = asyncio.Event()
         self._consumers: list = []
+        self._stopping = False
 
     async def start(self) -> None:
         """Start the worker.
@@ -157,6 +158,9 @@ class Worker:
         less than the K8s terminationGracePeriodSeconds with margin for
         connection cleanup.
         """
+        if self._stopping:
+            return
+        self._stopping = True
         logger.info("Stopping Bifrost Worker (graceful drain)...")
         self.running = False
 

--- a/api/tests/unit/jobs/test_rabbitmq_drain.py
+++ b/api/tests/unit/jobs/test_rabbitmq_drain.py
@@ -1,0 +1,210 @@
+"""
+Unit tests for graceful drain on RabbitMQ consumers.
+
+Covers BaseConsumer.drain() and the related _on_message changes that track
+in-flight tasks and reject new messages while draining. Tests are pure
+unit tests — no real RabbitMQ connection. Channel/queue/message are mocked.
+"""
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.jobs.rabbitmq import BaseConsumer, BroadcastConsumer
+
+
+class _NoopConsumer(BaseConsumer):
+    """Test consumer with a configurable-delay process_message."""
+
+    def __init__(self, queue_name: str = "test-queue", delay: float = 0.0):
+        super().__init__(queue_name=queue_name)
+        self.delay = delay
+        self.processed: list[dict[str, Any]] = []
+
+    async def process_message(self, body: dict[str, Any]) -> None:
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        self.processed.append(body)
+
+
+def _make_message_mock() -> MagicMock:
+    """Build a mock IncomingMessage with async ack/nack methods."""
+    message = MagicMock()
+    message.body = b'{"hello": "world"}'
+    message.message_id = "test-id"
+    message.ack = AsyncMock()
+    message.nack = AsyncMock()
+    return message
+
+
+class TestDrainWaitsForInflight:
+    """drain() must wait for in-flight tasks to complete (not cancel them)."""
+
+    @pytest.mark.asyncio
+    async def test_waits_for_running_task(self):
+        consumer = _NoopConsumer()
+        # Build a real in-flight task that sleeps then completes.
+        completed = asyncio.Event()
+
+        async def slow_task():
+            await asyncio.sleep(0.2)
+            completed.set()
+
+        task = asyncio.create_task(slow_task())
+        consumer._inflight.add(task)
+        task.add_done_callback(consumer._inflight.discard)
+
+        # drain() with a generous deadline must wait for the task to finish.
+        await consumer.drain(deadline=2.0)
+
+        assert completed.is_set(), "drain returned before task completed"
+        assert task.done()
+        assert not task.cancelled(), "drain should not cancel the task"
+        assert consumer._draining is True
+
+
+class TestDrainRespectsDeadline:
+    """drain() must give up after the deadline and log a warning."""
+
+    @pytest.mark.asyncio
+    async def test_returns_within_deadline(self, caplog):
+        consumer = _NoopConsumer()
+
+        async def too_slow():
+            await asyncio.sleep(5.0)
+
+        task = asyncio.create_task(too_slow())
+        consumer._inflight.add(task)
+        task.add_done_callback(consumer._inflight.discard)
+
+        with caplog.at_level(logging.WARNING):
+            start = asyncio.get_event_loop().time()
+            await consumer.drain(deadline=0.1)
+            elapsed = asyncio.get_event_loop().time() - start
+
+        # Should return quickly (well under the 5s task duration).
+        assert elapsed < 1.0, f"drain blocked too long: {elapsed}s"
+        assert any("deadline exceeded" in r.message for r in caplog.records)
+
+        # Cleanup so the test runner doesn't see a pending task.
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+class TestDrainIdempotent:
+    """drain() called twice must no-op on the second call."""
+
+    @pytest.mark.asyncio
+    async def test_second_call_noops(self):
+        consumer = _NoopConsumer()
+        # First call: nothing to do, returns quickly.
+        await consumer.drain(deadline=1.0)
+        assert consumer._draining is True
+
+        # Second call: must short-circuit. We assert this by ensuring
+        # _queue.cancel is not invoked (we set it up after first drain).
+        consumer._queue = MagicMock()
+        consumer._queue.cancel = AsyncMock()
+        consumer._consumer_tag = "tag-after-first-drain"
+
+        await consumer.drain(deadline=1.0)
+
+        consumer._queue.cancel.assert_not_called()
+
+
+class TestOnMessageWhileDraining:
+    """_on_message must nack messages that arrive after draining begins."""
+
+    @pytest.mark.asyncio
+    async def test_nacks_with_requeue(self):
+        consumer = _NoopConsumer()
+        consumer._draining = True
+        message = _make_message_mock()
+
+        await consumer._on_message(message)
+
+        message.nack.assert_awaited_once_with(requeue=True)
+        assert len(consumer._inflight) == 0
+
+
+class TestOnMessageTracksTasks:
+    """_on_message must add tasks to _inflight and discard them on completion."""
+
+    @pytest.mark.asyncio
+    async def test_task_added_and_removed(self):
+        consumer = _NoopConsumer()
+        consumer._process_message_with_ack = AsyncMock()  # type: ignore[method-assign]
+        message = _make_message_mock()
+
+        await consumer._on_message(message)
+
+        # Right after creation: task is in the set.
+        assert len(consumer._inflight) == 1
+        task = next(iter(consumer._inflight))
+
+        # Wait for the task to finish; done_callback should remove it.
+        await task
+        # Yield once so the done_callback runs.
+        await asyncio.sleep(0)
+
+        assert len(consumer._inflight) == 0
+        consumer._process_message_with_ack.assert_awaited_once_with(message)
+
+
+class TestDrainCancelsConsumerTag:
+    """drain() must call queue.cancel(consumer_tag) to stop new deliveries."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_called_with_tag(self):
+        consumer = _NoopConsumer()
+        consumer._queue = MagicMock()
+        consumer._queue.cancel = AsyncMock()
+        consumer._consumer_tag = "test-tag"
+
+        await consumer.drain(deadline=1.0)
+
+        consumer._queue.cancel.assert_awaited_once_with("test-tag")
+
+
+class TestDrainHandlesCancelException:
+    """drain() must not propagate exceptions from queue.cancel — only log them."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_exception_logged_not_raised(self, caplog):
+        consumer = _NoopConsumer()
+        consumer._queue = MagicMock()
+        consumer._queue.cancel = AsyncMock(side_effect=Exception("boom"))
+        consumer._consumer_tag = "test-tag"
+
+        with caplog.at_level(logging.WARNING):
+            # Must not raise.
+            await consumer.drain(deadline=1.0)
+
+        assert any("Error cancelling consumer" in r.message for r in caplog.records)
+
+
+class TestBroadcastConsumerHasDrain:
+    """BroadcastConsumer must have the same drain plumbing as BaseConsumer."""
+
+    def test_broadcast_consumer_attributes(self):
+        # Build a minimal subclass since BroadcastConsumer is abstract.
+        class _NoopBroadcast(BroadcastConsumer):
+            async def process_message(self, body: dict[str, Any]) -> None:
+                pass
+
+        consumer = _NoopBroadcast(exchange_name="test-fanout")
+
+        # Confirm the new fields and method exist.
+        assert hasattr(consumer, "_inflight")
+        assert hasattr(consumer, "_consumer_tag")
+        assert hasattr(consumer, "_draining")
+        assert callable(getattr(consumer, "drain", None))
+        assert isinstance(consumer._inflight, set)
+        assert consumer._consumer_tag is None
+        assert consumer._draining is False

--- a/api/tests/unit/jobs/test_rabbitmq_drain.py
+++ b/api/tests/unit/jobs/test_rabbitmq_drain.py
@@ -89,12 +89,11 @@ class TestDrainRespectsDeadline:
         assert elapsed < 1.0, f"drain blocked too long: {elapsed}s"
         assert any("deadline exceeded" in r.message for r in caplog.records)
 
-        # Cleanup so the test runner doesn't see a pending task.
+        # Cleanup so the test runner doesn't see a pending task. gather
+        # with return_exceptions absorbs the expected CancelledError without
+        # the awkward try/except-and-discard pattern.
         task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        await asyncio.gather(task, return_exceptions=True)
 
 
 class TestDrainIdempotent:
@@ -148,9 +147,9 @@ class TestOnMessageTracksTasks:
         assert len(consumer._inflight) == 1
         task = next(iter(consumer._inflight))
 
-        # Wait for the task to finish; done_callback should remove it.
-        await task
-        # Yield once so the done_callback runs.
+        # Wait for the task to finish, then yield once so the done_callback
+        # registered by _on_message runs and discards the task from _inflight.
+        await asyncio.wait([task])
         await asyncio.sleep(0)
 
         assert len(consumer._inflight) == 0

--- a/api/tests/unit/test_bifrost_client_retry.py
+++ b/api/tests/unit/test_bifrost_client_retry.py
@@ -1,0 +1,230 @@
+"""Unit tests for SDK transient-5xx retry behavior in ``BifrostClient``.
+
+Workstream E of issue #171: idempotent SDK calls retry on 502/503/504 during
+rolling API deploys. Non-idempotent methods (POST/PATCH) never auto-retry.
+
+Uses ``httpx.MockTransport`` to count transport calls without hitting the
+network. ``asyncio.sleep`` and ``time.sleep`` are patched so the 36s retry
+budget elapses instantly.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from bifrost.client import BifrostClient
+
+
+def _make_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> BifrostClient:
+    """Build a BifrostClient whose async + sync httpx clients use a mock transport.
+
+    Bypasses ``__init__`` so we don't open real httpx clients and so we can
+    inject the mock transport into both ``_http`` and ``_sync_http``.
+    """
+    client = BifrostClient.__new__(BifrostClient)
+    client.api_url = "http://test.local"
+    client._access_token = "test-token"
+    client._http = httpx.AsyncClient(
+        base_url=client.api_url,
+        headers={"Authorization": f"Bearer {client._access_token}"},
+        transport=httpx.MockTransport(handler),
+    )
+    client._http_loop = None
+    client._sync_http = httpx.Client(
+        base_url=client.api_url,
+        headers={"Authorization": f"Bearer {client._access_token}"},
+        transport=httpx.MockTransport(handler),
+    )
+    client._context = None
+    return client
+
+
+def _seq_handler(statuses: list[int]) -> tuple[Callable[[httpx.Request], httpx.Response], list[int]]:
+    """Return a handler that yields the given status codes in order, plus a call counter list."""
+    counter: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        idx = len(counter)
+        counter.append(1)
+        # If we run past the end of the list, the test queued too few responses.
+        if idx >= len(statuses):
+            raise AssertionError(
+                f"Mock transport received unexpected request #{idx + 1} "
+                f"to {request.method} {request.url}"
+            )
+        return httpx.Response(statuses[idx], json={"ok": True})
+
+    return handler, counter
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep():
+    """Skip real backoff so tests run instantly (~36s budget would otherwise dominate)."""
+    async def _async_noop(_delay: float) -> None:
+        return None
+
+    with patch("bifrost.client.asyncio.sleep", side_effect=_async_noop), \
+         patch("bifrost.client.time.sleep", return_value=None):
+        yield
+
+
+@pytest.fixture
+def force_no_refresh():
+    """Patch ``_refresh_and_update`` to always return False so 401 paths are inert.
+
+    The 5xx retry tests don't exercise 401, but the inner closure inspects
+    ``response.status_code == 401``; ensuring refresh returns False keeps the
+    test focused on 5xx behavior.
+    """
+    async def _no_refresh(_self) -> bool:
+        return False
+
+    with patch.object(BifrostClient, "_refresh_and_update", _no_refresh):
+        yield
+
+
+class _FixedLoopClient(BifrostClient):
+    """Test subclass: always return our pre-built transport-backed _http client.
+
+    The default ``_get_async_client`` rebuilds the client when it detects an
+    event-loop change, which would discard our mock transport.
+    """
+
+    def _get_async_client(self) -> httpx.AsyncClient:  # type: ignore[override]
+        assert self._http is not None
+        return self._http
+
+
+def _make_fixed_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> BifrostClient:
+    client = _FixedLoopClient.__new__(_FixedLoopClient)
+    client.api_url = "http://test.local"
+    client._access_token = "test-token"
+    client._http = httpx.AsyncClient(
+        base_url=client.api_url,
+        headers={"Authorization": f"Bearer {client._access_token}"},
+        transport=httpx.MockTransport(handler),
+    )
+    client._http_loop = None
+    client._sync_http = httpx.Client(
+        base_url=client.api_url,
+        headers={"Authorization": f"Bearer {client._access_token}"},
+        transport=httpx.MockTransport(handler),
+    )
+    client._context = None
+    return client
+
+
+# ------------------------- async tests -------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_get_retries_until_success(force_no_refresh):
+    """GET 503,503,200 → succeeds, 3 transport calls."""
+    handler, calls = _seq_handler([503, 503, 200])
+    client = _make_fixed_client(handler)
+    try:
+        response = await client.get("/api/things")
+        assert response.status_code == 200
+        assert len(calls) == 3
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_post_does_not_retry_on_503(force_no_refresh):
+    """POST 503 → returns 503 with 1 transport call (no retry on non-idempotent)."""
+    handler, calls = _seq_handler([503])
+    client = _make_fixed_client(handler)
+    try:
+        response = await client.post("/api/things")
+        assert response.status_code == 503
+        assert len(calls) == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_put_exhausts_retry_budget(force_no_refresh):
+    """PUT 503 x6 → returns the 6th (final) 503 after 1 + 5 retries = 6 transport calls."""
+    handler, calls = _seq_handler([503] * 6)
+    client = _make_fixed_client(handler)
+    try:
+        response = await client.put("/api/things/1")
+        assert response.status_code == 503
+        assert len(calls) == 6
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_get_success_first_try(force_no_refresh):
+    """GET 200 → 1 transport call."""
+    handler, calls = _seq_handler([200])
+    client = _make_fixed_client(handler)
+    try:
+        response = await client.get("/api/things")
+        assert response.status_code == 200
+        assert len(calls) == 1
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_delete_504_then_200(force_no_refresh):
+    """DELETE 504,200 → succeeds, 2 transport calls."""
+    handler, calls = _seq_handler([504, 200])
+    client = _make_fixed_client(handler)
+    try:
+        response = await client.delete("/api/things/1")
+        assert response.status_code == 200
+        assert len(calls) == 2
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_get_500_not_retried(force_no_refresh):
+    """GET 500 → returns 500, 1 transport call (500 is not in transient set)."""
+    handler, calls = _seq_handler([500])
+    client = _make_fixed_client(handler)
+    try:
+        response = await client.get("/api/things")
+        assert response.status_code == 500
+        assert len(calls) == 1
+    finally:
+        await client.close()
+
+
+# ------------------------- sync tests -------------------------
+
+
+def test_sync_get_retries_on_503(force_no_refresh):
+    """Sync GET retries on 503."""
+    handler, calls = _seq_handler([503, 200])
+    client = _make_fixed_client(handler)
+    try:
+        response = client.get_sync("/api/things")
+        assert response.status_code == 200
+        assert len(calls) == 2
+    finally:
+        client._sync_http.close()
+
+
+def test_sync_post_does_not_retry_on_503(force_no_refresh):
+    """Sync POST does NOT retry on 503."""
+    handler, calls = _seq_handler([503])
+    client = _make_fixed_client(handler)
+    try:
+        response = client.post_sync("/api/things")
+        assert response.status_code == 503
+        assert len(calls) == 1
+    finally:
+        client._sync_http.close()

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router-dom";
 import { Header } from "./Header";
 import { Sidebar } from "./Sidebar";
+import { VersionUpdateBanner } from "./VersionUpdateBanner";
 import { useAuth } from "@/contexts/AuthContext";
 import { NoAccess } from "@/components/NoAccess";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -21,6 +22,7 @@ export function Layout() {
 	if (isLoading) {
 		return (
 			<div className="min-h-screen bg-background">
+				<VersionUpdateBanner />
 				<Header />
 				<div className="flex">
 					<main className="flex-1 p-6 lg:p-8">
@@ -49,27 +51,30 @@ export function Layout() {
 	}
 
 	return (
-		<div className="h-screen flex bg-background overflow-hidden">
-			{/* Sidebar - full height with logo */}
-			<Sidebar
-				isMobileMenuOpen={isMobileMenuOpen}
-				setIsMobileMenuOpen={setIsMobileMenuOpen}
-				isCollapsed={isSidebarCollapsed}
-			/>
-
-			{/* Main content area with header */}
-			<div className="flex-1 flex flex-col overflow-hidden">
-				<Header
-					onMobileMenuToggle={() => setIsMobileMenuOpen(true)}
-					onSidebarToggle={toggleSidebar}
-					isSidebarCollapsed={isSidebarCollapsed}
+		<div className="h-screen flex flex-col bg-background overflow-hidden">
+			<VersionUpdateBanner />
+			<div className="flex-1 flex overflow-hidden">
+				{/* Sidebar - full height with logo */}
+				<Sidebar
+					isMobileMenuOpen={isMobileMenuOpen}
+					setIsMobileMenuOpen={setIsMobileMenuOpen}
+					isCollapsed={isSidebarCollapsed}
 				/>
-				<main className="flex-1 overflow-auto p-6 lg:p-8">
-					<PasskeySetupBanner />
-					<RouteErrorBoundary>
-						<Outlet />
-					</RouteErrorBoundary>
-				</main>
+
+				{/* Main content area with header */}
+				<div className="flex-1 flex flex-col overflow-hidden">
+					<Header
+						onMobileMenuToggle={() => setIsMobileMenuOpen(true)}
+						onSidebarToggle={toggleSidebar}
+						isSidebarCollapsed={isSidebarCollapsed}
+					/>
+					<main className="flex-1 overflow-auto p-6 lg:p-8">
+						<PasskeySetupBanner />
+						<RouteErrorBoundary>
+							<Outlet />
+						</RouteErrorBoundary>
+					</main>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/src/components/layout/VersionUpdateBanner.test.tsx
+++ b/client/src/components/layout/VersionUpdateBanner.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Tests for VersionUpdateBanner.
+ *
+ * The hook's behavior is covered in useVersionCheck.test.ts; here we just
+ * verify the banner renders conditionally and wires Refresh → location.reload.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const useVersionCheckMock = vi.fn<() => boolean>(() => false);
+
+vi.mock("@/hooks/useVersionCheck", () => ({
+	useVersionCheck: () => useVersionCheckMock(),
+}));
+
+import { VersionUpdateBanner } from "./VersionUpdateBanner";
+
+describe("VersionUpdateBanner", () => {
+	it("renders nothing when no update is available", () => {
+		useVersionCheckMock.mockReturnValueOnce(false);
+		const { container } = render(<VersionUpdateBanner />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders a refresh button that reloads the page when an update is available", () => {
+		useVersionCheckMock.mockReturnValueOnce(true);
+
+		const reload = vi.fn();
+		const originalLocation = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...originalLocation, reload },
+		});
+
+		try {
+			render(<VersionUpdateBanner />);
+			expect(
+				screen.getByText(/A new version of Bifrost is available/i),
+			).toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+			expect(reload).toHaveBeenCalledTimes(1);
+		} finally {
+			Object.defineProperty(window, "location", {
+				configurable: true,
+				value: originalLocation,
+			});
+		}
+	});
+});

--- a/client/src/components/layout/VersionUpdateBanner.tsx
+++ b/client/src/components/layout/VersionUpdateBanner.tsx
@@ -9,7 +9,7 @@ export function VersionUpdateBanner() {
 		<div
 			role="status"
 			aria-live="polite"
-			className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-3 bg-primary px-4 py-2 text-primary-foreground shadow-md"
+			className="flex w-full items-center justify-center gap-3 bg-primary px-4 py-2 text-primary-foreground shadow-md"
 		>
 			<span className="text-sm font-medium">
 				A new version of Bifrost is available.

--- a/client/src/components/layout/VersionUpdateBanner.tsx
+++ b/client/src/components/layout/VersionUpdateBanner.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@/components/ui/button";
+import { useVersionCheck } from "@/hooks/useVersionCheck";
+
+export function VersionUpdateBanner() {
+	const updateAvailable = useVersionCheck();
+	if (!updateAvailable) return null;
+
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-3 bg-primary px-4 py-2 text-primary-foreground shadow-md"
+		>
+			<span className="text-sm font-medium">
+				A new version of Bifrost is available.
+			</span>
+			<Button
+				size="sm"
+				variant="secondary"
+				onClick={() => window.location.reload()}
+			>
+				Refresh
+			</Button>
+		</div>
+	);
+}

--- a/client/src/hooks/useVersionCheck.dev.test.ts
+++ b/client/src/hooks/useVersionCheck.dev.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Dev-mode behavior for useVersionCheck.
+ *
+ * When APP_VERSION is "unknown" (no VITE_BIFROST_VERSION baked in), the hook
+ * must short-circuit: never fetch, never flip to true. We isolate this case
+ * in its own file so the module-scope mock for `@/lib/version` can return
+ * "unknown" without affecting the main suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@/lib/version", () => ({ APP_VERSION: "unknown" }));
+
+import { useVersionCheck } from "./useVersionCheck";
+
+describe("useVersionCheck (dev / unknown version)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("never fires fetch and stays false forever", async () => {
+		const fetchSpy = vi
+			.spyOn(window, "fetch")
+			.mockResolvedValue({ ok: true, json: async () => ({}) } as unknown as Response);
+
+		const { result } = renderHook(() => useVersionCheck(60_000));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000 * 10);
+		});
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(result.current).toBe(false);
+	});
+});

--- a/client/src/hooks/useVersionCheck.test.ts
+++ b/client/src/hooks/useVersionCheck.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for useVersionCheck.
+ *
+ * Covers polling cadence, visibility pause/resume, network error swallowing,
+ * and cleanup. The "skip in dev" case (APP_VERSION === "unknown") lives in
+ * useVersionCheck.dev.test.ts because it needs a different module-scope mock.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@/lib/version", () => ({ APP_VERSION: "v1.0.0" }));
+
+import { useVersionCheck } from "./useVersionCheck";
+
+function mockFetchOnce(version: string, ok = true) {
+	return vi.spyOn(window, "fetch").mockResolvedValue({
+		ok,
+		json: async () => ({ version }),
+	} as unknown as Response);
+}
+
+function setVisibility(state: "visible" | "hidden") {
+	Object.defineProperty(document, "visibilityState", {
+		configurable: true,
+		get: () => state,
+	});
+}
+
+describe("useVersionCheck", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		setVisibility("visible");
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("returns false when versions match", async () => {
+		mockFetchOnce("v1.0.0");
+		const { result } = renderHook(() => useVersionCheck(60_000));
+
+		// Let the immediate-fire fetch promise resolve.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		expect(result.current).toBe(false);
+	});
+
+	it("returns true when versions differ", async () => {
+		mockFetchOnce("v2.0.0");
+		const { result } = renderHook(() => useVersionCheck(60_000));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		expect(result.current).toBe(true);
+	});
+
+	it("pauses polling while the tab is hidden", async () => {
+		const fetchSpy = mockFetchOnce("v1.0.0");
+		setVisibility("hidden");
+		renderHook(() => useVersionCheck(60_000));
+
+		// Immediate fire is gated on visibility — it bails before fetching.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+
+		// Advance past the polling interval — still hidden, still no fetch.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("re-fires when visibility returns to visible", async () => {
+		const fetchSpy = mockFetchOnce("v1.0.0");
+		setVisibility("hidden");
+		renderHook(() => useVersionCheck(60_000));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+
+		// Flip to visible and dispatch the event the hook listens for.
+		setVisibility("visible");
+		await act(async () => {
+			document.dispatchEvent(new Event("visibilitychange"));
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("swallows fetch rejections without surfacing an update", async () => {
+		const fetchSpy = vi
+			.spyOn(window, "fetch")
+			.mockRejectedValue(new Error("network down"));
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const { result } = renderHook(() => useVersionCheck(60_000));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		expect(fetchSpy).toHaveBeenCalled();
+		expect(result.current).toBe(false);
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+
+	it("polls again after the interval elapses", async () => {
+		const fetchSpy = mockFetchOnce("v1.0.0");
+		renderHook(() => useVersionCheck(60_000));
+
+		// Immediate fire.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		// One full interval later, second poll.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000);
+		});
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("stops polling and removes the listener after unmount", async () => {
+		const fetchSpy = mockFetchOnce("v1.0.0");
+		const { unmount } = renderHook(() => useVersionCheck(60_000));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		unmount();
+
+		// Pending interval should be cancelled — no further fetches.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(60_000 * 5);
+		});
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		// Visibility events post-unmount must also be ignored.
+		setVisibility("visible");
+		await act(async () => {
+			document.dispatchEvent(new Event("visibilitychange"));
+			await vi.advanceTimersByTimeAsync(0);
+		});
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/client/src/hooks/useVersionCheck.ts
+++ b/client/src/hooks/useVersionCheck.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { APP_VERSION } from "@/lib/version";
+
+const DEFAULT_INTERVAL_MS = 60_000;
+
+/**
+ * Polls /api/version and reports when the deployed server version differs
+ * from the version baked into this build. Used to surface a "refresh to update"
+ * banner so tabs don't get stuck on stale bundles after a deploy.
+ *
+ * Skipped entirely in dev (when APP_VERSION === "unknown") so the banner
+ * doesn't fire constantly on hot-reload.
+ */
+export function useVersionCheck(intervalMs = DEFAULT_INTERVAL_MS): boolean {
+	const [updateAvailable, setUpdateAvailable] = useState(false);
+
+	useEffect(() => {
+		// No version baked in (dev) — nothing to compare against.
+		if (APP_VERSION === "unknown") return;
+
+		let cancelled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const check = async () => {
+			if (document.visibilityState === "hidden") return;
+			try {
+				const res = await fetch("/api/version");
+				if (!res.ok) return;
+				const data = (await res.json()) as { version?: string };
+				if (cancelled) return;
+				if (typeof data.version === "string" && data.version !== APP_VERSION) {
+					setUpdateAvailable(true);
+				}
+			} catch {
+				// Network error / API unavailable — quietly ignore; we'll try again.
+			}
+		};
+
+		const schedule = () => {
+			timer = setTimeout(async () => {
+				await check();
+				if (!cancelled) schedule();
+			}, intervalMs);
+		};
+
+		const onVisibility = () => {
+			if (document.visibilityState === "visible") {
+				void check();
+			}
+		};
+
+		void check(); // immediate fire on mount
+		schedule();
+		document.addEventListener("visibilitychange", onVisibility);
+
+		return () => {
+			cancelled = true;
+			if (timer !== null) clearTimeout(timer);
+			document.removeEventListener("visibilitychange", onVisibility);
+		};
+	}, [intervalMs]);
+
+	return updateAvailable;
+}

--- a/client/src/lib/api-client.test.ts
+++ b/client/src/lib/api-client.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { authFetch } from "./api-client";
+import { ACCESS_TOKEN_KEY } from "./auth-token";
+
+/**
+ * Build a mock Response with a given status and an empty body.
+ */
+function mockResponse(status: number): Response {
+	return new Response(null, { status });
+}
+
+/**
+ * Build a never-expiring access token so `ensureValidToken` short-circuits
+ * without actually hitting the refresh endpoint.
+ *
+ * JWT shape: header.payload.signature (signature is unverified by the
+ * client). The payload is `{exp: <far-future>}`.
+ */
+function buildFakeToken(): string {
+	const farFuture = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365;
+	const header = btoa(JSON.stringify({ alg: "none", typ: "JWT" }));
+	const payload = btoa(JSON.stringify({ exp: farFuture }));
+	return `${header}.${payload}.sig`;
+}
+
+/**
+ * Drain the microtask queue + advance fake timers so any pending setTimeout
+ * for retry backoff fires. Repeated multiple times to flush
+ * await-then-setTimeout chains.
+ */
+async function flushRetries(maxBackoffMs: number = 5000): Promise<void> {
+	// Run microtasks so awaited fetch promises resolve before timers tick.
+	for (let i = 0; i < 5; i++) {
+		await Promise.resolve();
+	}
+	await vi.advanceTimersByTimeAsync(maxBackoffMs);
+}
+
+describe("authFetch transient 5xx retry", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		// Seed a valid access token so ensureValidToken passes without a
+		// refresh call.
+		localStorage.setItem(ACCESS_TOKEN_KEY, buildFakeToken());
+
+		fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		// Use fake timers so the backoff sleeps don't actually delay tests.
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		localStorage.clear();
+		sessionStorage.clear();
+	});
+
+	it("retries a GET that returns 503 twice then 200", async () => {
+		fetchMock
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockResponse(200));
+
+		const promise = authFetch("/api/test");
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not retry a POST that returns 503", async () => {
+		fetchMock.mockResolvedValueOnce(mockResponse(503));
+
+		const promise = authFetch("/api/test", { method: "POST" });
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(503);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns the last 503 after a PUT exhausts all retries", async () => {
+		fetchMock
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockResponse(503));
+
+		const promise = authFetch("/api/test", {
+			method: "PUT",
+			body: JSON.stringify({ x: 1 }),
+		});
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(503);
+		// 1 initial attempt + 3 retries
+		expect(fetchMock).toHaveBeenCalledTimes(4);
+	});
+
+	it("does not retry a GET that returns 200 immediately", async () => {
+		fetchMock.mockResolvedValueOnce(mockResponse(200));
+
+		const promise = authFetch("/api/test");
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries a GET through 502 then 503 then resolves to 200", async () => {
+		fetchMock
+			.mockResolvedValueOnce(mockResponse(502))
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockResponse(200));
+
+		const promise = authFetch("/api/test");
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it("retries a DELETE on 504 and resolves to 204", async () => {
+		fetchMock
+			.mockResolvedValueOnce(mockResponse(504))
+			.mockResolvedValueOnce(mockResponse(204));
+
+		const promise = authFetch("/api/test", { method: "DELETE" });
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(204);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not retry a GET that returns 500 (not in TRANSIENT_5XX)", async () => {
+		fetchMock.mockResolvedValueOnce(mockResponse(500));
+
+		const promise = authFetch("/api/test");
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(500);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries a HEAD on 503 and resolves to 200", async () => {
+		fetchMock
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockResponse(200));
+
+		const promise = authFetch("/api/test", { method: "HEAD" });
+		await flushRetries();
+		const response = await promise;
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/client/src/lib/api-client.test.ts
+++ b/client/src/lib/api-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { authFetch } from "./api-client";
+import { apiClient, authFetch } from "./api-client";
 import { ACCESS_TOKEN_KEY } from "./auth-token";
 
 /**
@@ -162,5 +162,98 @@ describe("authFetch transient 5xx retry", () => {
 
 		expect(response.status).toBe(200);
 		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});
+
+/**
+ * Build a JSON Response with the given status and body.
+ *
+ * openapi-fetch tries to parse the response body when content-type is JSON,
+ * so 200 responses need a real JSON payload — even an empty object — or
+ * the parse step will throw.
+ */
+function mockJsonResponse(status: number, body: unknown = {}): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("apiClient (openapi-fetch middleware) transient 5xx retry", () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		// Seed a valid access token so the middleware's ensureValidToken
+		// short-circuits without trying to refresh.
+		localStorage.setItem(ACCESS_TOKEN_KEY, buildFakeToken());
+
+		fetchMock = vi.fn();
+		// openapi-fetch captures `globalThis.fetch` at createClient() time
+		// (so module load), so stubGlobal alone won't hit the initial
+		// request. The retry path inside the middleware DOES call global
+		// `fetch`, which we still want intercepted — but we also pass
+		// `fetch: fetchMock` per-call below so the initial request goes
+		// through the same mock.
+		vi.stubGlobal("fetch", fetchMock);
+
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		localStorage.clear();
+		sessionStorage.clear();
+	});
+
+	it("apiClient.GET retries a transient 5xx and returns the eventual 200", async () => {
+		fetchMock
+			.mockResolvedValueOnce(mockResponse(503))
+			.mockResolvedValueOnce(mockJsonResponse(200, { version: "1.0" }));
+
+		// `fetch` per-call override is supported by openapi-fetch's
+		// coreFetch (`fetch = baseFetch` at line 48 of node_modules/openapi-fetch/src/index.js).
+		// Cast to any since the typed FetchOptions doesn't surface the
+		// override field in the public types but it's implemented in core.
+		const promise = apiClient.GET("/api/version", {
+			fetch: fetchMock,
+		} as never);
+		await flushRetries();
+		const { response } = await promise;
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("apiClient.PUT replays the body across retries via the WeakMap clone cache", async () => {
+		// Capture the body sent on each fetch call. The body is a stream so
+		// we read it eagerly in the mock impl before resolving.
+		const capturedBodies: string[] = [];
+		fetchMock.mockImplementation(async (req: Request) => {
+			capturedBodies.push(await req.clone().text());
+			// First attempt 503, second attempt 200.
+			if (capturedBodies.length === 1) return mockResponse(503);
+			return mockJsonResponse(200, {});
+		});
+
+		const promise = apiClient.PUT("/api/branding", {
+			body: { primary_color: "#abcdef" },
+			// See note above re: per-call fetch override + cast.
+			fetch: fetchMock,
+		} as never);
+		await flushRetries();
+		const { response } = await promise;
+
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		// Both attempts must have carried the same body — proves the
+		// WeakMap-cached pre-send clone replayed correctly.
+		expect(capturedBodies).toHaveLength(2);
+		expect(JSON.parse(capturedBodies[0])).toEqual({
+			primary_color: "#abcdef",
+		});
+		expect(JSON.parse(capturedBodies[1])).toEqual({
+			primary_color: "#abcdef",
+		});
 	});
 });

--- a/client/src/lib/api-client.ts
+++ b/client/src/lib/api-client.ts
@@ -29,6 +29,87 @@ consumeEmbedTokenFromHash();
 // Buffer time before expiration to trigger refresh (60 seconds)
 const TOKEN_REFRESH_BUFFER_SECONDS = 60;
 
+// Transient 5xx statuses that warrant a client-side retry. Limited to the
+// classic LB/proxy "pod just dropped" responses — 500/501/505 indicate
+// server-side bugs we should surface, not paper over.
+const TRANSIENT_5XX = new Set([502, 503, 504]);
+
+// Retry only methods that are safe to replay. POST/PATCH may have already
+// taken effect server-side even when the response was a 5xx; auto-retrying
+// would create duplicate resources.
+const IDEMPOTENT_METHODS = new Set([
+	"GET",
+	"PUT",
+	"DELETE",
+	"HEAD",
+	"OPTIONS",
+]);
+
+// Backoff schedule (ms) between retry attempts. Up to 3 retries on top of
+// the initial attempt, totaling ~3s of additional latency in the worst case.
+const RETRY_BACKOFF_MS = [250, 750, 2000];
+
+function isTransient5xx(status: number): boolean {
+	return TRANSIENT_5XX.has(status);
+}
+
+function isIdempotent(method: string): boolean {
+	return IDEMPOTENT_METHODS.has(method.toUpperCase());
+}
+
+/**
+ * Wrap a fetch operation with retry on transient 5xx (502/503/504) for
+ * idempotent methods. Non-idempotent requests (POST/PATCH) pass through
+ * unchanged.
+ *
+ * The `doFetch` callback MUST produce a fresh Request each call — if a
+ * Request with a body is reused, its body stream will be consumed after
+ * the first attempt.
+ */
+async function withTransient5xxRetry(
+	method: string,
+	doFetch: () => Promise<Response>,
+): Promise<Response> {
+	if (!isIdempotent(method)) return doFetch();
+	let response = await doFetch();
+	for (const delay of RETRY_BACKOFF_MS) {
+		if (!isTransient5xx(response.status)) return response;
+		await new Promise((resolve) => setTimeout(resolve, delay));
+		response = await doFetch();
+	}
+	// Out of retries — caller sees the last 5xx.
+	return response;
+}
+
+/**
+ * Continue retrying after an initial fetch already produced a transient 5xx.
+ * Used in the openapi-fetch middleware paths where the framework fires the
+ * first request for us, so we react to the response rather than wrapping the
+ * full lifecycle.
+ */
+async function retryAfterTransient5xx(
+	method: string,
+	baseRequest: Request,
+	initialResponse: Response,
+): Promise<Response> {
+	if (!isIdempotent(method)) return initialResponse;
+	let response = initialResponse;
+	for (const delay of RETRY_BACKOFF_MS) {
+		if (!isTransient5xx(response.status)) return response;
+		await new Promise((resolve) => setTimeout(resolve, delay));
+		response = await fetch(baseRequest.clone());
+	}
+	return response;
+}
+
+/**
+ * Cache of pre-send Request clones, keyed by the live Request object that
+ * openapi-fetch hands to onRequest/onResponse. Stashed in onRequest before
+ * the body stream is consumed so 5xx retry in onResponse can replay
+ * requests with bodies (e.g. PUT).
+ */
+const _requestClones = new WeakMap<Request, Request>();
+
 // Endpoints that should skip token refresh check
 const AUTH_ENDPOINTS = [
 	"/auth/login",
@@ -249,6 +330,13 @@ baseClient.use({
 			}
 		}
 
+		// Stash a pre-send clone so onResponse can replay this request on
+		// transient 5xx (idempotent methods only — POST/PATCH bodies would
+		// just hold memory we never use).
+		if (isIdempotent(request.method)) {
+			_requestClones.set(request, request.clone());
+		}
+
 		return request;
 	},
 	async onResponse({ request, response }) {
@@ -282,6 +370,18 @@ baseClient.use({
 		}
 		// 403 Forbidden = permission issue, don't redirect (user is authenticated)
 		// Let the calling code handle displaying an appropriate error message
+
+		// Retry transient 5xx (502/503/504) on idempotent methods. Rides
+		// through brief windows during a rolling API deploy where a pod is
+		// dropping out of the LB.
+		if (isTransient5xx(response.status) && isIdempotent(request.method)) {
+			const baseRequest = _requestClones.get(request) ?? request;
+			return retryAfterTransient5xx(
+				request.method,
+				baseRequest,
+				response,
+			);
+		}
 
 		return response;
 	},
@@ -376,10 +476,28 @@ export function withUserContext(userId: string) {
 				}
 			}
 
+			// Stash a pre-send clone for transient 5xx replay (idempotent
+			// methods only).
+			if (isIdempotent(request.method)) {
+				_requestClones.set(request, request.clone());
+			}
+
 			return request;
 		},
 		async onResponse({ request, response }) {
-			return handleAuthResponse(request, response);
+			const finalResponse = await handleAuthResponse(request, response);
+			if (
+				isTransient5xx(finalResponse.status) &&
+				isIdempotent(request.method)
+			) {
+				const baseRequest = _requestClones.get(request) ?? request;
+				return retryAfterTransient5xx(
+					request.method,
+					baseRequest,
+					finalResponse,
+				);
+			}
+			return finalResponse;
 		},
 	});
 
@@ -461,8 +579,10 @@ export async function authFetch(
 		credentials: "same-origin",
 	});
 
-	const response = await fetch(request.clone());
-
-	// Handle 429 and 401 with retry support
-	return handleAuthResponse(request, response);
+	// Wrap the fetch + auth-handling in transient-5xx retry. Each attempt
+	// clones the assembled Request so any body stream is fresh.
+	return withTransient5xxRetry(method, async () => {
+		const response = await fetch(request.clone());
+		return handleAuthResponse(request.clone(), response);
+	});
 }

--- a/client/src/lib/preload-error-handler.test.ts
+++ b/client/src/lib/preload-error-handler.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the vite:preloadError handler.
+ *
+ * The handler reloads once on a preload error, but suppresses subsequent
+ * reloads within a 5s window so a chronically broken deploy can't trap
+ * the user in a reload tornado.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleVitePreloadError } from "./preload-error-handler";
+
+const RELOAD_KEY = "bifrost:last-preload-reload";
+
+describe("handleVitePreloadError", () => {
+	let reload: ReturnType<typeof vi.fn>;
+	let originalLocation: Location;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		sessionStorage.clear();
+
+		// Mirror the VersionUpdateBanner test pattern: replace window.location
+		// with a copy whose `reload` is a spy so we can assert without
+		// actually navigating jsdom.
+		reload = vi.fn();
+		originalLocation = window.location;
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: { ...originalLocation, reload },
+		});
+
+		consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			value: originalLocation,
+		});
+		consoleErrorSpy.mockRestore();
+		sessionStorage.clear();
+	});
+
+	it("first preload error reloads and stores timestamp", () => {
+		const before = Date.now();
+		handleVitePreloadError();
+		const after = Date.now();
+
+		expect(reload).toHaveBeenCalledTimes(1);
+
+		const stored = sessionStorage.getItem(RELOAD_KEY);
+		expect(stored).not.toBeNull();
+		const ts = Number(stored);
+		expect(ts).toBeGreaterThanOrEqual(before);
+		expect(ts).toBeLessThanOrEqual(after);
+	});
+
+	it("second preload error within 5s is suppressed (no reload)", () => {
+		// Simulate a reload that just happened 1s ago.
+		sessionStorage.setItem(RELOAD_KEY, String(Date.now() - 1000));
+
+		handleVitePreloadError();
+
+		expect(reload).not.toHaveBeenCalled();
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			"[bifrost] preload error after recent reload, suppressing",
+		);
+	});
+
+	it("preload error after the 5s window reloads again", () => {
+		// Simulate a reload from 6s ago — outside the loop guard.
+		sessionStorage.setItem(RELOAD_KEY, String(Date.now() - 6000));
+
+		handleVitePreloadError();
+
+		expect(reload).toHaveBeenCalledTimes(1);
+	});
+});

--- a/client/src/lib/preload-error-handler.ts
+++ b/client/src/lib/preload-error-handler.ts
@@ -1,0 +1,22 @@
+const RELOAD_KEY = "bifrost:last-preload-reload";
+const LOOP_GUARD_MS = 5_000;
+
+/**
+ * Handle a vite:preloadError by reloading, with a sessionStorage loop guard
+ * so a chronically broken deploy can't trap us in a reload tornado.
+ *
+ * Exported as a named function (not bound directly to addEventListener)
+ * so tests can call it with mocked sessionStorage / location.
+ */
+export function handleVitePreloadError(): void {
+	const lastReload = sessionStorage.getItem(RELOAD_KEY);
+	const now = Date.now();
+	if (lastReload && now - Number(lastReload) < LOOP_GUARD_MS) {
+		// Already reloaded within the last 5s — don't loop. The version banner
+		// will surface the version mismatch on the next poll cycle.
+		console.error("[bifrost] preload error after recent reload, suppressing");
+		return;
+	}
+	sessionStorage.setItem(RELOAD_KEY, String(now));
+	window.location.reload();
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,8 +7,27 @@ import App from "./App.tsx";
 import { queryClient } from "./lib/queryClient";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { OrgScopeQueryInvalidator } from "./components/OrgScopeQueryInvalidator";
+import { VersionUpdateBanner } from "@/components/layout/VersionUpdateBanner";
 import { configureMonaco } from "./lib/monaco-setup";
 import { initReactShim } from "./lib/esm-react-shim";
+
+// After a deploy, hashed JS chunks vanish and dynamic imports for old chunk
+// names start 404'ing. Vite emits `vite:preloadError` for those — reload once
+// to pull the fresh bundle, with a sessionStorage guard so a chronically
+// broken deploy can't trap the user in a reload loop.
+window.addEventListener("vite:preloadError", () => {
+	const RELOAD_KEY = "bifrost:last-preload-reload";
+	const lastReload = sessionStorage.getItem(RELOAD_KEY);
+	const now = Date.now();
+	if (lastReload && now - Number(lastReload) < 5_000) {
+		// Reloaded within the last 5s — don't loop. The banner will surface
+		// the version mismatch on the next poll cycle.
+		console.error("[bifrost] preload error after recent reload, suppressing");
+		return;
+	}
+	sessionStorage.setItem(RELOAD_KEY, String(now));
+	window.location.reload();
+});
 
 // Expose platform React via import map so esm.sh packages use the same instance
 initReactShim();
@@ -22,6 +41,7 @@ createRoot(document.getElementById("root")!).render(
 			<QueryClientProvider client={queryClient}>
 				<OrgScopeQueryInvalidator />
 				<App />
+				<VersionUpdateBanner />
 				<Toaster />
 			</QueryClientProvider>
 		</ThemeProvider>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,7 +7,6 @@ import App from "./App.tsx";
 import { queryClient } from "./lib/queryClient";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { OrgScopeQueryInvalidator } from "./components/OrgScopeQueryInvalidator";
-import { VersionUpdateBanner } from "@/components/layout/VersionUpdateBanner";
 import { configureMonaco } from "./lib/monaco-setup";
 import { initReactShim } from "./lib/esm-react-shim";
 
@@ -41,7 +40,6 @@ createRoot(document.getElementById("root")!).render(
 			<QueryClientProvider client={queryClient}>
 				<OrgScopeQueryInvalidator />
 				<App />
-				<VersionUpdateBanner />
 				<Toaster />
 			</QueryClientProvider>
 		</ThemeProvider>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -9,24 +9,13 @@ import { ThemeProvider } from "./contexts/ThemeContext";
 import { OrgScopeQueryInvalidator } from "./components/OrgScopeQueryInvalidator";
 import { configureMonaco } from "./lib/monaco-setup";
 import { initReactShim } from "./lib/esm-react-shim";
+import { handleVitePreloadError } from "@/lib/preload-error-handler";
 
 // After a deploy, hashed JS chunks vanish and dynamic imports for old chunk
 // names start 404'ing. Vite emits `vite:preloadError` for those — reload once
 // to pull the fresh bundle, with a sessionStorage guard so a chronically
 // broken deploy can't trap the user in a reload loop.
-window.addEventListener("vite:preloadError", () => {
-	const RELOAD_KEY = "bifrost:last-preload-reload";
-	const lastReload = sessionStorage.getItem(RELOAD_KEY);
-	const now = Date.now();
-	if (lastReload && now - Number(lastReload) < 5_000) {
-		// Reloaded within the last 5s — don't loop. The banner will surface
-		// the version mismatch on the next poll cycle.
-		console.error("[bifrost] preload error after recent reload, suppressing");
-		return;
-	}
-	sessionStorage.setItem(RELOAD_KEY, String(now));
-	window.location.reload();
-});
+window.addEventListener("vite:preloadError", handleVitePreloadError);
 
 // Expose platform React via import map so esm.sh packages use the same instance
 initReactShim();

--- a/docs/plans/2026-05-01-deploy-resilience.md
+++ b/docs/plans/2026-05-01-deploy-resilience.md
@@ -1,0 +1,376 @@
+# Deploy resilience plan — issue #171
+
+**Branch:** `171-deploy-resilience`
+**Tracking:** https://github.com/jackmusick/bifrost/issues/171
+
+## Goal
+
+Make every push-to-main rollout safe: zero failed user-visible requests, zero duplicate workflow executions, no white-screen tabs across deploys.
+
+## Out of scope (explicit)
+
+- POST idempotency keys
+- Vercel migration for the client
+- Scheduler HA (still singleton, `Recreate`)
+- WebSocket reconnect redesign (verify-only)
+
+## Workstreams and ordering
+
+The work splits into independent workstreams. Recommended commit order is by impact and risk: A first (smallest, highest user-visible win), then C (fixes the bundle bug), B (fixes double-execution), D, E. Workstream F mirrors A–D into `../kubernetes` once each lands.
+
+### Workstream A — API rolling deploy
+
+**Files**
+- `k8s/api/deployment.yaml`
+- `api/src/routers/health.py` (verify, may need update)
+
+**Changes**
+1. `replicas: 2`
+2. Add `strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } }`
+3. Add `terminationGracePeriodSeconds: 35` on the pod spec
+4. Add `lifecycle.preStop` to the api container:
+   ```yaml
+   lifecycle:
+     preStop:
+       exec:
+         command: ["sleep", "5"]
+   ```
+5. Update the uvicorn command to include `--timeout-graceful-shutdown 30`:
+   ```yaml
+   command: ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000",
+             "--timeout-graceful-shutdown", "30"]
+   ```
+6. **Audit `/health`**: confirm it actually checks DB + RabbitMQ + Redis connectivity before returning 200. If it's a dumb 200, fix it. Readiness must mean ready.
+
+**Tests**
+- Manual: deploy this, push a no-op to main, watch `kubectl get pods -w`, confirm both pods stay healthy through the rollout
+- Unit test on `/health`: mock each dep to be down, expect 503
+
+**Risk**
+- Bumping replicas means 2x DB connection pool usage — confirm Postgres `max_connections` headroom and per-pod pool size product is comfortable
+- **Latent: alembic concurrency on scale events.** `init_container.py` runs `alembic upgrade head` on every pod start. Rolling updates are safe (`maxSurge: 1` serializes init), but cold-start (0→2) and simultaneous reschedules can run two `alembic upgrade head` in parallel against the same DB. Real migrations with `CREATE INDEX CONCURRENTLY` or non-idempotent data steps can deadlock. Fix is a Postgres advisory lock around the upgrade in `init_container.py` (~5 lines). Out of scope for this issue; track separately if it ever bites.
+
+---
+
+### Workstream B — Worker graceful drain
+
+**Files**
+- `api/src/jobs/rabbitmq.py` (BaseConsumer + BroadcastConsumer)
+- `api/src/worker/main.py` (signal handler + drain orchestration)
+- `k8s/worker/deployment.yaml`
+- `api/tests/unit/jobs/test_rabbitmq_drain.py` (new)
+
+**Design**
+
+Today (`api/src/jobs/rabbitmq.py:166`) `stop()` closes the channel immediately, killing any in-flight `_process_message_with_ack` task mid-process. The ack fails and RabbitMQ requeues — the same workflow runs twice.
+
+New shape:
+
+```
+SIGTERM
+  → Worker.stop()
+      → for each consumer: consumer.drain()
+          → cancel consumer (await self._queue.cancel(consumer_tag))   ← new deliveries stop
+          → await asyncio.gather(*self._inflight, return_exceptions=True)
+              with timeout=DRAIN_DEADLINE (default 300s, env-tunable)
+          → close channel + connection
+  → close RabbitMQ pools, close DB
+  → exit 0
+```
+
+**Implementation steps**
+
+1. **Track in-flight tasks in `BaseConsumer`**:
+   ```python
+   def __init__(self, ...):
+       ...
+       self._inflight: set[asyncio.Task] = set()
+       self._consumer_tag: str | None = None
+       self._draining = False
+   ```
+
+2. **Capture consumer tag** at `start()`:
+   ```python
+   self._consumer_tag = await queue.consume(self._on_message)
+   ```
+
+3. **Reject new messages while draining** in `_on_message`:
+   ```python
+   async def _on_message(self, message: IncomingMessage) -> None:
+       if self._draining:
+           # consumer was cancelled but a message slipped through
+           await message.nack(requeue=True)
+           return
+       task = asyncio.create_task(self._process_message_with_ack(message))
+       self._inflight.add(task)
+       task.add_done_callback(self._inflight.discard)
+   ```
+
+4. **Add `drain()` method**:
+   ```python
+   async def drain(self, deadline: float) -> None:
+       """Stop new deliveries, wait on in-flight, then close."""
+       self._draining = True
+       if self._queue and self._consumer_tag:
+           await self._queue.cancel(self._consumer_tag)
+       if self._inflight:
+           logger.info(f"Draining {len(self._inflight)} in-flight on {self.queue_name}")
+           try:
+               await asyncio.wait_for(
+                   asyncio.gather(*self._inflight, return_exceptions=True),
+                   timeout=deadline,
+               )
+           except asyncio.TimeoutError:
+               logger.warning(
+                   f"Drain deadline exceeded with {len(self._inflight)} tasks still running on {self.queue_name}"
+               )
+       await self.stop()
+   ```
+
+5. **Worker.stop() calls drain() instead of stop() per consumer.**
+
+6. **Hook into Redis heartbeat** so `/diagnostics` shows worker state. Find the heartbeat publisher in `api/src/jobs/` (process pool heartbeat, used by `api/src/routers/platform/workers.py`) and add a `state` field that flips to `"draining"` while drain is active.
+
+7. **K8s manifest changes** in `k8s/worker/deployment.yaml`:
+   - `terminationGracePeriodSeconds: 360`
+   - `lifecycle.preStop: { exec: { command: ["sleep", "5"] } }`
+   - `strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } }`
+
+**Tests**
+
+Unit test (`api/tests/unit/jobs/test_rabbitmq_drain.py`):
+- Mock consumer with a slow `process_message` (simulates 2s of work)
+- Start consumer, dispatch one message, immediately call `drain()`
+- Assert: drain blocks until message completes, ack is sent, no requeue
+- Second test: dispatch two messages, drain with deadline=0.1s, assert one survives the deadline and gets warned-but-killed cleanly (no crash)
+
+E2E (existing tests should keep passing — drain is a superset of current stop)
+
+**Risk**
+- The `await message.nack(requeue=True)` path in step 3 is rare (consumer cancel should be quick) but worth a unit test
+- DRAIN_DEADLINE should match `terminationGracePeriodSeconds` minus a buffer (e.g., 300s drain, 360s grace, 60s for cleanup)
+
+---
+
+### Workstream C — Client version banner + bundle-error reload
+
+**Files**
+- `client/src/lib/version.ts` (existing — read-only, just import)
+- `client/src/hooks/useVersionCheck.ts` (new)
+- `client/src/components/layout/VersionUpdateBanner.tsx` (new)
+- `client/src/main.tsx` (register `vite:preloadError` listener)
+- `client/src/App.tsx` (mount the banner)
+- `client/src/hooks/useVersionCheck.test.ts` (new)
+- `k8s/client/deployment.yaml`
+
+**Design**
+
+`/api/version` already exists (`api/src/routers/version.py:14`) and returns `{version, min_cli_version}`. The hook polls it, compares to `APP_VERSION`, and exposes a boolean.
+
+```ts
+// useVersionCheck.ts
+export function useVersionCheck(intervalMs = 60_000) {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const check = async () => {
+      if (document.visibilityState === "hidden") return;
+      try {
+        const res = await fetch("/api/version");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled && data.version !== APP_VERSION && APP_VERSION !== "unknown") {
+          setUpdateAvailable(true);
+        }
+      } catch { /* ignore network errors */ }
+    };
+
+    const schedule = () => {
+      timer = setTimeout(async () => {
+        await check();
+        if (!cancelled) schedule();
+      }, intervalMs);
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") void check();
+    };
+
+    void check();          // immediate fire on mount
+    schedule();
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [intervalMs]);
+
+  return updateAvailable;
+}
+```
+
+Banner component: non-dismissable toast at top of viewport, "A new version is available." + "Refresh" button → `window.location.reload()`. Use shadcn/ui primitives. Skip rendering when `APP_VERSION === "unknown"` (dev environment).
+
+**Bundle-error reload** (in `main.tsx`):
+
+```ts
+window.addEventListener("vite:preloadError", () => {
+  const lastReload = sessionStorage.getItem("bifrost:last-reload");
+  const now = Date.now();
+  if (lastReload && now - Number(lastReload) < 5_000) {
+    // already reloaded within 5s — don't loop, surface the banner instead
+    console.error("[bifrost] preload error after recent reload, suppressing");
+    return;
+  }
+  sessionStorage.setItem("bifrost:last-reload", String(now));
+  window.location.reload();
+});
+```
+
+**K8s** (`k8s/client/deployment.yaml`):
+- `replicas: 2`
+- `strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } }`
+
+**Tests**
+
+Vitest (`useVersionCheck.test.ts`):
+- Mock `fetch` to return matching version → `updateAvailable === false`
+- Mock `fetch` to return different version → `updateAvailable === true`
+- Mock `document.visibilityState = "hidden"` → no fetch fired
+- Test sessionStorage loop guard with `vi.useFakeTimers`
+
+Playwright optional: trigger banner manually by mocking `/api/version` response.
+
+**Risk**
+- `APP_VERSION` is "unknown" in dev (no `VITE_BIFROST_VERSION` set) — hook must skip the comparison or it'll banner constantly
+- Polling adds ~1 RPS for 50 active users — confirm with backend team that this is fine (it is)
+
+---
+
+### Workstream D — Client retry on 502/503/504
+
+**Files**
+- `client/src/lib/api-client.ts`
+- `client/src/lib/api-client.test.ts` (new or extend existing)
+
+**Design**
+
+Existing `apiClient` middleware already handles 401 (token refresh) and 429 (rate limit). Add a transient-5xx layer for idempotent methods.
+
+```ts
+const TRANSIENT_5XX = new Set([502, 503, 504]);
+const IDEMPOTENT = new Set(["GET", "PUT", "DELETE", "HEAD", "OPTIONS"]);
+const BACKOFF_MS = [250, 750, 2000];
+
+async function withRetryOn5xx(request: Request, doFetch: () => Promise<Response>): Promise<Response> {
+  if (!IDEMPOTENT.has(request.method)) return doFetch();
+
+  let lastResponse: Response | null = null;
+  for (let attempt = 0; attempt <= BACKOFF_MS.length; attempt++) {
+    const response = await doFetch();
+    if (!TRANSIENT_5XX.has(response.status)) return response;
+    lastResponse = response;
+    if (attempt < BACKOFF_MS.length) {
+      await new Promise(r => setTimeout(r, BACKOFF_MS[attempt]));
+    }
+  }
+  return lastResponse!;
+}
+```
+
+Wire into the existing middleware chain. Order matters: 5xx retry should be **outside** the 401-refresh wrapper (refresh on 401, then bubble up; transient 5xx wraps the whole thing).
+
+**Tests**
+- GET that returns 503 twice then 200 → succeeds, 3 fetches
+- POST that returns 503 → returns 503 immediately, 1 fetch (no retry)
+- GET that returns 503 four times → returns 503, 4 fetches (3 retries exhausted)
+- Retries don't apply to 401/429 (existing behavior preserved)
+
+**Risk**
+- A user clicking through quickly during a deploy could see compounded latency (up to 3s slower per failed request). Acceptable — the alternative is a visible error.
+
+---
+
+### Workstream E — SDK retry layer
+
+**Files**
+- Find the workflow SDK HTTP client. Likely candidates:
+  - `api/shared/sdk/` or `api/src/services/workflow_sdk/`
+  - Search for `httpx.AsyncClient` usage in workflow contexts
+
+**Design**
+
+Same shape as workstream D, different tuning:
+- Backoff: 500ms / 1.5s / 4s / 10s / 20s (~36s total budget)
+- Retry on 502/503/504 only
+- Idempotent methods only (GET/PUT/DELETE)
+- Use `httpx`'s built-in transport retry if available, else custom wrapper
+
+**Tests**
+- Unit tests with `respx` (httpx mock library) — same scenarios as D
+
+**Risk**
+- Workflow SDK calls can be in deeply nested code paths. The retry must be at the HTTP layer (transport), not per-call-site, so it's transparent to workflow authors.
+- If the API is down for >36s, workflows fail — this is correct, but the failure message should mention "API was unavailable across X retries" for diagnosis.
+
+**This workstream may be deferred to a follow-up PR if it grows.** It's the most exploratory of the five.
+
+---
+
+### Workstream F — Mirror to `../kubernetes` (live deployment)
+
+**Files**
+- `../kubernetes/components/bifrost/api/deployment.yaml`
+- `../kubernetes/components/bifrost/worker/deployment.yaml`
+- `../kubernetes/components/bifrost/client/deployment.yaml`
+- `../kubernetes/components/bifrost/scheduler/deployment.yaml` (touch only if needed — likely no-op)
+
+**Changes**
+
+Apply the same diffs from workstreams A, B, C — verbatim where possible. Notes:
+- The live `api/deployment.yaml` already has `replicas: 2`; just add the rollout strategy + preStop + graceful shutdown.
+- Confirm the live worker `terminationGracePeriodSeconds` doesn't conflict with anything (e.g., Cloudflare tunnel timeouts).
+- This is a separate repo — separate PR.
+
+**Order:** ship F **after** the in-tree manifest changes are merged and dev has been observed for at least one push-to-main rollout. Don't blast prod with untested manifests.
+
+---
+
+## Sequencing for the PR(s)
+
+**Single PR vs split:** A single PR for A + B + C + D in `bifrost`, then a follow-up PR (or commit on the same branch if quick) for E. F is its own PR in the `kubernetes` repo. This keeps the in-tree change reviewable in one pass while still letting F land separately when ready.
+
+**Commit-by-commit within the PR:**
+1. `feat(api): rolling-update strategy + uvicorn graceful shutdown` — workstream A
+2. `feat(client): version-check banner + preload-error reload` — workstream C
+3. `feat(client): retry transient 5xx on idempotent requests` — workstream D
+4. `feat(worker): graceful drain on SIGTERM` — workstream B
+5. `feat(sdk): retry transient 5xx on workflow API calls` — workstream E (or split)
+
+Each commit independently passes `pyright`, `ruff`, `tsc`, `lint`, `./test.sh all`, `./test.sh client unit`.
+
+## Verification (before opening PR)
+
+Per CLAUDE.md's pre-completion checklist, in the worktree:
+
+```bash
+./debug.sh status | grep -q "Status:   UP" || ./debug.sh
+cd api && pyright && ruff check .
+cd ../client && npm run generate:types && npm run tsc && npm run lint
+cd .. && ./test.sh stack up && ./test.sh all && ./test.sh client unit
+```
+
+Plus targeted manual verification:
+- Boot the debug stack, open the app, confirm the version banner doesn't fire (versions match locally)
+- `kubectl rollout restart deployment/bifrost-worker` against the dev cluster after merge → confirm no duplicate executions in `/diagnostics`
+
+## Open questions parked for review
+
+1. Should `useVersionCheck` poll interval be configurable per-env (e.g., 10s in dev, 60s in prod)? Default for now: hardcoded 60s, env-tunable later if needed.
+2. Should the SDK retry budget include `Retry-After` honoring? Probably yes for 503; out of scope if the API never sends it (verify in workstream E).
+3. Worker drain deadline (default 300s) — does this match the longest reasonable workflow? If workflows can run 30+ min, drain becomes useless and we need a different model (e.g., reject-and-requeue on shutdown). For now: assume <5min is the common case.

--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/component: api
     app.kubernetes.io/part-of: bifrost
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: bifrost-api
@@ -32,7 +37,11 @@ spec:
       containers:
         - name: api
           image: jackmusick/bifrost-api:latest
-          command: ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+          command: ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-graceful-shutdown", "30"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           ports:
             - containerPort: 8000
               name: http
@@ -58,12 +67,13 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+      terminationGracePeriodSeconds: 35
       # Run as non-root user (matches Dockerfile)
       securityContext:
         runAsUser: 1000

--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -37,7 +37,15 @@ spec:
       containers:
         - name: api
           image: jackmusick/bifrost-api:latest
-          command: ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--timeout-graceful-shutdown", "30"]
+          command:
+            - uvicorn
+            - src.main:app
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --timeout-graceful-shutdown
+            - "30"
           lifecycle:
             preStop:
               exec:
@@ -73,7 +81,8 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
-      terminationGracePeriodSeconds: 35
+      # Shutdown budget: preStop (5s) + uvicorn graceful shutdown (30s) + cleanup margin (5s)
+      terminationGracePeriodSeconds: 40
       # Run as non-root user (matches Dockerfile)
       securityContext:
         runAsUser: 1000

--- a/k8s/client/deployment.yaml
+++ b/k8s/client/deployment.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/component: client
     app.kubernetes.io/part-of: bifrost
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: bifrost-client
@@ -19,12 +24,18 @@ spec:
         app.kubernetes.io/component: client
         app.kubernetes.io/part-of: bifrost
     spec:
+      # Shutdown budget: preStop (5s) + nginx graceful (~30s default) + headroom
+      terminationGracePeriodSeconds: 35
       containers:
         - name: client
           image: jackmusick/bifrost-client:latest
           ports:
             - containerPort: 80
               name: http
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
           resources:
             requests:
               cpu: "50m"

--- a/k8s/worker/deployment.yaml
+++ b/k8s/worker/deployment.yaml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/part-of: bifrost
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: bifrost-worker
@@ -46,6 +51,12 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sleep", "5"]
+      # Drain budget: drain deadline (300s) + cleanup margin (60s)
+      terminationGracePeriodSeconds: 360
       # Run as non-root user (matches Dockerfile)
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION
## Summary

Fixes #171.

Five-workstream effort to make every push-to-main `:dev` rollout safe:

- **API rolling deploy** — `replicas: 2`, RollingUpdate `maxSurge: 1, maxUnavailable: 0`, `preStop sleep 5`, uvicorn `--timeout-graceful-shutdown 30`, readiness probe → `/health/ready` (real DB+Redis+RabbitMQ+S3 check).
- **Worker graceful drain** — `BaseConsumer`/`BroadcastConsumer` track in-flight tasks; new `drain()` cancels the consumer (stops new deliveries), awaits in-flight with 300s deadline (env-tunable), then closes the channel. Eliminates silent double-execution of workflows on every worker rollout. K8s `terminationGracePeriodSeconds: 360`.
- **Client version banner + preload-error reload** — `useVersionCheck` polls `/api/version` every 60s (paused while tab hidden), surfaces a "Refresh" banner on mismatch. Global `vite:preloadError` listener reloads on stale chunk imports with a 5s loop guard.
- **Client retry on 5xx** — 502/503/504 retry on idempotent methods (GET/PUT/DELETE/HEAD/OPTIONS), backoff 250/750/2000ms, wired into base middleware, `withUserContext`, and `authFetch`. POST/PATCH never auto-retry.
- **SDK retry on 5xx** — same shape but more generous (~36s budget: 0.5/1.5/4/10/20s) since workflow SDK calls are M2M.

Scheduler intentionally untouched (singleton, `Recreate` strategy, just enqueues).

## Out of scope (tracked separately)

- Mirroring manifest changes to `../kubernetes` live deploy repo (workstream F — separate PR after this lands).
- `init_container.py` advisory lock for concurrent alembic upgrades — latent issue surfaced by review, not a regression. Captured in `docs/plans/2026-05-01-deploy-resilience.md`.
- Process-pool heartbeat hook for `/diagnostics` drain visibility — explicit deferral.
- POST idempotency keys.

## Verification

- Backend: 3353/3353 unit tests passing (16 new — 8 worker drain + 8 SDK retry)
- Client: 797/797 vitest passing (15 new — 7 version-check hook + 2 banner + 3 preload-error handler + 8+2 api-client retry, of which 2 cover the openapi-fetch middleware path)
- pyright: 0 errors / ruff: clean / tsc: clean / lint: clean (1 pre-existing unrelated warning)
- E2E not run for this PR — no backend route changes, scope is plumbing
- See `docs/plans/2026-05-01-deploy-resilience.md` for the full design

## Commits

10 commits, each independently buildable/lintable:

```
b3581a85 feat(k8s): zero-downtime API rollout
8fb9b7c7 chore(k8s): tighten API rollout shutdown budget + readability
e53238db feat(client): version-update banner + preload-error auto-reload
cb5564c0 fix(client): version banner in layout flow, not fixed-position overlay
d4d5da7a feat(worker): graceful drain on SIGTERM
e0fac4f6 fix(worker): drain always closes channel; validate deadline env var
80a2cac4 feat(client): retry transient 5xx on idempotent requests
276c6ba6 feat(sdk): retry transient 5xx on idempotent SDK requests
9ecafd62 docs(plans): add deploy-resilience plan for issue #171
cd8cd4eb fix: address final-review feedback before merging deploy-resilience
```

## Test plan

- [ ] CI green
- [ ] Once merged, push lands a `:dev` image and triggers `kubectl rollout restart` — watch `kubectl get pods -n bifrost -w` and confirm rolling updates without service interruption
- [ ] Confirm zero duplicate workflow executions in the executions tab during the worker rollout
- [ ] Open the app in two tabs, push a new build, confirm one tab gets the version banner (other tab should auto-reload via `vite:preloadError` if it has a stale chunk in flight)
- [ ] After this lands and dev has been stable through one push-to-main rollout, mirror the manifest changes into `../kubernetes` (workstream F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)