### PR TITLE
fix(plugin): use valid relative-path source in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "bifrost",
-      "source": ".",
+      "source": "./",
       "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI.",
       "category": "automation",
       "tags": ["msp", "automation", "workflows", "bifrost", "psa"]


### PR DESCRIPTION
## Summary
- The `source: "."` value in `.claude-plugin/marketplace.json` is not a recognized Claude Code source type
- Users hit `Failed to install: This plugin uses a source type your Claude Code version does not support` when running `/plugin install bifrost@bifrost`
- Relative paths in marketplace.json must start with `./` per the [official docs](https://code.claude.com/docs/en/plugin-marketplaces)

## Test plan
- [ ] After merge, run `/plugin marketplace update bifrost` locally
- [ ] Run `/plugin install bifrost@bifrost` and confirm no source-type error
- [ ] Confirm `bifrost:build` and `bifrost:setup` skills load

🤖 Generated with [Claude Code](https://claude.com/claude-code)