### PR TITLE
fix(client): break version-banner reload loop; move banner into header

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -151,11 +151,22 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 
-    # SPA fallback - serve index.html for client-side routing
-    # index.html must not be cached so new deploys serve fresh JS/CSS references
+    # SPA fallback - serve index.html for client-side routing.
+    # index.html MUST NOT be cached (no-store, not no-cache) so rolling deploys
+    # don't pin the browser to a stale bundle. With replicas>1, each pod's
+    # ETag for index.html differs, and `no-cache` lets browsers revalidate
+    # against any pod — which can return 304 against a stale ETag and keep
+    # the user on old chunk hashes through dozens of refreshes. `no-store`
+    # forces a fresh fetch every time, and `etag off` prevents the
+    # revalidation race in any intermediary that ignores no-store.
+    location = /index.html {
+        add_header Cache-Control "no-store, must-revalidate" always;
+        etag off;
+    }
     location / {
         try_files $uri $uri/ /index.html;
-        add_header Cache-Control "no-cache";
+        add_header Cache-Control "no-store, must-revalidate" always;
+        etag off;
     }
 
     # Static assets caching

--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -22,6 +22,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { NotificationCenter } from "@/components/layout/NotificationCenter";
+import { VersionUpdateBanner } from "@/components/layout/VersionUpdateBanner";
 import { useAuth } from "@/contexts/AuthContext";
 import { APP_VERSION } from "@/lib/version";
 import { useProfile } from "@/hooks/useProfile";
