### PR TITLE
fix(cli): version check actually blocks stale CLIs (#206)

### DIFF
--- a/.claude/skills/bifrost-issues/SKILL.md
+++ b/.claude/skills/bifrost-issues/SKILL.md
@@ -161,21 +161,31 @@ Once a PR is open, three independent signals can come in: CI check transitions, 
 
 ```bash
 # Hash reviews + check states + comments together; emit only on change.
+# Terminal condition is INTENTIONALLY narrow: only state==MERGED|CLOSED.
+# Don't try to be clever with "BLOCKED + all checks done" — mergeStateStatus
+# is BLOCKED from the moment a PR opens against a protected branch, and
+# `statusCheckRollup` may briefly contain entries with empty conclusion+state
+# while checks are being scheduled, which makes the "all done" predicate
+# fire prematurely. Watch until merge or close; the user can interrupt.
 prev=""
+prev_c=""
 while true; do
   s=$(gh pr view <N> --repo jackmusick/bifrost \
-        --json reviews,statusCheckRollup,reviewDecision,mergeStateStatus 2>/dev/null) || { sleep 60; continue; }
-  c=$(gh api repos/jackmusick/bifrost/pulls/<N>/comments --jq '.[] | "\(.user.login):\(.id)"' 2>/dev/null | sort)
+        --json reviews,statusCheckRollup,reviewDecision,mergeStateStatus,state 2>/dev/null) || { sleep 60; continue; }
+  c=$(gh api repos/jackmusick/bifrost/pulls/<N>/comments --jq '.[] | "\(.user.login):\(.id):\(.path):\(.line):\(.body|gsub("\n";" ")|.[0:100])"' 2>/dev/null | sort)
   cur=$(printf '%s\n%s' "$s" "$c" | sha256sum | cut -d' ' -f1)
   if [ "$cur" != "$prev" ]; then
-    echo "=== $(date -u +%H:%M:%S) state changed ==="
-    jq -r '"reviewDecision: \(.reviewDecision)\nmergeStateStatus: \(.mergeStateStatus)\nchecks:", (.statusCheckRollup[] | "  \(.name // .context): \(.conclusion // .state)"), "reviews:", (.reviews[] | "  \(.author.login) \(.state) \(.submittedAt)")' <<<"$s"
-    echo "inline comments: $(echo "$c" | wc -l)"
+    echo "=== $(date -u +%H:%M:%S) PR <N> update ==="
+    jq -r '"  reviewDecision: \(.reviewDecision // "(none)")\n  mergeStateStatus: \(.mergeStateStatus)\n  state: \(.state)\nchecks:", (.statusCheckRollup[] | "  \(.name // .context // "?"): \(.conclusion // .state // "queued")"), "reviews:", (.reviews[] | "  \(.author.login) \(.state)")' <<<"$s"
+    if [ -n "$prev_c" ] && [ "$c" != "$prev_c" ]; then
+      echo "NEW review comments:"
+      diff <(echo "$prev_c") <(echo "$c") | grep '^>' | head -10
+    fi
+    prev_c=$c
     prev=$cur
   fi
-  # Stop when terminal: merged, closed, or fully checked-and-decided.
-  jq -e '.mergeStateStatus == "CLEAN" or .mergeStateStatus == "BLOCKED" or .mergeStateStatus == "DIRTY"' <<<"$s" >/dev/null && \
-    jq -e '[.statusCheckRollup[] | (.conclusion // .state)] | all(. != "PENDING" and . != "IN_PROGRESS" and . != "QUEUED")' <<<"$s" >/dev/null && break
+  st=$(jq -r '.state' <<<"$s")
+  case "$st" in MERGED|CLOSED) echo "PR is $st"; break ;; esac
   sleep 60
 done
 ```

--- a/.claude/skills/bifrost-issues/SKILL.md
+++ b/.claude/skills/bifrost-issues/SKILL.md
@@ -153,27 +153,56 @@ gh api repos/jackmusick/bifrost/branches/main/protection \
 
 If the count is ≥1, `--auto` is safe. Otherwise it isn't (a `--auto` merge would fire the moment GitHub considers the PR mergeable, which without required checks is *immediately*).
 
-**Path A — protection exists (preferred):**
+**Watch reviews and CI together — `gh pr checks` alone will miss code review comments.**
+
+Once a PR is open, three independent signals can come in: CI check transitions, code-review comments (CodeQL bot, human reviewers, copilot/Anthropic), and merge-state changes. The watcher must cover all three. Don't just `tail -f` `gh pr checks` — that silently misses CodeQL findings until they're already old, and an auto-merge queued PR can sit forever blocked on an "actionable" review you never noticed.
+
+**Combined watcher pattern (use this, not a checks-only loop):**
+
+```bash
+# Hash reviews + check states + comments together; emit only on change.
+prev=""
+while true; do
+  s=$(gh pr view <N> --repo jackmusick/bifrost \
+        --json reviews,statusCheckRollup,reviewDecision,mergeStateStatus 2>/dev/null) || { sleep 60; continue; }
+  c=$(gh api repos/jackmusick/bifrost/pulls/<N>/comments --jq '.[] | "\(.user.login):\(.id)"' 2>/dev/null | sort)
+  cur=$(printf '%s\n%s' "$s" "$c" | sha256sum | cut -d' ' -f1)
+  if [ "$cur" != "$prev" ]; then
+    echo "=== $(date -u +%H:%M:%S) state changed ==="
+    jq -r '"reviewDecision: \(.reviewDecision)\nmergeStateStatus: \(.mergeStateStatus)\nchecks:", (.statusCheckRollup[] | "  \(.name // .context): \(.conclusion // .state)"), "reviews:", (.reviews[] | "  \(.author.login) \(.state) \(.submittedAt)")' <<<"$s"
+    echo "inline comments: $(echo "$c" | wc -l)"
+    prev=$cur
+  fi
+  # Stop when terminal: merged, closed, or fully checked-and-decided.
+  jq -e '.mergeStateStatus == "CLEAN" or .mergeStateStatus == "BLOCKED" or .mergeStateStatus == "DIRTY"' <<<"$s" >/dev/null && \
+    jq -e '[.statusCheckRollup[] | (.conclusion // .state)] | all(. != "PENDING" and . != "IN_PROGRESS" and . != "QUEUED")' <<<"$s" >/dev/null && break
+  sleep 60
+done
+```
+
+**When a review comment lands** (CodeQL, copilot, human): pull the body and address it before merging. CodeQL findings on this repo's pre-push hook are usually real — see `feedback_codeql_friendly_idioms.md` in memory. Never queue `--auto` and walk away from a fresh review.
+
+**Path A — protection exists (preferred for ship-when-green):**
 
 1. Confirm with the user once ("Queue auto-merge so it ships when CI is green?").
-2. On approval: `gh pr merge <N> --auto --squash --delete-branch=false` (keep the remote branch; the worktree still references it, cleanup in step 8).
-3. **Stop here.** No CI watcher needed — GitHub merges automatically when checks pass. Tell the user they'll see the merge land in their notifications and can return for cleanup whenever.
-4. The contributor's value of this path is bigger than the admin's: contributors with no merge perms can still queue `--auto`, walk away, and the merge fires the moment approval + checks both arrive — they don't have to come back to click merge.
-5. If a review is required (`required_pull_request_reviews` is set) and the user isn't admin, surface that the merge is gated on approval and offer to request reviewers via `gh pr edit <N> --add-reviewer <login>`. Don't pick reviewers unprompted.
+2. On approval: `gh pr merge <N> --auto --squash --delete-branch=false` (keep the remote branch; worktree still references it, cleanup in step 8).
+3. **Arm the combined watcher above.** `--auto` does not exempt you from picking up review comments — CodeQL still fires after queueing, and the auto-merge will not proceed past a `BLOCKED`/`DIRTY` mergeStateStatus.
+4. If a review is required (`required_pull_request_reviews` is set) and the user isn't admin, surface that the merge is gated on approval and offer to request reviewers via `gh pr edit <N> --add-reviewer <login>`. Don't pick reviewers unprompted.
 
 **Path B — no protection (fallback):**
 
-1. **Watch CI.** Snapshot status with `gh pr checks <N> --repo jackmusick/bifrost` once, then arm a session-length watcher via the `loop` skill in dynamic mode (no interval, event-gated) — it knows how to set up a Monitor on `gh pr checks` plus a heartbeat fallback. Don't roll your own polling loop.
-2. **If CI fails:** stay in the existing worktree on the existing branch — fixes are additional commits to `<issue-num>-<slug>`, not a fresh worktree. The PR auto-updates on push. New worktree only if the branch is being abandoned entirely.
-3. **If CI passes:** check `gh pr view <N> --json viewerCanAdminister,reviewDecision,mergeStateStatus` to decide.
-   - `viewerCanAdminister: true` → self-merge: confirm once ("CI's green — merge?"), then `gh pr merge <N> --squash --delete-branch=false`.
-   - Otherwise → contributor needs review: surface reviewer-request as in Path A step 5.
+1. Arm the combined watcher above.
+2. **If CI fails or a review comment lands:** stay in the existing worktree on the existing branch — fixes are additional commits to `<issue-num>-<slug>`, not a fresh worktree. The PR auto-updates on push. New worktree only if the branch is being abandoned entirely.
+3. **If CI passes and reviews are clean:** check `gh pr view <N> --json viewerCanAdminister,reviewDecision,mergeStateStatus` to decide.
+   - `viewerCanAdminister: true` → self-merge: confirm once ("CI's green and reviews are clean — merge?"), then `gh pr merge <N> --squash --delete-branch=false`.
+   - Otherwise → contributor needs review: surface reviewer-request as in Path A step 4.
 4. **Never `--auto` on Path B.** Without required checks, it would fire before CI completes.
 
 **Both paths:**
 
 - Don't merge unprompted. "Merge?" or "queue auto-merge?" is the user's decision — confirm, never assume.
 - If CI is already failing on the PR when you reach this step, surface the failure and don't offer merge until it's fixed.
+- **Review comments are not optional.** A `gh pr checks` watcher that doesn't also poll reviews/comments will leave the user thinking nothing is happening while CodeQL has been waiting on you for 20 minutes.
 
 ### 8. Cleanup (after merge)
 

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -131,35 +131,60 @@ WATCH_HEARTBEAT_SECONDS = 60
 
 
 def _check_cli_version() -> None:
-    """Warn if the installed CLI is older than the API's minimum required version."""
+    """Hard-block the command if the installed CLI doesn't match the deployed server.
+
+    Mirrors the policy in ``client/src/hooks/useVersionCheck.ts``: compare the
+    baked-in build version against ``data.version`` from ``GET /api/version``
+    via string equality, treat ``"unknown"`` / ``"0.0.0+source"`` as dev installs
+    and skip. The CLI diverges from the SPA only by ``sys.exit(1)``-ing on
+    mismatch instead of showing a banner — the user must upgrade before any
+    command runs.
+    """
     try:
         import urllib.request
         import json as _json
         from bifrost import __version__
 
-        config_path = pathlib.Path.home() / ".bifrost" / "config.json"
-        if not config_path.exists():
-            return
-        config = _json.loads(config_path.read_text())
-        api_url = config.get("api_url", "").rstrip("/")
+        installed = __version__.lstrip("v")
+        if installed in ("unknown", "0.0.0+source"):
+            return  # dev/source install — nothing to compare against
+
+        # Re-load dotenv so a CWD-local .env's BIFROST_API_URL is honored even
+        # if bifrost.client's import-time load happened against a different cwd.
+        try:
+            from dotenv import find_dotenv, load_dotenv
+            load_dotenv(find_dotenv(usecwd=True), override=False)
+        except ImportError:
+            pass
+
+        # Use credentials._resolve_url (not get_credentials) because the version
+        # check only needs the URL — get_credentials returns None unless full
+        # tokens are present too, which would skip the check on a logged-out CLI.
+        api_url = credentials._resolve_url(None)
         if not api_url:
             return
 
         with urllib.request.urlopen(f"{api_url}/api/version", timeout=3) as resp:
             data = _json.loads(resp.read())
 
-        min_ver = data.get("min_cli_version", "")
-        installed = __version__.lstrip("v")
-        if min_ver and installed != "unknown" and installed < min_ver:
+        server_version = (data.get("version") or "").lstrip("v")
+        if not server_version:
+            return  # server didn't tell us its version — best-effort skip
+
+        if server_version != installed:
             print(
-                f"\033[33mWarning: CLI version {installed} is older than the "
-                f"minimum required {min_ver}. Run:\n"
-                f"  pipx install {api_url}/api/cli/download\n\033[0m",
+                f"\033[33mYour CLI ({installed}) is out of date. "
+                f"Server is on {server_version}.\nRun:\n"
+                f"  pipx install --force {api_url}/api/cli/download\n\033[0m",
                 file=sys.stderr,
             )
+            sys.exit(1)
+    except SystemExit:
+        raise
     except Exception as e:
-        # Best-effort version check on every CLI invocation — no network, malformed config,
-        # or non-200 response should ever break the CLI flow
+        # Best-effort: network errors, malformed JSON, missing credentials store,
+        # etc. should never block the user. The exit-on-mismatch above is the
+        # only intentional bail-out.
         logger.debug(f"CLI version check skipped: {e}")
 
 

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -155,7 +155,7 @@ def _check_cli_version() -> None:
             from dotenv import find_dotenv, load_dotenv
             load_dotenv(find_dotenv(usecwd=True), override=False)
         except ImportError:
-            pass
+            pass  # python-dotenv is optional; without it, only os.environ is consulted
 
         # Use credentials._resolve_url (not get_credentials) because the version
         # check only needs the URL — get_credentials returns None unless full

--- a/api/shared/version.py
+++ b/api/shared/version.py
@@ -2,8 +2,6 @@ import os
 import subprocess
 from functools import lru_cache
 
-MIN_CLI_VERSION = "2.0.0"
-
 
 @lru_cache(maxsize=1)
 def get_version() -> str:

--- a/api/src/routers/version.py
+++ b/api/src/routers/version.py
@@ -1,19 +1,17 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from shared.version import MIN_CLI_VERSION, get_version
+from shared.version import get_version
 
 router = APIRouter(prefix="/api/version", tags=["version"])
 
 
 class VersionResponse(BaseModel):
     version: str
-    min_cli_version: str
 
 
 @router.get("", response_model=VersionResponse)
 async def get_version_info() -> VersionResponse:
     return VersionResponse(
         version=get_version(),
-        min_cli_version=MIN_CLI_VERSION,
     )

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -1,0 +1,306 @@
+"""Tests for ``bifrost.cli._check_cli_version``.
+
+The check must:
+
+* Skip silently for source/dev installs (``__version__`` of ``"unknown"`` or
+  ``"0.0.0+source"``).
+* Resolve the API URL via ``credentials._resolve_url`` so a project
+  ``.env`` (loaded by python-dotenv before the call) is honored alongside
+  the keyring/JSON store. We use ``_resolve_url`` (not
+  ``get_credentials``) because the version check only needs the URL — a
+  logged-out CLI with ``BIFROST_API_URL`` set in ``.env`` should still get
+  checked, even though it has no tokens yet.
+* Compare installed vs. server version with string equality and ``sys.exit(1)``
+  when they differ — no warning-and-continue, no escape hatch.
+* Treat network/parse failures as best-effort: skip silently, do not block.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_version_check_state():
+    """Keep this file's tests from polluting other test files.
+
+    Two state leaks to clean up:
+
+    * The memoized ``_persistent_backend`` global in ``bifrost.credentials``,
+      which downstream credentials tests rely on being unset.
+    * ``BIFROST_API_URL`` written to ``os.environ`` by ``python-dotenv`` in
+      the dotenv-resolution test — monkeypatch doesn't track it because
+      load_dotenv writes to os.environ directly. Subsequent SDK credentials
+      tests assume the env var is unset and resolve via the JSON store.
+    """
+    import os
+
+    from bifrost.credentials import _reset_persistent_backend_for_tests
+
+    _reset_persistent_backend_for_tests()
+    yield
+    _reset_persistent_backend_for_tests()
+    os.environ.pop("BIFROST_API_URL", None)
+
+
+def _patch_version(monkeypatch, value: str) -> None:
+    """Patch ``bifrost.__version__`` for the duration of a test.
+
+    ``_check_cli_version`` does ``from bifrost import __version__`` inside
+    its body, so we have to monkeypatch the attribute on the package itself.
+    """
+    import bifrost
+
+    monkeypatch.setattr(bifrost, "__version__", value, raising=False)
+
+
+def _make_url_response(payload: dict) -> object:
+    """Return a context-manager-shaped fake for ``urllib.request.urlopen``."""
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def read(self):
+            return json.dumps(payload).encode()
+
+    return _Resp()
+
+
+# --------------------------------------------------------------------------- #
+# Skip cases
+# --------------------------------------------------------------------------- #
+
+
+class TestSkipCases:
+    def test_skips_when_version_is_unknown(self, monkeypatch):
+        """Source/dev installs (no baked version) skip the check entirely."""
+        _patch_version(monkeypatch, "unknown")
+        from bifrost import cli
+
+        with patch("urllib.request.urlopen") as urlopen:
+            cli._check_cli_version()
+            urlopen.assert_not_called()
+
+    def test_skips_when_version_is_source_marker(self, monkeypatch):
+        """The ``0.0.0+source`` marker from pyproject.toml is also a dev install."""
+        _patch_version(monkeypatch, "0.0.0+source")
+        from bifrost import cli
+
+        with patch("urllib.request.urlopen") as urlopen:
+            cli._check_cli_version()
+            urlopen.assert_not_called()
+
+    def test_skips_when_no_credentials(self, monkeypatch):
+        """No api_url anywhere → nothing to compare against, return silently."""
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch("bifrost.credentials._resolve_url", return_value=None), \
+             patch("urllib.request.urlopen") as urlopen:
+            cli._check_cli_version()
+            urlopen.assert_not_called()
+
+    def test_skips_on_network_error(self, monkeypatch):
+        """A connection failure must not block the user's command."""
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://server.example",
+        ), patch("urllib.request.urlopen", side_effect=OSError("network down")):
+            cli._check_cli_version()  # must not raise SystemExit
+
+    def test_skips_on_malformed_response(self, monkeypatch):
+        """Server returns non-JSON or unexpected shape — best-effort, skip."""
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        class _BadResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+            def read(self):
+                return b"<html>not json</html>"
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://server.example",
+        ), patch("urllib.request.urlopen", return_value=_BadResp()):
+            cli._check_cli_version()  # must not raise SystemExit
+
+    def test_skips_when_server_version_missing(self, monkeypatch):
+        """Server omits ``version`` — skip rather than block on an empty string."""
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://server.example",
+        ), patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({}),
+        ):
+            cli._check_cli_version()  # must not raise SystemExit
+
+
+# --------------------------------------------------------------------------- #
+# Match / mismatch behavior
+# --------------------------------------------------------------------------- #
+
+
+class TestVersionComparison:
+    def test_passes_when_versions_match(self, monkeypatch):
+        """Installed and server agree → no exit, no stderr noise."""
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        stderr = io.StringIO()
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://server.example",
+        ), patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({"version": "1.2.3"}),
+        ), patch("sys.stderr", stderr):
+            cli._check_cli_version()
+
+        assert stderr.getvalue() == ""
+
+    def test_passes_when_server_prefixes_with_v(self, monkeypatch):
+        """``v1.2.3`` from the server should match ``1.2.3`` installed."""
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://server.example",
+        ), patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({"version": "v1.2.3"}),
+        ):
+            cli._check_cli_version()  # no SystemExit
+
+    def test_exits_on_stale_cli(self, monkeypatch, capsys):
+        """Mismatch → exit 1 with upgrade message on stderr."""
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://server.example",
+        ), patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({"version": "1.3.0"}),
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                cli._check_cli_version()
+            assert excinfo.value.code == 1
+
+        err = capsys.readouterr().err
+        assert "1.2.3" in err
+        assert "1.3.0" in err
+        # Upgrade instructions reference the resolved api_url.
+        assert "http://server.example/api/cli/download" in err
+
+    def test_exits_when_server_is_older_too(self, monkeypatch):
+        """Policy is ``!=``, not ordering — even a 'newer' CLI exits.
+
+        This is intentional: every CLI is expected to track the deployed server
+        exactly. If a user is on a fresher dev build than prod, they should
+        downgrade (or pin BIFROST_API_URL to the right server) before running.
+        """
+        _patch_version(monkeypatch, "2.0.0")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://server.example",
+        ), patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({"version": "1.9.9"}),
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                cli._check_cli_version()
+            assert excinfo.value.code == 1
+
+
+# --------------------------------------------------------------------------- #
+# URL resolution: .env / env-var path
+# --------------------------------------------------------------------------- #
+
+
+class TestUrlResolution:
+    def test_delegates_to_credentials_resolve_url(self, monkeypatch):
+        """Version check must delegate URL resolution to credentials._resolve_url.
+
+        ``_resolve_url`` already implements the full chain (env → keyring/JSON
+        store) and honors python-dotenv-loaded BIFROST_API_URL. The check
+        should not reinvent it. Using ``_resolve_url`` (not
+        ``get_credentials``) means a logged-out CLI in an env with
+        ``BIFROST_API_URL`` set still gets a version check — we only need the
+        URL, not full tokens.
+        """
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://from-credentials.example",
+        ) as resolve, patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({"version": "1.2.3"}),
+        ) as urlopen:
+            cli._check_cli_version()
+            resolve.assert_called_once()
+            # The /api/version GET should target the URL credentials returned.
+            url = urlopen.call_args[0][0]
+            assert url == "http://from-credentials.example/api/version"
+
+    def test_loads_dotenv_before_resolving(self, monkeypatch, tmp_path):
+        """A project ``.env`` containing BIFROST_API_URL is honored.
+
+        ``_check_cli_version`` runs before the rest of the CLI imports
+        ``bifrost.client`` (which is where dotenv is normally loaded). The
+        check must load dotenv itself so a CWD-local ``.env`` resolves the
+        URL just like the rest of the CLI would.
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text("BIFROST_API_URL=http://from-dotenv.example\n")
+
+        monkeypatch.chdir(tmp_path)
+        # Make sure the env var isn't already set in the test process so we
+        # know the value got there via dotenv, not inheritance.
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        # No persistent-store credentials should be returned — we want the
+        # resolution to land on the env var written by dotenv.
+        with patch(
+            "bifrost.credentials.get_persistent_backend"
+        ) as get_backend, patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({"version": "1.2.3"}),
+        ) as urlopen:
+            backend = get_backend.return_value
+            backend.list_urls.return_value = []
+            backend.get.return_value = None
+            cli._check_cli_version()
+
+        # urlopen should have been called against the URL from .env.
+        assert urlopen.called, "urlopen never called — dotenv URL not resolved"
+        url = urlopen.call_args[0][0]
+        assert url == "http://from-dotenv.example/api/version"

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -53,9 +53,7 @@ def _patch_version(monkeypatch, value: str) -> None:
     ``_check_cli_version`` does ``from bifrost import __version__`` inside
     its body, so we have to monkeypatch the attribute on the package itself.
     """
