### PR TITLE
fix(client): use jsDelivr for es-module-shims (JSPM 404s on floating tag)

### DIFF
--- a/client/src/components/jsx-app/BundledAppShell.tsx
+++ b/client/src/components/jsx-app/BundledAppShell.tsx
@@ -32,7 +32,9 @@ import {
 import { useAppBuilderStore } from "@/stores/app-builder.store";
 import { AppLoadingSkeleton } from "./AppLoadingSkeleton";
 
-const ESM_SHIMS_URL = "https://ga.jspm.io/npm:es-module-shims@2/dist/es-module-shims.js";
+// jsDelivr — JSPM's CDN 404s on floating tags (`@2`), only exact versions
+// resolve. Pinned to an exact version for reproducible loads.
+const ESM_SHIMS_URL = "https://cdn.jsdelivr.net/npm/es-module-shims@2.8.0/dist/es-module-shims.js";
 // Force esm.sh to leave React/Router as bare specifiers in its own response so
 // they resolve back through our static import map to the host's copies. Same
 // instance everywhere -> no "two Reacts" hooks failure when a user dep calls


### PR DESCRIPTION
## Summary
- `https://ga.jspm.io/npm:es-module-shims@2/dist/es-module-shims.js` returns **HTTP 404** — JSPM's CDN doesn't resolve floating-tag specifiers, only exact versions.
- Every app with user-declared deps (the `hasUserDeps` branch added in #175) failed to load with `Failed to load es-module-shims from ...`.
- Switched to jsDelivr — the CDN the es-module-shims docs themselves use — pinned to `2.8.0` for reproducible loads.

## Test plan
- [x] `npm run tsc` clean
- [x] `eslint` clean on changed file
- [ ] In Firefox, open a Bifrost app with at least one user-declared dependency and confirm the bundle loads without the prior error
- [ ] In Chrome, confirm apps with no user deps still take the native-import path (no shim fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)