### PR TITLE
ci: add --durations=50 to e2e for slowest-test profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           chmod +x test.sh
           ./test.sh stack up
-          ./test.sh e2e
+          ./test.sh e2e --durations=50
 
   # =============================================================================
   # Dev Build - Every push to main, gated by unit tests only


### PR DESCRIPTION
## Summary
- Adds `--durations=50` to the E2E pytest invocation in CI so we can identify which tests dominate the 7m 26s serial e2e run.
- Measurement-only — will be reverted or superseded once we have data to decide whether sharding would balance well.
- Reversible by deleting one line.

## Test plan
- [ ] CI E2E job completes successfully and emits the `slowest 50 durations` table at the end of pytest output.

Generated with Claude Code.