-    import bifrost
-
-    monkeypatch.setattr(bifrost, "__version__", value, raising=False)
+    monkeypatch.setattr("bifrost.__version__", value, raising=False)
 
 
 def _make_url_response(payload: dict) -> object:

--- a/api/tests/unit/test_version.py
+++ b/api/tests/unit/test_version.py
@@ -30,10 +30,3 @@ def test_get_version_git_fallback(monkeypatch):
     with patch("subprocess.check_output", return_value="v2.0.0-12-gabc1234\n"):
         v = _reload_version()
         assert v.get_version() == "v2.0.0-12-gabc1234"
-
-
-def test_min_cli_version_is_string(monkeypatch):
-    monkeypatch.setenv("BIFROST_VERSION", "2.0.0")
-    v = _reload_version()
-    assert isinstance(v.MIN_CLI_VERSION, str)
-    assert v.MIN_CLI_VERSION  # non-empty

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -19813,8 +19813,6 @@ export interface components {
         VersionResponse: {
             /** Version */
             version: string;
-            /** Min Cli Version */
-            min_cli_version: string;
         };
         /**
          * WatchSessionRequest


### PR DESCRIPTION
## Summary

- The CLI version check has been silently no-op'd for everyone since credentials moved out of `~/.bifrost/config.json` — `_check_cli_version` read the URL from a file nothing writes anymore. Many releases shipped without a single user seeing a prompt while the SPA banner worked fine.
- Rewrite to mirror the SPA policy (`client/src/hooks/useVersionCheck.ts`): compare baked-in `__version__` against `data.version` from `/api/version` with string equality. Skip dev installs (`unknown` / `0.0.0+source`). Best-effort skip on network/parse errors. Diverge from the SPA only by `sys.exit(1)`-ing on mismatch — no prompt, no escape hatch, same in TTY and CI.
- URL resolution delegates to `credentials._resolve_url` so a project `.env`'s `BIFROST_API_URL` is honored through the same chain the rest of the CLI uses. Using `_resolve_url` (vs `get_credentials`) means a logged-out CLI with `BIFROST_API_URL` in `.env` still gets checked — we only need the URL, not full tokens.
- Drop `MIN_CLI_VERSION` constant + `min_cli_version` field from `VersionResponse`. Hardcoded floor was never bumped; equality against `data.version` replaces it.

Fixes #206

## Test plan

- [x] `./test.sh tests/unit/cli/test_cli_version_check.py` — 12 new tests covering: skip-on-unknown, skip-on-source-marker, skip-on-no-credentials, skip-on-network-error, skip-on-malformed-response, skip-on-server-version-missing, pass-when-versions-match, pass-when-server-prefixes-with-v, exit-on-stale-cli, exit-when-server-is-older-too, delegates-to-_resolve_url, loads-dotenv-before-resolving
- [x] `./test.sh` — full unit suite, 3700 passed
- [x] Cross-file ordering: `./test.sh tests/unit/cli/test_cli_version_check.py tests/unit/sdk/test_sdk_credentials.py` runs clean (autouse fixture clears the credentials backend cache + `BIFROST_API_URL`)
- [x] `pyright` on changed files — 0 errors, 0 warnings
- [x] `ruff check` on changed files — passes
- [x] `npm run tsc` — passes (only `min_cli_version` line removed from `v1.d.ts`)
- [ ] Manual smoke after merge: `bifrost --version` against an updated server, expect exit 1 with upgrade instructions