### PR TITLE
fix(embeddings): batch resilience, accurate reindex status, DB-grounded save gate

### DIFF
--- a/api/src/routers/llm_config.py
+++ b/api/src/routers/llm_config.py
@@ -390,7 +390,9 @@ async def set_embedding_config(
     from src.models.orm import SystemConfig
     from src.services.embeddings.base import EmbeddingConfig as EmbeddingClientConfig
     from src.services.embeddings.openai_client import OpenAIEmbeddingClient
-    from src.services.embeddings.reindex import count_knowledge_rows
+    from src.services.embeddings.reindex import (
+        count_knowledge_rows_at_other_dims,
+    )
     from src.services.notification_service import get_notification_service
 
     settings = get_settings()
@@ -488,30 +490,31 @@ async def set_embedding_config(
     # to old rows when dims differ, and even at matching dims the two models
     # live in different vector spaces (similarity scores are noise).
     #
-    # Reindex policy:
-    #   - dim matches saved dim → skip reindex (deliberate trade-off; the
-    #     "Reindex knowledge store" button is right there if the user wants it).
-    #   - dim differs AND rows > 0 → require confirm_reindex=true; otherwise
-    #     return needs_reindex_confirmation and don't persist.
+    # Reindex policy: ground the prompt in *DB state*, not config diff.
+    # If the table has any row at a dim other than the new one — whether
+    # left over from a previous failed reindex, a never-completed migration,
+    # or a config that was saved without recording its dim — fire the
+    # confirmation. The previous config-vs-config diff missed the resave
+    # case (issue #198): same config saved twice with stale rows still in
+    # the table never prompted.
     old_dim: int | None = None
     old_model: str | None = None
     if existing and existing.value_json:
         old_dim = existing.value_json.get("dimensions")
         old_model = existing.value_json.get("model")
 
-    dim_changed = old_dim is not None and old_dim != dimensions
-    if dim_changed and not request.confirm_reindex:
-        row_count = await count_knowledge_rows()
-        if row_count > 0:
+    if not request.confirm_reindex:
+        stale_count = await count_knowledge_rows_at_other_dims(dimensions)
+        if stale_count > 0:
             return EmbeddingConfigSaveResponse(
                 saved=False,
                 needs_reindex_confirmation=True,
-                reason="dim_change",
+                reason="stale_rows",
                 old_dim=old_dim,
                 new_dim=dimensions,
                 old_model=old_model,
                 new_model=request.model,
-                row_count=row_count,
+                row_count=stale_count,
             )
 
     config_data: dict[str, object] = {
@@ -553,10 +556,12 @@ async def set_embedding_config(
         uses_llm_key=False,
     )
 
-    # Trigger reindex when the user confirmed a dim change.
+    # Trigger reindex when the user clicked through the confirmation dialog.
+    # The gate above already verified there are stale rows at non-`dimensions`
+    # dims; re-check here so we don't fire a notification for a clean DB.
     notification_id: str | None = None
-    if dim_changed and request.confirm_reindex:
-        row_count = await count_knowledge_rows()
+    if request.confirm_reindex:
+        row_count = await count_knowledge_rows_at_other_dims(dimensions)
         if row_count > 0:
             notif_service = get_notification_service()
             notification = await notif_service.create_notification(

--- a/api/src/services/embeddings/openai_client.py
+++ b/api/src/services/embeddings/openai_client.py
@@ -14,6 +14,30 @@ from src.services.embeddings.base import BaseEmbeddingClient, EmbeddingConfig
 logger = logging.getLogger(__name__)
 
 
+class EmptyEmbeddingResponseError(Exception):
+    """
+    Raised when the upstream embeddings endpoint returns 200 with an
+    unusable body (data missing, None, or empty).
+
+    OpenAI-compatible providers like OpenRouter sometimes return a 200 with
+    no `data` field for over-cap batches, token-cap hits, or soft-throttled
+    requests. The OpenAI SDK silently parses these into a response where
+    `data is None`, which then crashes downstream consumers with a generic
+    NoneType error. Surface a typed error with provider/model/batch context
+    so logs say *what* failed.
+    """
+
+    def __init__(self, *, model: str, endpoint: str | None, batch_size: int):
+        self.model = model
+        self.endpoint = endpoint
+        self.batch_size = batch_size
+        super().__init__(
+            f"Embeddings endpoint returned no data "
+            f"(model={model!r}, endpoint={endpoint or 'default'!r}, "
+            f"batch_size={batch_size})"
+        )
+
+
 class OpenAIEmbeddingClient(BaseEmbeddingClient):
     """
     OpenAI embedding client.
@@ -30,14 +54,19 @@ class OpenAIEmbeddingClient(BaseEmbeddingClient):
         """
         Generate embeddings for a list of texts.
 
-        Uses OpenAI's batch embedding endpoint for efficiency.
-        Maximum batch size is 2048 texts.
+        Uses OpenAI's batch embedding endpoint for efficiency. On an empty
+        200 response (see ``EmptyEmbeddingResponseError``), recursively
+        halve the batch and retry — some OpenAI-compatible providers
+        (OpenRouter pass-through) silently 200 with no data when the input
+        array exceeds an undocumented per-request cap. Halving down to N=1
+        recovers the working slice of the batch; if N=1 still fails the
+        error propagates so the caller can fail loudly.
 
         Args:
             texts: List of text strings to embed
 
         Returns:
-            List of embedding vectors
+            List of embedding vectors, in the same order as ``texts``.
         """
         if not texts:
             return []
@@ -59,14 +88,31 @@ class OpenAIEmbeddingClient(BaseEmbeddingClient):
                 model=self.config.model,
                 encoding_format="float",
             )
-
-            # Sort by index to ensure order matches input
-            sorted_data = sorted(response.data, key=lambda x: x.index)
-            return [item.embedding for item in sorted_data]
-
         except Exception as e:
             logger.error(f"Failed to generate embeddings: {e}")
             raise
+
+        if not response.data:
+            # Empty 200 — typically a provider-side per-request cap. Halve
+            # and retry; bottom out at N=1 with a typed error.
+            if len(texts) == 1:
+                raise EmptyEmbeddingResponseError(
+                    model=self.config.model,
+                    endpoint=self.config.endpoint,
+                    batch_size=1,
+                )
+            mid = len(texts) // 2
+            logger.warning(
+                f"Empty 200 from embeddings endpoint at batch_size={len(texts)}; "
+                f"splitting into {mid} + {len(texts) - mid} and retrying"
+            )
+            left = await self.embed(texts[:mid])
+            right = await self.embed(texts[mid:])
+            return left + right
+
+        # Sort by index to ensure order matches input
+        sorted_data = sorted(response.data, key=lambda x: x.index)
+        return [item.embedding for item in sorted_data]
 
     async def embed_single(self, text: str) -> list[float]:
         """

--- a/api/src/services/embeddings/reindex.py
+++ b/api/src/services/embeddings/reindex.py
@@ -94,6 +94,7 @@ async def run_reindex(notification_id: str) -> None:
     processed = 0
     total = 0
     failed_batches = 0
+    total_batches = 0
 
     try:
         async with get_db_context() as db:
@@ -128,6 +129,8 @@ async def run_reindex(notification_id: str) -> None:
 
             client = await get_embedding_client(db)
 
+            total_batches = (total + EMBED_BATCH_SIZE - 1) // EMBED_BATCH_SIZE
+
             # Embedding API calls happen in batches (round-trip efficiency).
             # Progress notifications fire per-row so the UI sees real-time motion.
             # Cancellation is checked between embed-batches.
@@ -145,6 +148,7 @@ async def run_reindex(notification_id: str) -> None:
                                 "processed": processed,
                                 "total": total,
                                 "failed_batches": failed_batches,
+                                "total_batches": total_batches,
                                 "cancelled": True,
                             },
                         ),
@@ -174,7 +178,10 @@ async def run_reindex(notification_id: str) -> None:
                         f"failed: {e}"
                     )
                     # Skip the batch; the rows keep their old embeddings.
-                    processed += len(batch_rows)
+                    # Do NOT bump `processed` — that counter reflects rows
+                    # whose embedding was actually rewritten. Bumping it on
+                    # failure produced the "Reindexed N/N" lie that hid the
+                    # original incident (issue #198).
                     await _push_progress(
                         notif_service, notification_id, processed, total
                     )
@@ -195,26 +202,50 @@ async def run_reindex(notification_id: str) -> None:
                         notif_service, notification_id, processed, total
                     )
 