@@ -101,8 +102,11 @@ export function AppHeader({ appName, isPreview = false }: AppHeaderProps) {
 				{/* Spacer */}
 				<div className="flex-1" />
 
-				{/* Right: Search, Notifications, Theme, Profile */}
+				{/* Right: Version banner, Search, Notifications, Theme, Profile */}
 				<div className="flex items-center gap-1">
+					{/* Version Update Banner — only renders on version mismatch */}
+					<VersionUpdateBanner />
+
 					{/* Search Button */}
 					<Button
 						variant="ghost"

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -27,6 +27,7 @@ import { APP_VERSION } from "@/lib/version";
 import { useEditorStore } from "@/stores/editorStore";
 import { useQuickAccessStore } from "@/stores/quickAccessStore";
 import { NotificationCenter } from "@/components/layout/NotificationCenter";
+import { VersionUpdateBanner } from "@/components/layout/VersionUpdateBanner";
 import { useProfile } from "@/hooks/useProfile";
 import { profileService } from "@/services/profile";
 import { webSocketService } from "@/services/websocket";
@@ -149,6 +150,12 @@ export function Header({
 
 				{/* Spacer */}
 				<div className="flex-1" />
+
+				{/* Version Update Banner — only renders when /api/version
+				    differs from the baked-in client version. */}
+				<div className="mr-4">
+					<VersionUpdateBanner />
+				</div>
 
 				{/* File Activity Indicator (Platform Admin only) */}
 				{isPlatformAdmin && <FileActivityIndicator />}

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from "react-router-dom";
 import { Header } from "./Header";
 import { Sidebar } from "./Sidebar";
-import { VersionUpdateBanner } from "./VersionUpdateBanner";
 import { useAuth } from "@/contexts/AuthContext";
 import { NoAccess } from "@/components/NoAccess";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -22,7 +21,6 @@ export function Layout() {
 	if (isLoading) {
 		return (
 			<div className="min-h-screen bg-background">
-				<VersionUpdateBanner />
 				<Header />
 				<div className="flex">
 					<main className="flex-1 p-6 lg:p-8">
@@ -51,30 +49,27 @@ export function Layout() {
 	}
 
 	return (
-		<div className="h-screen flex flex-col bg-background overflow-hidden">
-			<VersionUpdateBanner />
-			<div className="flex-1 flex overflow-hidden">
-				{/* Sidebar - full height with logo */}
-				<Sidebar
-					isMobileMenuOpen={isMobileMenuOpen}
-					setIsMobileMenuOpen={setIsMobileMenuOpen}
-					isCollapsed={isSidebarCollapsed}
-				/>
+		<div className="h-screen flex bg-background overflow-hidden">
+			{/* Sidebar - full height with logo */}
+			<Sidebar
+				isMobileMenuOpen={isMobileMenuOpen}
+				setIsMobileMenuOpen={setIsMobileMenuOpen}
+				isCollapsed={isSidebarCollapsed}
+			/>
 
-				{/* Main content area with header */}
-				<div className="flex-1 flex flex-col overflow-hidden">
-					<Header
-						onMobileMenuToggle={() => setIsMobileMenuOpen(true)}
-						onSidebarToggle={toggleSidebar}
-						isSidebarCollapsed={isSidebarCollapsed}
-					/>
-					<main className="flex-1 overflow-auto p-6 lg:p-8">
-						<PasskeySetupBanner />
-						<RouteErrorBoundary>
-							<Outlet />
-						</RouteErrorBoundary>
-					</main>
-				</div>
+			{/* Main content area with header */}
+			<div className="flex-1 flex flex-col overflow-hidden">
+				<Header
+					onMobileMenuToggle={() => setIsMobileMenuOpen(true)}
+					onSidebarToggle={toggleSidebar}
+					isSidebarCollapsed={isSidebarCollapsed}
+				/>
+				<main className="flex-1 overflow-auto p-6 lg:p-8">
+					<PasskeySetupBanner />
+					<RouteErrorBoundary>
+						<Outlet />
+					</RouteErrorBoundary>
+				</main>
 			</div>
 		</div>
 	);

--- a/client/src/components/layout/VersionUpdateBanner.test.tsx
+++ b/client/src/components/layout/VersionUpdateBanner.test.tsx
@@ -35,11 +35,9 @@ describe("VersionUpdateBanner", () => {
 
 		try {
 			render(<VersionUpdateBanner />);
-			expect(
-				screen.getByText(/A new version of Bifrost is available/i),
-			).toBeInTheDocument();
-
-			fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+			fireEvent.click(
+				screen.getByRole("button", { name: /update available/i }),
+			);
 			expect(reload).toHaveBeenCalledTimes(1);
 		} finally {
 			Object.defineProperty(window, "location", {

--- a/client/src/components/layout/VersionUpdateBanner.tsx
+++ b/client/src/components/layout/VersionUpdateBanner.tsx
@@ -1,26 +1,48 @@
+import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useVersionCheck } from "@/hooks/useVersionCheck";
 
+/**
+ * Compact "new version available" affordance for the app header.
+ *
+ * Polls /api/version via useVersionCheck; renders nothing until a version
+ * mismatch is detected, then surfaces a small icon button with a primary
+ * status dot. Click reloads the page; tooltip explains.
+ */
 export function VersionUpdateBanner() {
 	const updateAvailable = useVersionCheck();
 	if (!updateAvailable) return null;
 
 	return (
-		<div
-			role="status"
-			aria-live="polite"
-			className="flex w-full items-center justify-center gap-3 bg-primary px-4 py-2 text-primary-foreground shadow-md"
-		>
-			<span className="text-sm font-medium">
-				A new version of Bifrost is available.
-			</span>
-			<Button
-				size="sm"
-				variant="secondary"
-				onClick={() => window.location.reload()}
-			>
-				Refresh
-			</Button>
+		<div role="status" aria-live="polite">
+			<TooltipProvider delayDuration={150}>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							aria-label="Update available — click to refresh"
+							variant="ghost"
+							size="icon"
+							onClick={() => window.location.reload()}
+							className="relative text-primary hover:text-primary"
+						>
+							<RefreshCw className="h-4 w-4" />
+							<span
+								aria-hidden="true"
+								className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-primary ring-2 ring-background"
+							/>
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">
+						A new version of Bifrost is available. Click to refresh.
+					</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- `index.html` had `Cache-Control: no-cache`, which stores the response and revalidates on every load. With `replicas: 2` and per-pod ETags that don't agree, browsers churned between the two pods' caches without ever pulling fresh content — meanwhile `useVersionCheck` kept polling `/api/version` and the banner kept reappearing on every reload (sometimes dozens of times). Switch to `no-store, must-revalidate` and `etag off` for `/` and `/index.html` so the next page load is guaranteed fresh.
- Move the banner from the full-width `Layout` slot into a compact icon button in `Header.tsx` / `AppHeader.tsx`. `RefreshCw` with a primary status dot; tooltip carries the explanatory copy. Reads as subtle status, not an obnoxious takeover bar.

Fixes #208. Follow-up to #171.

## Verification
- `npm run tsc` clean
- `npm run lint` clean (one pre-existing unrelated warning in `FormRenderer.tsx`)
- `VersionUpdateBanner.test.tsx` updated for the new compact UI; both tests pass

## Test plan
- [ ] Pull this branch, deploy, confirm a fresh page load on a previously-stuck session shows the new compact button (no full-width bar)
- [ ] Trigger a deploy from a clean session, confirm the badge appears, click → page reloads fresh, badge clears and stays cleared
- [ ] On a stuck pre-fix session, hard-reload (Ctrl+Shift+R) to break the cache loop one last time before the new nginx config kicks in

## Notes
- The cache fix only takes effect on the **next** deploy. Existing stuck sessions need a hard reload to clear, then they'll behave correctly going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)