### PR TITLE
ci: cache dev image builds via GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,37 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # Pre-build the dev images via build-push-action so we get GHA layer
+      # caching. docker-compose.test.yml pins both images to fixed tags
+      # (bifrost-test-api-dev / bifrost-test-client-dev) and test.sh respects
+      # BIFROST_SKIP_BUILD=1 so compose reuses the local images instead of
+      # rebuilding (which would skip the GHA cache).
+      #
+      # Cache is shared with test-e2e via the same scope so the second job to
+      # run gets warm hits from the first, even on cold-cache PRs.
+      - name: Build API dev image (cached)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./api/Dockerfile.dev
+          load: true
+          tags: bifrost-test-api-dev:latest
+          cache-from: type=gha,scope=test-api-dev
+          cache-to: type=gha,scope=test-api-dev,mode=max
+
+      - name: Build client dev image (cached)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./client
+          file: ./client/Dockerfile.dev
+          load: true
+          tags: bifrost-test-client-dev:latest
+          cache-from: type=gha,scope=test-client-dev
+          cache-to: type=gha,scope=test-client-dev,mode=max
+
       - name: Run unit tests
+        env:
+          BIFROST_SKIP_BUILD: "1"
         run: |
           chmod +x test.sh
           ./test.sh stack up
@@ -153,7 +183,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      # See test-unit for caching strategy notes.
+      - name: Build API dev image (cached)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./api/Dockerfile.dev
+          load: true
+          tags: bifrost-test-api-dev:latest
+          cache-from: type=gha,scope=test-api-dev
+          cache-to: type=gha,scope=test-api-dev,mode=max
+
+      - name: Build client dev image (cached)
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./client
+          file: ./client/Dockerfile.dev
+          load: true
+          tags: bifrost-test-client-dev:latest
+          cache-from: type=gha,scope=test-client-dev
+          cache-to: type=gha,scope=test-client-dev,mode=max
+
       - name: Run E2E tests
+        env:
+          BIFROST_SKIP_BUILD: "1"
         run: |
           chmod +x test.sh
           ./test.sh stack up

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           chmod +x test.sh
           ./test.sh stack up
-          ./test.sh e2e
+          ./test.sh e2e --durations=50
 
   # =============================================================================
   # Dev Build - Every push to main, gated by unit tests only

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -123,6 +123,7 @@ services:
 
   # Init Container (Test) - Runs migrations and warms module cache before API/workers start
   init:
+    image: bifrost-test-api-dev:latest
     build:
       context: .
       dockerfile: api/Dockerfile.dev
@@ -147,6 +148,7 @@ services:
 
   # FastAPI Application (Test) - Only started for E2E tests
   api:
+    image: bifrost-test-api-dev:latest
     build:
       context: .
       dockerfile: api/Dockerfile.dev
@@ -201,6 +203,7 @@ services:
   # Note: Discovery service has been removed - workflow/form extraction
   # now happens at write time in FileStorageService
   worker:
+    image: bifrost-test-api-dev:latest
     build:
       context: .
       dockerfile: api/Dockerfile.dev
@@ -247,6 +250,7 @@ services:
   # Scheduler (Test) - Only started for E2E tests
   # Handles background jobs like GitHub sync via Redis pubsub
   scheduler:
+    image: bifrost-test-api-dev:latest
     build:
       context: .
       dockerfile: api/Dockerfile.dev
@@ -293,6 +297,7 @@ services:
 
   # Test Runner - Executes pytest inside container with all dependencies
   test-runner:
+    image: bifrost-test-api-dev:latest
     build:
       context: .
       dockerfile: api/Dockerfile.dev
@@ -377,6 +382,7 @@ services:
   # Client frontend (Vite dev server)
   # Serves the React app for Playwright browser tests
   client:
+    image: bifrost-test-client-dev:latest
     build:
       context: ./client
       dockerfile: Dockerfile.dev

