### PR TITLE
fix(security): close py/log-injection in tables router

### DIFF
--- a/api/src/routers/tables.py
+++ b/api/src/routers/tables.py
@@ -684,7 +684,10 @@ async def get_table_or_404(
         table = await repo.get(id=table_uuid)
     except ValueError:
         # Not a UUID — fall through to name-based lookup
-        logger.debug(f"table identifier {name_or_id!r} is not a UUID, falling back to name lookup")
+        logger.debug(
+            f"table identifier {log_safe(name_or_id)!r} is not a UUID, "
+            "falling back to name lookup"
+        )
 
     # Fall back to name lookup (cascade scoping: org-specific then global)
     if not table:


### PR DESCRIPTION
## Summary

- Wraps `name_or_id` in `log_safe()` at `api/src/routers/tables.py:687` to close CodeQL alert #1139 (`py/log-injection`, security-severity **medium**).
- `log_safe` is already imported in this router and used elsewhere for the same reason — drop-in fix.

## Test plan

- [x] `./test.sh tests/unit/test_log_safety.py` — `log_safe` helper coverage (20 passing)
- [x] `ruff check` clean on `api/src/routers/tables.py`
- [ ] CI: lint + type-check + unit + e2e
- [ ] CodeQL: alert #1139 closes on next scan

Fixes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)