### PR TITLE
fix(tables): backfill admin_bypass policy on existing tables

### DIFF
--- a/api/alembic/versions/20260504_backfill_table_access_admin_bypass.py
+++ b/api/alembic/versions/20260504_backfill_table_access_admin_bypass.py
@@ -1,0 +1,58 @@
+"""backfill admin_bypass policy on tables created before access JSONB existed
+
+Revision ID: 20260504_backfill_table_access
+Revises: 20260502_drop_table_app
+Create Date: 2026-05-04 00:00:00.000000
+
+The 20260429 migration added the `access` JSONB column as nullable, no default.
+Tables created before that migration ran kept `access = NULL`. The runtime
+policy loader treats NULL as an empty `TablePolicies` — which is default deny
+for everyone except platform admins... except we don't have admin bypass in
+the empty set either, so it's default deny full stop.
+
+Result: every table created before 2026-04-29 became unreadable for every
+non-superuser the moment the table-policies feature shipped.
+
+This migration backfills those rows with the same `admin_bypass`-only seed
+that `make_seed_admin_bypass()` produces for new tables, so the runtime
+behavior matches what the create handler does today.
+
+Idempotent: only touches `access IS NULL`. Re-running is a no-op.
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20260504_backfill_table_access"
+down_revision = "20260502_drop_table_app"
+branch_labels = None
+depends_on = None
+
+
+SEED_ADMIN_BYPASS = """
+{
+  "policies": [
+    {
+      "name": "admin_bypass",
+      "description": "Platform admins bypass all checks. Edit or delete to enforce stricter audit.",
+      "actions": ["read", "create", "update", "delete"],
+      "when": {"user": "is_platform_admin"}
+    }
+  ]
+}
+"""
+
+
+def upgrade() -> None:
+    op.execute(
+        f"UPDATE tables "
+        f"SET access = '{SEED_ADMIN_BYPASS.strip()}'::jsonb "
+        f"WHERE access IS NULL"
+    )
+
+
+def downgrade() -> None:
+    # Intentionally a no-op. We can't tell which rows were backfilled by this
+    # migration vs. legitimately set to the same seed by hand. Reverting blind
+    # would risk wiping a user's deliberate admin_bypass-only policy.
+    pass

--- a/api/tests/unit/test_admin_bypass_seed_migration.py
+++ b/api/tests/unit/test_admin_bypass_seed_migration.py
@@ -1,0 +1,81 @@
+"""Pin the seed JSON used by both the create handler and the backfill migration.
+
+`make_seed_admin_bypass()` is the runtime helper for new tables; the 2026-05-04
+backfill migration hard-codes the same shape into a SQL UPDATE. The two paths
+must produce identical TablePolicies. This test fails loudly if either side
+drifts.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from shared.policies.probe import make_seed_admin_bypass
+from src.models.contracts.policies import TablePolicies
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "20260504_backfill_table_access_admin_bypass.py"
+)
+
+
+def _extract_seed_from_migration() -> dict:
+    """Pull the SEED_ADMIN_BYPASS literal out of the migration file."""
+    src = MIGRATION_PATH.read_text()
+    marker = 'SEED_ADMIN_BYPASS = """'
+    start = src.index(marker) + len(marker)
+    end = src.index('"""', start)
+    return json.loads(src[start:end])
+
+
+def test_migration_seed_matches_runtime_helper():
+    migration_seed = _extract_seed_from_migration()
+    runtime_seed = make_seed_admin_bypass()
+    assert migration_seed == runtime_seed, (
+        "20260504_backfill_table_access drifted from make_seed_admin_bypass(). "
+        "Update one or the other so the migration backfills the same shape "
+        "the create handler writes for new tables."
+    )
+
+
+def test_migration_seed_validates_as_table_policies():
+    """The shape the migration writes must round-trip through Pydantic."""
+    migration_seed = _extract_seed_from_migration()
+    parsed = TablePolicies.model_validate(migration_seed)
+    assert len(parsed.policies) == 1
+    only = parsed.policies[0]
+    assert only.name == "admin_bypass"
+    assert set(only.actions) == {"read", "create", "update", "delete"}
+
+
+@pytest.mark.parametrize(
+    "user_attrs,expected",
+    [
+        ({"is_platform_admin": True}, True),
+        ({"is_platform_admin": False}, False),
+    ],
+)
+def test_migration_seed_admin_only_evaluation(user_attrs, expected):
+    """Behaviorally: the seed grants every action to admins, denies all others."""
+    from shared.policies.probe import evaluate_action
+
+    class StubUser:
+        def __init__(self, **kw):
+            self.user_id = "u1"
+            self.email = "x@example.com"
+            self.organization_id = None
+            self.is_platform_admin = False
+            self.role_ids = []
+            self.role_names = []
+            for k, v in kw.items():
+                setattr(self, k, v)
+
+    policies = TablePolicies.model_validate(_extract_seed_from_migration())
+    user = StubUser(**user_attrs)
+    for action in ("read", "create", "update", "delete"):
+        assert evaluate_action(action, policies, row={}, user=user) is expected, (
+            f"action={action!r} user={user_attrs} expected={expected}"
+        )


