### PR TITLE
Fix AMQP errors during deploys (rabbitmq probe + publish retry)

### DIFF
--- a/api/src/jobs/rabbitmq.py
+++ b/api/src/jobs/rabbitmq.py
@@ -637,41 +637,53 @@ async def consume_from_exchange(
         await connection_ctx.__aexit__(None, None, None)
 
 
-async def publish_message(
+_PUBLISH_RETRY_DELAYS_S = (0.1, 0.3, 1.0)
+
+# Connection/channel drops worth retrying (rabbitmq pod briefly out of the
+# Service endpoints, broker restarting, etc.).
+_PUBLISH_TRANSIENT_ERRORS: tuple[type[BaseException], ...] = (
+    aio_pika.exceptions.AMQPConnectionError,
+    aio_pika.exceptions.ChannelClosed,
+)
+
+# Subclasses of AMQPConnectionError that are NOT transient — auth/protocol
+# failures will not get better with retry, so propagate immediately.
+_PUBLISH_FATAL_ERRORS: tuple[type[BaseException], ...] = (
+    aio_pika.exceptions.AuthenticationError,
+    aio_pika.exceptions.ProbableAuthenticationError,
+    aio_pika.exceptions.IncompatibleProtocolError,
+    aio_pika.exceptions.ProtocolSyntaxError,
+)
+
+
+def _is_transient_publish_error(exc: BaseException) -> bool:
+    if isinstance(exc, _PUBLISH_FATAL_ERRORS):
+        return False
+    return isinstance(exc, _PUBLISH_TRANSIENT_ERRORS)
+
+
+async def _publish_once(
     queue_name: str,
     message: dict[str, Any],
-    priority: int = 0,
+    priority: int,
 ) -> None:
-    """
-    Publish a message to a queue.
-
-    Args:
-        queue_name: Target queue name
-        message: Message body (will be JSON encoded)
-        priority: Message priority (0-9, higher = more important)
-    """
-    await rabbitmq.init_pools()
     async with rabbitmq.get_connection() as connection:
         channel = await connection.channel()
-
         try:
             dead_letter_exchange = f"{queue_name}-dlx"
 
-            # Declare dead letter exchange
             await channel.declare_exchange(
                 dead_letter_exchange,
                 aio_pika.ExchangeType.DIRECT,
                 durable=True,
             )
 
-            # Declare dead letter queue
             dlq = await channel.declare_queue(
                 f"{queue_name}-poison",
                 durable=True,
             )
             await dlq.bind(dead_letter_exchange, routing_key=queue_name)
 
-            # Declare main queue with dead letter routing (matches consumer)
             await channel.declare_queue(
                 queue_name,
                 durable=True,
@@ -681,7 +693,6 @@ async def publish_message(
                 },
             )
 
-            # Publish message
             await channel.default_exchange.publish(
                 aio_pika.Message(
                     body=json.dumps(message).encode(),
@@ -692,6 +703,48 @@ async def publish_message(
             )
 
             logger.debug(f"Published message to {queue_name}")
-
         finally:
             await channel.close()
+
+
+async def publish_message(
+    queue_name: str,
+    message: dict[str, Any],
+    priority: int = 0,
+) -> None:
+    """
+    Publish a message to a queue.
+
+    Retries on transient broker errors (connection drops, channel close) so a
+    brief readiness flap on the rabbitmq pod doesn't surface as a workflow
+    failure. Real failures (auth, malformed message, broker rejecting the
+    publish) are not retried and propagate immediately.
+
+    Args:
+        queue_name: Target queue name
+        message: Message body (will be JSON encoded)
+        priority: Message priority (0-9, higher = more important)
+    """
+    await rabbitmq.init_pools()
+    last_exc: BaseException | None = None
+    for attempt, delay in enumerate((*_PUBLISH_RETRY_DELAYS_S, None)):
+        try:
+            await _publish_once(queue_name, message, priority)
+            return
+        except Exception as exc:
+            if not _is_transient_publish_error(exc):
+                raise
+            last_exc = exc
+            if delay is None:
+                break
+            logger.warning(
+                "Transient AMQP error publishing to %s (attempt %d/%d, sleeping %.2fs): %s",
+                queue_name,
+                attempt + 1,
+                len(_PUBLISH_RETRY_DELAYS_S) + 1,
+                delay,
+                type(exc).__name__,
+            )
+            await asyncio.sleep(delay)
+    assert last_exc is not None
+    raise last_exc

--- a/api/tests/unit/jobs/test_publish_message_retry.py
+++ b/api/tests/unit/jobs/test_publish_message_retry.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for publish_message retry on transient broker errors.
+
+Covers the readiness-flap scenario: when the rabbitmq Service endpoint
+briefly drops (probe timeout), publish_message must retry on connection /
+channel close errors before surfacing the failure to the caller. Real
+errors (auth, malformed) propagate without retry.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import aio_pika.exceptions
+import pytest
+
+from src.jobs import rabbitmq as rabbitmq_module
+from src.jobs.rabbitmq import publish_message
+
+
+@pytest.fixture(autouse=True)
+def _zero_backoff(monkeypatch):
+    """Skip real sleeps so tests run instantly."""
+    monkeypatch.setattr(rabbitmq_module, "_PUBLISH_RETRY_DELAYS_S", (0.0, 0.0, 0.0))
+
+
+@pytest.fixture(autouse=True)
+def _stub_init_pools():
+    """publish_message calls rabbitmq.init_pools(); stub it out."""
+    with patch.object(rabbitmq_module.rabbitmq, "init_pools", AsyncMock(return_value=None)):
+        yield
+
+
+class TestPublishMessageRetry:
+    @pytest.mark.asyncio
+    async def test_succeeds_first_try(self):
+        with patch.object(
+            rabbitmq_module, "_publish_once", AsyncMock(return_value=None)
+        ) as mock_publish:
+            await publish_message("q", {"k": "v"})
+        assert mock_publish.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_recovers_from_connection_drop(self):
+        attempts = AsyncMock(
+            side_effect=[
+                aio_pika.exceptions.AMQPConnectionError("boom"),
+                None,
+            ]
+        )
+        with patch.object(rabbitmq_module, "_publish_once", attempts):
+            await publish_message("q", {"k": "v"})
+        assert attempts.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_recovers_from_channel_close(self):
+        attempts = AsyncMock(
+            side_effect=[
+                aio_pika.exceptions.ChannelClosed(0, "transient"),
+                None,
+            ]
+        )
+        with patch.object(rabbitmq_module, "_publish_once", attempts):
+            await publish_message("q", {"k": "v"})
+        assert attempts.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries_then_raises(self):
+        # 4 attempts total: initial + 3 retries; all fail.
+        err = aio_pika.exceptions.ConnectionClosed(0, "still down")
+        attempts = AsyncMock(side_effect=[err] * 4)
+        with patch.object(rabbitmq_module, "_publish_once", attempts):
+            with pytest.raises(aio_pika.exceptions.ConnectionClosed):
+                await publish_message("q", {"k": "v"})
+        assert attempts.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_non_transient(self):
+        err = aio_pika.exceptions.AuthenticationError("bad creds")
+        attempts = AsyncMock(side_effect=err)
+        with patch.object(rabbitmq_module, "_publish_once", attempts):
+            with pytest.raises(aio_pika.exceptions.AuthenticationError):
+                await publish_message("q", {"k": "v"})
+        assert attempts.await_count == 1

--- a/k8s/kustomization.yml
+++ b/k8s/kustomization.yml
@@ -9,6 +9,5 @@ resources:
   - client/service.yaml
   - worker/deployment.yaml
   - scheduler/deployment.yaml
-  - coding-agent/deployment.yaml
   - rabbitmq/deployment.yaml
   - rabbitmq/service.yaml

--- a/k8s/rabbitmq/deployment.yaml
+++ b/k8s/rabbitmq/deployment.yaml
@@ -44,22 +44,22 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+          # TCP probes on the AMQP port. "Can a client connect to 5672" is
+          # what consumers actually need; rabbitmq-diagnostics check_running
+          # measured ~1s at idle and routinely exceeded the 5s readiness
+          # timeout under load, flapping the pod out of the Service.
           livenessProbe:
-            exec:
-              command:
-                - rabbitmq-diagnostics
-                - check_running
+            tcpSocket:
+              port: amqp
             initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 10
+            timeoutSeconds: 5
           readinessProbe:
-            exec:
-              command:
-                - rabbitmq-diagnostics
-                - check_running
+            tcpSocket:
+              port: amqp
             initialDelaySeconds: 10
             periodSeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 3
           volumeMounts:
             - name: rabbitmq-data
               mountPath: /var/lib/rabbitmq


### PR DESCRIPTION
## Summary

Closes #193.

Three commits, smallest blast radius first:

1. **fix(api): retry publish_message on transient AMQP errors** — wraps the API publish path in a 4-attempt retry (initial + 100/300/1000ms backoff) on `AMQPConnectionError` / `ChannelClosed`. Auth, protocol, and delivery errors propagate immediately. Includes 5 unit tests covering happy path, recovery, exhaustion, and the auth-not-retried case.

2. **fix(k8s): switch rabbitmq probes to TCP on 5672** — the exec probes (`rabbitmq-diagnostics check_running`) measured ~1s at idle and routinely exceeded the 5s readiness timeout under load; tcpSocket on the AMQP port is both cheaper and more directly aligned with what AMQP clients need.

3. **chore(k8s): drop stale `coding-agent` reference from `kustomization.yml`** — `k8s/coding-agent/deployment.yaml` was deleted in `4829fca8`; the kustomization still listed it.

## Why this matters

Cluster snapshot from today's investigation:
- 779 readiness-probe-failed events on rabbitmq in 13 days
- 0 liveness failures, 0 pod restarts, no new ReplicaSet revisions since 2026-04-02
- Pod healthy throughout — only the Service endpoint was flapping
- Of the broker's 388m steady-state CPU, ~78m was the probe itself (1s × 12 probes/min)

(1) hides flaps from users today. (2) eliminates the flap underneath. (3) is one-line cleanup.

## Test plan

- [x] `./test.sh unit` — 3637 passed (2:25)
- [x] `./test.sh tests/e2e/api/test_workflow_scheduled_execution.py tests/e2e/api/test_backfill_summaries.py` — 21 passed
- [x] `./test.sh tests/unit/jobs/test_publish_message_retry.py` — 5 passed
- [x] `cd api && ruff check .` — clean
- [x] `cd api && pyright src/jobs/rabbitmq.py tests/unit/jobs/test_publish_message_retry.py` — 0 type errors (only env-related missing-import noise)
- [x] `kubectl kustomize k8s/` — emits 10 resources, zero coding-agent
- [ ] CI: full e2e + lint + analyze on PR

## Out of scope

- Switching rabbitmq's `emptyDir` to a PVC. Today's investigation found it's not actually being lost (no pod restarts in 33 days), so no behavior change today; worth doing as separate housekeeping.
- Resource-limit drift: live cluster has `1 CPU / 1Gi`; manifest in repo has `500m / 512Mi`. Out of scope here, but flag for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)