-            await notif_service.update_notification(
-                notification_id,
-                NotificationUpdate(
-                    status=NotificationStatus.COMPLETED,
-                    description=(
-                        f"Reindexed {processed}/{total} rows."
-                        + (
-                            f" ({failed_batches} batches failed and were skipped.)"
-                            if failed_batches
-                            else ""
-                        )
+            # Terminal status reflects the real outcome:
+            #   all batches failed   → FAILED (no rows rewritten)
+            #   some batches failed  → COMPLETED, partial-state message
+            #   all batches succeeded → COMPLETED
+            if failed_batches and failed_batches >= total_batches:
+                await notif_service.update_notification(
+                    notification_id,
+                    NotificationUpdate(
+                        status=NotificationStatus.FAILED,
+                        error=(
+                            f"All {failed_batches} batches failed; no rows were "
+                            "re-embedded. Check scheduler logs and the embedding "
+                            "configuration."
+                        ),
+                        description=f"Reindex failed: 0/{total} rows re-embedded.",
+                        result={
+                            "processed": processed,
+                            "total": total,
+                            "failed_batches": failed_batches,
+                            "total_batches": total_batches,
+                        },
                     ),
-                    percent=100.0,
-                    result={
-                        "processed": processed,
-                        "total": total,
-                        "failed_batches": failed_batches,
-                    },
-                ),
-            )
+                )
+            else:
+                description = f"Reindexed {processed}/{total} rows."
+                if failed_batches:
+                    description += (
+                        f" ({failed_batches}/{total_batches} batches failed; "
+                        f"{total - processed} row(s) kept their old embedding.)"
+                    )
+                await notif_service.update_notification(
+                    notification_id,
+                    NotificationUpdate(
+                        status=NotificationStatus.COMPLETED,
+                        description=description,
+                        percent=100.0,
+                        result={
+                            "processed": processed,
+                            "total": total,
+                            "failed_batches": failed_batches,
+                            "total_batches": total_batches,
+                        },
+                    ),
+                )
 
     except Exception as e:
         logger.exception("Reindex job failed")
@@ -258,6 +289,35 @@ async def count_knowledge_rows() -> int:
         return cast(int, result.scalar_one())
 
 
+async def count_knowledge_rows_at_other_dims(target_dim: int) -> int:
+    """
+    Return the number of `knowledge_store` rows whose embedding dimension
+    is NOT ``target_dim``.
+
+    The embedding-config save gate uses this to ground its reindex prompt
+    in actual DB state instead of the persisted config, which closes two
+    holes:
+
+    1. **Resave with stale rows.** If the persisted config already says
+       3072 but the DB still has 1536-dim rows from before the previous
+       (failed) reindex, a config-vs-config diff would say "no change"
+       and skip the prompt. A DB-grounded check still fires.
+    2. **First save with no recorded ``dimensions``.** Same shape — the
+       diff has nothing to compare against and silently passes.
+    """
+    from sqlalchemy import func, text
+
+    async with get_db_context() as db:
+        # vector_dims() is a pgvector function; SQLAlchemy doesn't model it,
+        # so we drop down to a literal text expression.
+        result = await db.execute(
+            select(func.count()).where(
+                text("vector_dims(embedding) <> :td").bindparams(td=target_dim)
+            ).select_from(KnowledgeStore)
+        )
+        return cast(int, result.scalar_one())
+
+
 __all__ = [
     "EMBED_BATCH_SIZE",
     "run_reindex",
@@ -265,4 +325,5 @@ __all__ = [
     "mark_cancelled",
     "clear_cancel_flag",
     "count_knowledge_rows",
+    "count_knowledge_rows_at_other_dims",
 ]

--- a/api/tests/unit/services/test_embeddings_openai_client.py
+++ b/api/tests/unit/services/test_embeddings_openai_client.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for OpenAIEmbeddingClient.embed() — specifically the empty-200
+recovery path that backs issue #198.
+
+OpenRouter (and other OpenAI-compatible providers) sometimes return a 200
+with `data=None` for over-cap batches; the SDK silently parses that into a
+response where the consumer iterates None. We turn that into a typed error
+plus halve-and-retry so a working sub-batch can still complete.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.embeddings.base import EmbeddingConfig
+from src.services.embeddings.openai_client import (
+    EmptyEmbeddingResponseError,
+    OpenAIEmbeddingClient,
+)
+
+
+def _make_response(items):
+    """Build a fake openai response object with a `data` attribute."""
+    return SimpleNamespace(data=items)
+
+
+def _embedding_item(index: int, dim: int = 4):
+    """One openai-shaped embedding-item record."""
+    return SimpleNamespace(index=index, embedding=[float(index)] * dim)
+
+
+@pytest.fixture
+def client():
+    cfg = EmbeddingConfig(
+        api_key="sk-test",
+        model="text-embedding-3-large",
+        endpoint="https://example.invalid/v1",
+    )
+    with patch(
+        "src.services.embeddings.openai_client.AsyncOpenAI"
+    ) as async_openai:
+        # The SUT only uses _client.embeddings.create — wire that.
+        async_openai.return_value = MagicMock()
+        async_openai.return_value.embeddings = MagicMock()
+        async_openai.return_value.embeddings.create = AsyncMock()
+        c = OpenAIEmbeddingClient(cfg)
+    return c
+
+
+@pytest.mark.asyncio
+async def test_embed_returns_ordered_vectors_on_happy_path(client):
+    """Plain success path — verifies order is preserved by `index`."""
+    # Provider returns results out of order; client must sort by index.
+    client._client.embeddings.create = AsyncMock(
+        return_value=_make_response(
+            [_embedding_item(2), _embedding_item(0), _embedding_item(1)]
+        )
+    )
+    out = await client.embed(["a", "b", "c"])
+    assert [v[0] for v in out] == [0.0, 1.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_embed_raises_typed_error_when_n1_returns_no_data(client):
+    """At N=1 there's nothing to halve — propagate the typed error."""
+    client._client.embeddings.create = AsyncMock(
+        return_value=_make_response(None)
+    )
+    with pytest.raises(EmptyEmbeddingResponseError) as exc:
+        await client.embed(["only one"])
+    assert exc.value.batch_size == 1
+    assert exc.value.model == "text-embedding-3-large"
+
+
+@pytest.mark.asyncio
+async def test_embed_halves_and_retries_on_empty_200_batch(client):
+    """The bug from prod: N=256 returns data=None, but smaller batches succeed.
+
+    We simulate the reproducer by tracking the per-call batch size: any call
+    with len(input) > 4 gets data=None; smaller batches get a real response.
+    Halve-and-retry should drive the recursion down until each leaf works
+    and then concatenate the leaves in order.
+    """
+    call_log = []
+
+    async def fake_create(*, input, model, encoding_format):
+        call_log.append(len(input))
+        if len(input) > 4:
+            return _make_response(None)
+        # Index is per-call (per the OpenAI contract).
+        return _make_response(
+            [_embedding_item(i) for i in range(len(input))]
+        )
+
+    client._client.embeddings.create = AsyncMock(side_effect=fake_create)
+
+    inputs = [f"text-{i}" for i in range(8)]
+    out = await client.embed(inputs)
+
+    # We should have gotten 8 vectors back, in order.
+    assert len(out) == 8
+    # First call had the full batch (8); subsequent halved (4 + 4).
+    assert call_log[0] == 8
+    assert sorted(call_log[1:]) == [4, 4]
+
+
+@pytest.mark.asyncio
+async def test_embed_halves_recursively_to_n1_then_propagates(client):
+    """Provider is broken at every batch size — error propagates from the
+    deepest leaf with the typed error, not a generic NoneType crash."""
+    client._client.embeddings.create = AsyncMock(
+        return_value=_make_response(None)
+    )
+    with pytest.raises(EmptyEmbeddingResponseError):
+        await client.embed(["a", "b", "c", "d"])
+
+
+@pytest.mark.asyncio
+async def test_embed_empty_input_short_circuits(client):
+    """No texts → no API call, empty list back."""
+    client._client.embeddings.create = AsyncMock()
+    out = await client.embed([])
+    assert out == []
+    client._client.embeddings.create.assert_not_awaited()

--- a/api/tests/unit/services/test_embeddings_reindex.py
+++ b/api/tests/unit/services/test_embeddings_reindex.py
@@ -140,3 +140,182 @@ async def test_run_reindex_bails_on_cancellation_before_first_batch():
     final_update = final_call.args[1]
     assert final_update.status is not None
     assert final_update.status.value == "cancelled"
+
+
+# --- Terminal-status tests for issue #198 ---
+#
+# Before the fix, a per-batch failure incremented `processed` and the
+# terminal notification fired COMPLETED regardless of failure count. These
+# tests pin the new behavior:
+#   - all batches failed   → FAILED, processed=0
+#   - some batches failed  → COMPLETED, processed = succeeded * batch_rows,
+#                            description mentions failures
+#   - all batches succeeded → COMPLETED (existing behavior, unchanged)
+
+
+@pytest.mark.asyncio
+async def test_run_reindex_marks_failed_when_every_batch_fails():
+    """Repro of the prod incident: 23 batches, all failed, UI claimed success."""
+    notif_service = MagicMock()
+    notif_service.update_notification = AsyncMock()
+
+    db = AsyncMock()
+    # 600 rows → 3 batches of 256 (256 + 256 + 88).
+    row_count = 600
+    rows_result = MagicMock()
+    rows_result.all = MagicMock(return_value=[(f"id-{i}",) for i in range(row_count)])
+
+    # Per-batch content lookup: returns (id, content) tuples.
+    def make_content_result(start, end):
+        r = MagicMock()
+        # The reindex code uses `row.content`, so produce row-shaped objects
+        # rather than plain tuples.
+        rows = []
+        for i in range(start, end):
+            row = MagicMock()
+            row.id = f"id-{i}"
+            row.content = f"text-{i}"
+            rows.append(row)
+        r.all = MagicMock(return_value=rows)
+        return r
+
+    # First execute() returns ids; subsequent ones return per-batch content.
+    db.execute = AsyncMock(
+        side_effect=[
+            rows_result,
+            make_content_result(0, 256),
+            make_content_result(256, 512),
+            make_content_result(512, 600),
+        ]
+    )
+
+    db_ctx = AsyncMock()
+    db_ctx.__aenter__ = AsyncMock(return_value=db)
+    db_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    embedding_client = MagicMock()
+    embedding_client.embed = AsyncMock(side_effect=RuntimeError("provider broken"))
+
+    with (
+        patch.object(reindex, "get_notification_service", return_value=notif_service),
+        patch.object(reindex, "get_db_context", return_value=db_ctx),
+        patch.object(reindex, "clear_cancel_flag", AsyncMock()),
+        patch.object(reindex, "is_cancelled", AsyncMock(return_value=False)),
+        patch.object(
+            reindex, "get_embedding_client", AsyncMock(return_value=embedding_client)
+        ),
+    ):
+        await reindex.run_reindex("nid")
+
+    final_call = notif_service.update_notification.await_args_list[-1]
+    final_update = final_call.args[1]
+    assert final_update.status.value == "failed", (
+        "All-batches-failed must report FAILED, not COMPLETED — that was "
+        "the issue #198 lie."
+    )
+    # No row was actually rewritten.
+    assert final_update.result["processed"] == 0
+    assert final_update.result["failed_batches"] == 3
+    assert final_update.result["total_batches"] == 3
+
+
+@pytest.mark.asyncio
+async def test_run_reindex_partial_failure_completes_with_failed_batch_count():
+    """One batch fails, two succeed → COMPLETED, but result carries the count."""
+    notif_service = MagicMock()
+    notif_service.update_notification = AsyncMock()
+
+    db = AsyncMock()
+    row_count = 600
+    rows_result = MagicMock()
+    rows_result.all = MagicMock(
+        return_value=[(f"id-{i}",) for i in range(row_count)]
+    )
+
+    def make_content_result(start, end):
+        r = MagicMock()
+        # The reindex code uses `row.content`, so produce row-shaped objects
+        # rather than plain tuples.
+        rows = []
+        for i in range(start, end):
+            row = MagicMock()
+            row.id = f"id-{i}"
+            row.content = f"text-{i}"
+            rows.append(row)
+        r.all = MagicMock(return_value=rows)
+        return r
+
+    # Many execute() calls — the per-row UPDATE issues one each. We only
+    # care that the IDs and per-batch content are correct in order; the
+    # UPDATE results are unused.
+    db.execute = AsyncMock(
+        side_effect=[
+            rows_result,
+            make_content_result(0, 256),
+            *[MagicMock() for _ in range(256)],  # UPDATEs for batch 0
+            make_content_result(256, 512),
+            # Batch 1 fails, no UPDATEs.
+            make_content_result(512, 600),
+            *[MagicMock() for _ in range(88)],  # UPDATEs for batch 2
+        ]
+    )
+
+    db_ctx = AsyncMock()
+    db_ctx.__aenter__ = AsyncMock(return_value=db)
+    db_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    # Embed: succeed for batch 0 (256 vectors), fail for batch 1, succeed
+    # for batch 2 (88 vectors).
+    embedding_client = MagicMock()
+    embedding_client.embed = AsyncMock(
+        side_effect=[
+            [[0.0] * 4 for _ in range(256)],
+            RuntimeError("provider blip"),
+            [[0.0] * 4 for _ in range(88)],
+        ]
+    )
+
+    with (
+        patch.object(reindex, "get_notification_service", return_value=notif_service),
+        patch.object(reindex, "get_db_context", return_value=db_ctx),
+        patch.object(reindex, "clear_cancel_flag", AsyncMock()),
+        patch.object(reindex, "is_cancelled", AsyncMock(return_value=False)),
+        patch.object(
+            reindex, "get_embedding_client", AsyncMock(return_value=embedding_client)
+        ),
+    ):
+        await reindex.run_reindex("nid")
+
+    final_call = notif_service.update_notification.await_args_list[-1]
+    final_update = final_call.args[1]
+    assert final_update.status.value == "completed"
+    # 256 + 88 rows actually rewritten; batch 1's 256 rows skipped.
+    assert final_update.result["processed"] == 344
+    assert final_update.result["failed_batches"] == 1
+    assert final_update.result["total_batches"] == 3
+    assert final_update.result["total"] == 600
+    assert "1/3 batches failed" in final_update.description
+
+
+@pytest.mark.asyncio
+async def test_count_knowledge_rows_at_other_dims_uses_vector_dims_filter():
+    """Sanity-check the helper: it should grow the WHERE clause with
+    `vector_dims(embedding) <> :td` and bind target_dim."""
+    db = AsyncMock()
+    scalar_result = MagicMock()
+    scalar_result.scalar_one = MagicMock(return_value=42)
+    db.execute = AsyncMock(return_value=scalar_result)
+
+    db_ctx = AsyncMock()
+    db_ctx.__aenter__ = AsyncMock(return_value=db)
+    db_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with patch.object(reindex, "get_db_context", return_value=db_ctx):
+        result = await reindex.count_knowledge_rows_at_other_dims(3072)
+
+    assert result == 42
+    # Verify the SQL used vector_dims; we look at the compiled string.
+    executed_stmt = db.execute.await_args.args[0]
+    compiled = str(executed_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "vector_dims" in compiled
+    assert "3072" in compiled

--- a/client/src/pages/settings/LLMConfig.tsx
+++ b/client/src/pages/settings/LLMConfig.tsx
@@ -1412,21 +1412,20 @@ function EmbeddingConfigCard({
 						<DialogHeader>
 							<DialogTitle>Re-embed knowledge store?</DialogTitle>
 							<DialogDescription>
-								The new model produces{" "}
-								<strong>{reindexConfirm?.new_dim ?? "?"}-dim</strong>{" "}
-								vectors but{" "}
 								{reindexConfirm?.row_count ?? 0} existing row
-								{reindexConfirm?.row_count === 1 ? "" : "s"} were
-								embedded with{" "}
-								<strong>{reindexConfirm?.old_dim ?? "?"}-dim</strong>{" "}
-								vectors{" "}
+								{reindexConfirm?.row_count === 1 ? "" : "s"}{" "}
+								{reindexConfirm?.row_count === 1 ? "is" : "are"}{" "}
+								embedded with vectors that don't match the new
+								model's{" "}
+								<strong>{reindexConfirm?.new_dim ?? "?"}-dim</strong>{" "}
+								output
 								{reindexConfirm?.old_model
-									? `(${reindexConfirm.old_model})`
+									? ` (previously ${reindexConfirm.old_model})`
 									: ""}
-								. Search will not work against the existing rows
-								until they are re-embedded with the new model.
-								Re-embedding runs in the background and you can
-								cancel from the notification center.
+								. Search won't work against those rows until
+								they're re-embedded. Re-embedding runs in the
+								background and you can cancel from the
+								notification center.
 							</DialogDescription>
 						</DialogHeader>
 						<DialogFooter>


### PR DESCRIPTION
## Summary

Three coordinated fixes for the embedding reindex regression hit in production today (issue #198). The platform was deployed with the model switched to a 3072-dim provider via OpenRouter; reindex silently failed on every batch but reported success, leaving `knowledge_store` in a mixed-dim state.

- **`openai_client.py`** — detect empty 200 responses, raise typed `EmptyEmbeddingResponseError`, recursive halve-and-retry down to N=1. OpenRouter's pass-through returns 200-with-no-data when the input array exceeds an undocumented per-request cap; halving recovers automatically.
- **`reindex.py`** — terminal notification status reflects the actual outcome. All batches failed → `FAILED`. Some failed → `COMPLETED` with `failed_batches`/`total_batches` in `result` and a description that names the failure count. `processed` no longer increments on skipped batches (was the source of the "Reindexed N/N rows" lie).
- **`llm_config.py` save gate** — replace `old_config.dimensions != new.dimensions` with a DB query (`count_knowledge_rows_at_other_dims(new_dim)`). Confirmation dialog now fires whenever any `knowledge_store` row's dim ≠ `new_dim`, regardless of prior config state. Closes the resave-with-stale-rows hole and the first-save-with-no-recorded-dim hole. Cancel UX is already correct (already-existing `saved=False` short-circuit; client closes dialog without re-POSTing).

Confirmation-dialog copy updated so the framing works whether the trigger is a dim change or stale rows ("rows that don't match the new model's X-dim output").

## Production state at time of this PR

```
SELECT vector_dims(embedding) AS dim, count(*) FROM knowledge_store GROUP BY 1;
 dim  | count
------+-------
 1536 |  5888
 3072 |    41
```

After merging + deploying, the on-demand reindex button needs to be hit to clear the 5,888 stale rows. The new gate ensures any future resave that leaves stale state will prompt — including resaves of the same config.

## Test plan

- [x] `./test.sh tests/unit/services/test_embeddings_openai_client.py` — 5 new tests, all pass (happy path, N=1 typed error, halve-and-retry on empty 200, recursive bottom-out, empty-input short-circuit)
- [x] `./test.sh tests/unit/services/test_embeddings_reindex.py` — 3 new tests for terminal-status variants + 1 for the new helper, all pass
- [x] `./test.sh unit` — 3679 passed, no regressions
- [x] `cd api && ../.venv/bin/pyright src/services/embeddings/ src/routers/llm_config.py` — 0 errors
- [x] `cd api && ../.venv/bin/ruff check ...` — All checks passed
- [x] `cd client && npm run tsc` — clean
- [x] `cd client && npm run lint` — clean (only pre-existing FormRenderer warning, unrelated)
- [ ] Post-deploy manual smoke: hit the on-demand reindex button on prod; confirm progress notifications stream and the dim-distribution query reports a single dim

## Out of scope (follow-ups, not in this PR)

- Save-time test currently uses N=1 (`embed_single`). Provider per-request caps that bite at batch sizes used by reindex are now caught by the runtime resilience but won't surface during save. Consider testing with a small batch (e.g. N=8) so config issues fail loudly at save time.

Fixes #198