--- a/test.sh
+++ b/test.sh
@@ -143,6 +143,18 @@ stack_up() {
         exit 1
     fi
 
+    # CI pre-builds the dev images via docker/build-push-action with GHA cache
+    # and tags them as bifrost-test-api-dev:latest / bifrost-test-client-dev:latest
+    # before calling stack up. Setting BIFROST_SKIP_BUILD=1 tells compose to
+    # use those local images directly instead of building. Local dev leaves
+    # this unset so `--build` continues to apply (image layer cache makes the
+    # rebuilds fast after the first one).
+    local build_flag="--build"
+    if [ "${BIFROST_SKIP_BUILD:-0}" = "1" ]; then
+        build_flag="--no-build"
+        echo "BIFROST_SKIP_BUILD=1 — using pre-built images from local docker."
+    fi
+
     echo "Booting infrastructure..."
     docker compose -f "$COMPOSE_FILE" up -d postgres rabbitmq redis minio
 
@@ -157,12 +169,12 @@ stack_up() {
     "$SCRIPT_DIR/scripts/stack_template_init.sh"
 
     echo "Starting API + Worker + Scheduler..."
-    docker compose -f "$COMPOSE_FILE" --profile e2e up -d --build
+    docker compose -f "$COMPOSE_FILE" --profile e2e up -d "$build_flag"
     echo "Waiting for API to be serving traffic on /health/ready..."
     wait_for_api_ready "$COMPOSE_FILE"
 
     echo "Starting client..."
-    docker compose -f "$COMPOSE_FILE" --profile client up -d --build client
+    docker compose -f "$COMPOSE_FILE" --profile client up -d "$build_flag" client
     echo "Waiting for client to be healthy..."
     for i in {1..120}; do
         cid=$(docker compose -f "$COMPOSE_FILE" ps -q client 2>/dev/null)


### PR DESCRIPTION
## Summary

Pre-build the test stack's dev images (`api/Dockerfile.dev` and `client/Dockerfile.dev`) via `docker/build-push-action` with `cache-from/cache-to: type=gha`, then have `docker compose` reuse the local images instead of rebuilding. Today every CI run pays the full pip install + npm ci cost (~2m for the api image, ~1.5m for the client image).

## Approach (Option A — explicit pre-build)

1. **`docker-compose.test.yml`** — pin the api-stack services (`init`, `api`, `worker`, `scheduler`, `test-runner`) to a single shared `image: bifrost-test-api-dev:latest`, and the `client` service to `bifrost-test-client-dev:latest`. Without this, compose generates a per-service image name (`<project>-api`, `<project>-init`, `<project>-test-runner`, ...) and would build the same Dockerfile up to 5 times.
2. **`test.sh`** — `BIFROST_SKIP_BUILD=1` swaps `--build` for `--no-build` on the `compose up` calls in `stack_up`. Local dev leaves the env var unset and continues to build via `--build`.
3. **`.github/workflows/ci.yml`** — both `test-unit` and `test-e2e` get two new pre-build steps (api dev image, client dev image) using `docker/build-push-action@v7` with `cache-from/cache-to: type=gha,scope=test-{api,client}-dev,mode=max` and `load: true` (loads into local docker so compose can find it). Cache scope is shared between the two jobs so the second one to land in CI benefits from layers the first one populated.

## Why Option A vs B (`buildx bake`) / C (`COMPOSE_BAKE=true`)

- **Most explicit** — each cache hit/miss is visible in its own step in the GHA UI; debuggable.
- **Reuses the same `build-push-action` machinery** the existing `build-dev` / `build-api` / `build-client` jobs already use; one mental model for cache.
- **Decouples API and client cache scopes** — they have very different invalidation profiles (Python deps churn slower than npm).

## Measured results — E2E job

Baseline (from main run `25326844926`, job `74249809927`): **13m 11s** total.

| Phase | Baseline | Cold cache (this PR, attempt 1) | Warm cache (this PR, attempt 2) |
|---|---|---|---|
| Set up job + checkout + buildx | ~22s | 6s | 6s |
| Build API dev image (cached) | — | **2m 33s** | **40s** |
| Build client dev image (cached) | — | **1m 11s** | **37s** |
| Boot infrastructure | 24s | 20s | 19s |
| Build template DB (init image) | **2m 29s** | 6s | 6s |
| Start API + worker + scheduler | 18s | 17s | 17s |
| Start client | **1m 27s** | 13s | 13s |
| First reset_state | 16s | 24s | 22s |
| Pytest startup | 8s | 8s | 8s |
| Pytest run (e2e) | 7m 26s | (cancelled¹) | 8m 50s |
| Post + complete | ~5s | — | 7s |
| **Total job** | **13m 11s** | (cancelled¹ at 11m 04s in pytest) | **11m 52s** |

¹ Attempt 1's E2E job got cancelled mid-pytest at ~72% test progress with `##[error]The operation was canceled` and no `cancel_requested_at` in the GitHub API. No newer commit to the branch, no concurrency rule that would cause this. The Unit Tests job from the same attempt completed successfully (7m 59s vs baseline 7m 32s — small regression because it now also pre-builds the client image which it doesn't strictly need; could be optimized away later). I reran the E2E job to get the warm-cache reading, which is the data shown above.

## Net savings (warm cache)

- **Build steps**: cold cache 3m 44s → warm cache 1m 17s = **2m 27s saved on builds alone**
- **Inner stack boot**: collapses to 19s + 6s + 17s + 13s + 22s = ~1m 17s, vs baseline 24s + 2m 29s + 18s + 1m 27s + 16s = ~4m 54s = **3m 37s saved**
- **Total E2E job warm-cache: 11m 52s** vs baseline 13m 11s = **1m 19s end-to-end savings** (would be more without the ~1m 24s pytest regression that's likely test-order noise)
- **Cache builds the dedicated cache layers up front**; the actual stack boot afterwards no longer rebuilds anything regardless of cache state, because `--no-build` is applied. So even cold-cache runs get the inner stack-boot speedup (~3m 37s saved on inner stack boot).
- **Cold cache total** ≈ baseline (with savings on inner boot offset by extra time spent populating the cache layers and pushing them to GHA)

## Gotchas

- **Per-service `image:` tags were necessary** — without them compose generates a unique image name per service from `COMPOSE_PROJECT_NAME`, so even with build cache active the same Dockerfile gets re-tagged 5 times. Sharing one tag across `init`/`api`/`worker`/`scheduler`/`test-runner` means compose only builds once.
- **`stack_template_init.sh` does `docker compose run --rm init`** which would build the image if it weren't already present. The pre-build step in CI must run before `./test.sh stack up`, and `BIFROST_SKIP_BUILD=1` doesn't affect this (compose `run` will use the local image silently when present).
- **Cold cache attempt 1's E2E got cancelled** — unclear cause, no concurrency rule. The rerun (warm cache) succeeded cleanly. Worth keeping an eye on if this reproduces.

## Test plan

- [x] Cold-cache CI run E2E job: build steps populated cache (~2m 33s + 1m 11s); inner stack boot already faster than baseline (init/client builds collapsed)
- [x] Warm-cache CI run E2E job: completes successfully in 11m 52s, build steps drop to 40s + 37s
- [ ] Local `./test.sh stack up` still works (no `BIFROST_SKIP_BUILD` set → `--build` flag preserved); not yet smoke-tested locally for this PR but the change is a one-line `if`-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)