### PR DESCRIPTION
## Summary

PR #178 added the table-access policy system: tables get `access` JSONB containing a `TablePolicies` document, the runtime checks it on every read/write, default deny for any caller not matched by a rule. New tables seed `admin_bypass` automatically via `make_seed_admin_bypass()` in the create handler.

**The gap:** the `20260429_add_table_access` migration added the column as nullable with no default. Every table created before that migration ran kept `access = NULL`. The runtime `_load_policies` treats NULL as an empty `TablePolicies` — empty policy set is default deny full stop.

**Result:** every pre-existing table on prod became invisible to every non-superuser the moment #178 shipped (137 tables affected).

This PR adds the backfill migration. Pairs with the manual SQL fix already applied to prod.

## Changes

- `api/alembic/versions/20260504_backfill_table_access_admin_bypass.py` — UPDATE pre-existing `access IS NULL` rows to the same admin_bypass-only seed that `make_seed_admin_bypass()` produces for new tables.
  - Idempotent (touches only NULL rows).
  - Downgrade is intentionally a no-op — we can't distinguish backfilled rows from rows a user deliberately set to the same shape.
- `api/tests/unit/test_admin_bypass_seed_migration.py` — pin the migration's hard-coded JSON against `make_seed_admin_bypass()`. Drift between the two paths fails loudly. Plus a behavioral test confirming admin-only evaluation semantics.

## Behavior post-merge

- **Existing tables with `access = NULL`** → backfilled to `{"policies": [admin_bypass]}` on next deploy. Platform admins can read/write; everyone else default deny (same as the create-handler default for new tables).
- **Tables already given a custom policy** → untouched (`WHERE access IS NULL`).
- **Tables already at the seed via prod hotfix** → untouched (same reason).

If a user removes `admin_bypass` after the seed lands (legitimate use case for sensitive audit-only tables), the migration will not put it back on subsequent runs — alembic only runs upgrade once per revision.

## Why default seed only on create, not enforced on update

Discussed in conversation: the intent is `admin_bypass` as a default seed, not a forced invariant. New tables get it; existing tables get it backfilled; users may delete it later if they want strict audit. The server validator is unchanged — it accepts any structurally-valid `TablePolicies`, including ones without admin_bypass.

## Test plan

- [x] `./test.sh tests/unit/test_admin_bypass_seed_migration.py` (4 passed)
- [x] `./test.sh tests/unit/test_table_contract_policies.py tests/unit/test_policies_validate_endpoint.py` (22 passed)
- [x] `./test.sh tests/e2e/platform/test_tables.py` (27 passed)
- [x] `./test.sh stack reset` → alembic head reaches `20260504_backfill_table_access` cleanly
- [x] Full unit suite (3530 passed; 4 unrelated DNS flakes in `test_model_selection.py`)
- [ ] CI green
- [ ] Production: PR-merge → next deploy idempotently backfills any NULL rows added since the manual hotfix (none expected, but the safety check is the point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)