### PR TITLE
fix(security): close py/partial-ssrf class issue in GitHubAPIClient

### DIFF
--- a/api/src/services/github_api.py
+++ b/api/src/services/github_api.py
@@ -10,7 +10,9 @@ eliminating multi-container issues with local git folders.
 
 import base64
 import logging
+import re
 from dataclasses import dataclass
+from urllib.parse import quote
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
@@ -18,6 +20,85 @@ from pydantic import BaseModel, ConfigDict, Field
 from src.core.log_safety import log_safe
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Path-segment validators
+# =============================================================================
+#
+# User-controlled identifiers (repo, sha, ref, organization) flow into
+# f-string-built URLs that hit api.github.com. Without sanitization this is
+# partial SSRF: a value like "../../malicious" or "evil/repo;@victim.com"
+# can redirect requests to other GitHub endpoints — or off-host entirely.
+#
+# We validate each kind against its GitHub-documented shape, then route
+# the cleansed value through urllib.parse.quote(safe=""). CodeQL's
+# py/partial-ssrf model recognizes quote() return values as cleansed input.
+# Matches the urlunparse pattern used in services/embeddings/url_safety.py.
+
+# GitHub repo: owner/name. Each segment 1-100 chars of [A-Za-z0-9._-].
+# (GitHub's published limit is 39 for owners, 100 for repos; we go loose
+# on owners since enterprise instances allow longer names.)
+_REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$")
+
+# Git SHA: 7-64 lowercase hex chars (full SHA-1 is 40, SHA-256 is 64; GitHub
+# also accepts 7+ as abbreviated).
+_SHA_RE = re.compile(r"^[a-fA-F0-9]{7,64}$")
+
+# Git ref: branch, tag, or "heads/<name>" / "tags/<name>". Disallow:
+# starting with -, containing .., @{, control chars, spaces, ~^:?*[\
+# Per git-check-ref-format(1) — simplified for paths we accept here.
+_REF_RE = re.compile(r"^[A-Za-z0-9._/-]{1,250}$")
+
+# GitHub org/user login: alphanumeric + dash, no leading dash, 1-39 chars.
+_ORG_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
+
+
+def _validate_repo(repo: str) -> str:
+    """Validate `owner/name` shape and return URL-quoted form.
+
+    Returns urllib.parse.quote(repo, safe='/') — CodeQL recognizes the
+    quote() return as cleansed input for py/partial-ssrf, closing the
+    data-flow path from user input to httpx.AsyncClient.request(url=...).
+    """
+    if not _REPO_RE.match(repo) or ".." in repo:
+        raise ValueError(
+            f"Invalid GitHub repo identifier (expected 'owner/name'): {log_safe(repo)!r}"
+        )
+    return quote(repo, safe="/")
+
+
+def _validate_sha(sha: str) -> str:
+    """Validate hex SHA and return URL-quoted form."""
+    if not _SHA_RE.match(sha):
+        raise ValueError(f"Invalid git SHA: {log_safe(sha)!r}")
+    return quote(sha, safe="")
+
+
+def _validate_ref(ref: str) -> str:
+    """Validate git ref shape and return URL-quoted form.
+
+    Note: refs can legitimately contain `/` (e.g. `heads/main`,
+    `tags/v1.0`), so we keep `/` unencoded.
+    """
+    if (
+        not _REF_RE.match(ref)
+        or ".." in ref
+        or ref.startswith("-")
+        or ref.startswith("/")
+        or ref.endswith("/")
+    ):
+        raise ValueError(f"Invalid git ref: {log_safe(ref)!r}")
+    return quote(ref, safe="/")
+
+
+def _validate_org(org: str) -> str:
+    """Validate GitHub org/user login shape and return URL-quoted form."""
+    if not _ORG_RE.match(org):
+        raise ValueError(
+            f"Invalid GitHub organization/user login: {log_safe(org)!r}"
+        )
+    return quote(org, safe="")
 
 
 # =============================================================================
@@ -428,11 +509,14 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/trees/{sha}"
+        # GitHub's GET /repos/.../git/trees/{tree_sha} accepts a SHA *or*
+        # a ref name (branch/tag) here; use the ref validator since its
+        # char set is a superset of hex.
+        endpoint = f"/repos/{_validate_repo(repo)}/git/trees/{_validate_ref(sha)}"
         if recursive:
             endpoint += "?recursive=1"
 
-        logger.debug(f"Fetching tree: {repo} @ {sha} (recursive={recursive})")
+        logger.debug(f"Fetching tree: {log_safe(repo)} @ {log_safe(sha)} (recursive={recursive})")
 
         data = await self._request("GET", endpoint)
         tree = GitHubTree.model_validate(data)
@@ -459,8 +543,8 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/commits/{sha}"
-        logger.debug(f"Fetching commit: {repo} @ {sha}")
+        endpoint = f"/repos/{_validate_repo(repo)}/git/commits/{_validate_sha(sha)}"
+        logger.debug(f"Fetching commit: {log_safe(repo)} @ {log_safe(sha)}")
 
         data = await self._request("GET", endpoint)
         return GitHubCommit.model_validate(data)
@@ -483,8 +567,8 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/blobs/{sha}"
-        logger.debug(f"Fetching blob: {repo} @ {sha}")
+        endpoint = f"/repos/{_validate_repo(repo)}/git/blobs/{_validate_sha(sha)}"
+        logger.debug(f"Fetching blob: {log_safe(repo)} @ {log_safe(sha)}")
 
         data = await self._request("GET", endpoint)
         blob = GitHubBlob.model_validate(data)
@@ -511,8 +595,8 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/blobs"
-        logger.debug(f"Creating blob in {repo} ({len(content)} bytes)")
+        endpoint = f"/repos/{_validate_repo(repo)}/git/blobs"
+        logger.debug(f"Creating blob in {log_safe(repo)} ({len(content)} bytes)")
 
         data = await self._request(
             "POST",
@@ -550,8 +634,8 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/trees"
-        logger.debug(f"Creating tree in {repo} with {len(tree_items)} items")
+        endpoint = f"/repos/{_validate_repo(repo)}/git/trees"
+        logger.debug(f"Creating tree in {log_safe(repo)} with {len(tree_items)} items")
 
         # Build tree array for API
         tree_array = []
@@ -608,8 +692,8 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/commits"
-        logger.debug(f"Creating commit in {repo}")
+        endpoint = f"/repos/{_validate_repo(repo)}/git/commits"
+        logger.debug(f"Creating commit in {log_safe(repo)}")
 
         request_data: dict = {
             "message": message,
@@ -646,8 +730,8 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/ref/{ref}"
-        logger.debug(f"Fetching ref: {repo} @ {ref}")
+        endpoint = f"/repos/{_validate_repo(repo)}/git/ref/{_validate_ref(ref)}"
+        logger.debug(f"Fetching ref: {log_safe(repo)} @ {log_safe(ref)}")
 
         data = await self._request("GET", endpoint)
         ref_obj = GitHubRef.model_validate(data)
@@ -672,8 +756,8 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/git/refs/{ref}"
-        logger.debug(f"Updating ref: {repo} @ {ref} -> {sha[:8]}")
+        endpoint = f"/repos/{_validate_repo(repo)}/git/refs/{_validate_ref(ref)}"
+        logger.debug(f"Updating ref: {log_safe(repo)} @ {log_safe(ref)} -> {_validate_sha(sha)[:8]}")
 
         await self._request(
             "PATCH",
@@ -756,15 +840,17 @@ class GitHubAPIClient:
         Raises:
             GitHubAPIError: On API errors
         """
-        endpoint = f"/repos/{repo}/commits"
+        endpoint = f"/repos/{_validate_repo(repo)}/commits"
         params = []
 
         if sha:
-            params.append(f"sha={sha}")
+            # `sha` here can be a branch name or a commit SHA; the ref
+            # validator covers both shapes safely.
+            params.append(f"sha={_validate_ref(sha)}")
         if per_page != 30:
-            params.append(f"per_page={per_page}")
+            params.append(f"per_page={int(per_page)}")
         if page != 1:
-            params.append(f"page={page}")
+            params.append(f"page={int(page)}")
 
         if params:
             endpoint += "?" + "&".join(params)
@@ -848,7 +934,7 @@ class GitHubAPIClient:
         """
         logger.debug(f"Listing branches for {log_safe(repo)}")
 
-        endpoint = f"/repos/{repo}/branches?per_page=100"
+        endpoint = f"/repos/{_validate_repo(repo)}/branches?per_page=100"
         data = await self._request("GET", endpoint)
 
         branches = []
@@ -895,7 +981,7 @@ class GitHubAPIClient:
         }
 
         if organization:
-            endpoint = f"/orgs/{organization}/repos"
+            endpoint = f"/orgs/{_validate_org(organization)}/repos"
         else:
             endpoint = "/user/repos"
 

--- a/api/tests/unit/services/test_github_api.py
+++ b/api/tests/unit/services/test_github_api.py
@@ -326,9 +326,9 @@ class TestGetBlobContent:
         encoded = base64.b64encode(content).decode("ascii")
 
         api_response = {
-            "sha": "blob-sha",
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "size": len(content),
-            "url": "https://api.github.com/repos/owner/repo/git/blobs/blob-sha",
+            "url": "https://api.github.com/repos/owner/repo/git/blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "content": encoded,
             "encoding": "base64",
         }
@@ -336,11 +336,11 @@ class TestGetBlobContent:
         with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = api_response
 
-            result = await client.get_blob_content("owner/repo", "blob-sha")
+            result = await client.get_blob_content("owner/repo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
             assert result == content
             mock_request.assert_called_once_with(
-                "GET", "/repos/owner/repo/git/blobs/blob-sha"
+                "GET", "/repos/owner/repo/git/blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             )
 
     @pytest.mark.asyncio
@@ -352,9 +352,9 @@ class TestGetBlobContent:
         encoded_with_newlines = "\n".join([encoded[i : i + 10] for i in range(0, len(encoded), 10)])
 
         api_response = {
-            "sha": "blob-sha",
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "size": len(content),
-            "url": "https://api.github.com/repos/owner/repo/git/blobs/blob-sha",
+            "url": "https://api.github.com/repos/owner/repo/git/blobs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "content": encoded_with_newlines,
             "encoding": "base64",
         }
@@ -362,7 +362,7 @@ class TestGetBlobContent:
         with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = api_response
 
-            result = await client.get_blob_content("owner/repo", "blob-sha")
+            result = await client.get_blob_content("owner/repo", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
             assert result == content
 
@@ -382,8 +382,8 @@ class TestCreateBlob:
         encoded = base64.b64encode(content).decode("ascii")
 
         api_response = {
-            "sha": "new-blob-sha",
-            "url": "https://api.github.com/repos/owner/repo/git/blobs/new-blob-sha",
+            "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "url": "https://api.github.com/repos/owner/repo/git/blobs/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         }
 
         with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
@@ -391,7 +391,7 @@ class TestCreateBlob:
 
             result = await client.create_blob("owner/repo", content)
 
-            assert result == "new-blob-sha"
+            assert result == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             mock_request.assert_called_once_with(
                 "POST",
                 "/repos/owner/repo/git/blobs",
@@ -485,8 +485,8 @@ class TestCreateCommit:
     async def test_creates_commit(self, client):
         """Test creating a commit."""
         api_response = {
-            "sha": "new-commit-sha",
-            "url": "https://api.github.com/repos/owner/repo/git/commits/new-commit-sha",
+            "sha": "dddddddddddddddddddddddddddddddddddddddd",
+            "url": "https://api.github.com/repos/owner/repo/git/commits/dddddddddddddddddddddddddddddddddddddddd",
             "tree": {"sha": "tree-sha", "url": "tree-url"},
             "parents": [{"sha": "parent-sha", "url": "parent-url"}],
             "author": {"name": "Test", "email": "test@example.com", "date": "2024-01-08T00:00:00Z"},
@@ -504,7 +504,7 @@ class TestCreateCommit:
                 parents=["parent-sha"],
             )
 
-            assert result == "new-commit-sha"
+            assert result == "dddddddddddddddddddddddddddddddddddddddd"
             mock_request.assert_called_once_with(
                 "POST",
                 "/repos/owner/repo/git/commits",
@@ -519,8 +519,8 @@ class TestCreateCommit:
     async def test_creates_commit_with_author(self, client):
         """Test creating a commit with custom author."""
         api_response = {
-            "sha": "new-commit-sha",
-            "url": "https://api.github.com/repos/owner/repo/git/commits/new-commit-sha",
+            "sha": "dddddddddddddddddddddddddddddddddddddddd",
+            "url": "https://api.github.com/repos/owner/repo/git/commits/dddddddddddddddddddddddddddddddddddddddd",
             "tree": {"sha": "tree-sha", "url": "tree-url"},
             "parents": [],
             "author": {"name": "Custom", "email": "custom@example.com", "date": "2024-01-08T00:00:00Z"},
@@ -559,9 +559,9 @@ class TestGetRef:
             "ref": "refs/heads/main",
             "url": "https://api.github.com/repos/owner/repo/git/refs/heads/main",
             "object": {
-                "sha": "commit-sha",
+                "sha": "cccccccccccccccccccccccccccccccccccccccc",
                 "type": "commit",
-                "url": "https://api.github.com/repos/owner/repo/git/commits/commit-sha",
+                "url": "https://api.github.com/repos/owner/repo/git/commits/cccccccccccccccccccccccccccccccccccccccc",
             },
         }
 
@@ -570,7 +570,7 @@ class TestGetRef:
 
             result = await client.get_ref("owner/repo", "heads/main")
 
-            assert result == "commit-sha"
+            assert result == "cccccccccccccccccccccccccccccccccccccccc"
             mock_request.assert_called_once_with(
                 "GET", "/repos/owner/repo/git/ref/heads/main"
             )
@@ -591,22 +591,22 @@ class TestUpdateRef:
             "ref": "refs/heads/main",
             "url": "https://api.github.com/repos/owner/repo/git/refs/heads/main",
             "object": {
-                "sha": "new-commit-sha",
+                "sha": "dddddddddddddddddddddddddddddddddddddddd",
                 "type": "commit",
-                "url": "https://api.github.com/repos/owner/repo/git/commits/new-commit-sha",
+                "url": "https://api.github.com/repos/owner/repo/git/commits/dddddddddddddddddddddddddddddddddddddddd",
             },
         }
 
         with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = api_response
 
-            await client.update_ref("owner/repo", "heads/main", "new-commit-sha")
+            await client.update_ref("owner/repo", "heads/main", "dddddddddddddddddddddddddddddddddddddddd")
 
             mock_request.assert_called_once_with(
                 "PATCH",
                 "/repos/owner/repo/git/refs/heads/main",
                 json_data={
-                    "sha": "new-commit-sha",
+                    "sha": "dddddddddddddddddddddddddddddddddddddddd",
                     "force": False,
                 },
             )
@@ -618,16 +618,16 @@ class TestUpdateRef:
             "ref": "refs/heads/main",
             "url": "https://api.github.com/repos/owner/repo/git/refs/heads/main",
             "object": {
-                "sha": "new-commit-sha",
+                "sha": "dddddddddddddddddddddddddddddddddddddddd",
                 "type": "commit",
-                "url": "https://api.github.com/repos/owner/repo/git/commits/new-commit-sha",
+                "url": "https://api.github.com/repos/owner/repo/git/commits/dddddddddddddddddddddddddddddddddddddddd",
             },
         }
 
         with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = api_response
 
-            await client.update_ref("owner/repo", "heads/main", "new-commit-sha", force=True)
+            await client.update_ref("owner/repo", "heads/main", "dddddddddddddddddddddddddddddddddddddddd", force=True)
 
             call_args = mock_request.call_args
             json_data = call_args[1]["json_data"]
@@ -657,20 +657,20 @@ class TestHighLevelHelpers:
     async def test_update_branch(self, client):
         """Test update_branch convenience method."""
         with patch.object(client, "update_ref", new_callable=AsyncMock) as mock_update_ref:
-            await client.update_branch("owner/repo", "main", "new-sha")
+            await client.update_branch("owner/repo", "main", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
 
             mock_update_ref.assert_called_once_with(
-                "owner/repo", "heads/main", "new-sha", force=False
+                "owner/repo", "heads/main", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", force=False
             )
 
     @pytest.mark.asyncio
     async def test_update_branch_with_force(self, client):
         """Test update_branch with force flag."""
         with patch.object(client, "update_ref", new_callable=AsyncMock) as mock_update_ref:
-            await client.update_branch("owner/repo", "main", "new-sha", force=True)
+            await client.update_branch("owner/repo", "main", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", force=True)
 
             mock_update_ref.assert_called_once_with(
-                "owner/repo", "heads/main", "new-sha", force=True
+                "owner/repo", "heads/main", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", force=True
             )
 
 
@@ -686,8 +686,8 @@ class TestGetCommit:
     async def test_gets_commit(self, client):
         """Test getting a commit."""
         api_response = {
-            "sha": "commit-sha",
-            "url": "https://api.github.com/repos/owner/repo/git/commits/commit-sha",
+            "sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "url": "https://api.github.com/repos/owner/repo/git/commits/cccccccccccccccccccccccccccccccccccccccc",
             "tree": {"sha": "tree-sha", "url": "tree-url"},
             "parents": [{"sha": "parent-sha", "url": "parent-url"}],
             "author": {"name": "Author", "email": "author@example.com", "date": "2024-01-08T00:00:00Z"},
@@ -698,9 +698,9 @@ class TestGetCommit:
         with patch.object(client, "_request", new_callable=AsyncMock) as mock_request:
             mock_request.return_value = api_response
 
-            result = await client.get_commit("owner/repo", "commit-sha")
+            result = await client.get_commit("owner/repo", "cccccccccccccccccccccccccccccccccccccccc")
 
-            assert result.sha == "commit-sha"
+            assert result.sha == "cccccccccccccccccccccccccccccccccccccccc"
             assert result.tree.sha == "tree-sha"
             assert len(result.parents) == 1
             assert result.parents[0].sha == "parent-sha"
@@ -708,7 +708,7 @@ class TestGetCommit:
             assert result.author.name == "Author"
 
             mock_request.assert_called_once_with(
-                "GET", "/repos/owner/repo/git/commits/commit-sha"
+                "GET", "/repos/owner/repo/git/commits/cccccccccccccccccccccccccccccccccccccccc"
             )
 
 
@@ -812,8 +812,8 @@ class TestListCommits:
         """Test listing commits for a specific branch."""
         api_response = [
             {
-                "sha": "commit-sha",
-                "url": "https://api.github.com/repos/owner/repo/commits/commit-sha",
+                "sha": "cccccccccccccccccccccccccccccccccccccccc",
+                "url": "https://api.github.com/repos/owner/repo/commits/cccccccccccccccccccccccccccccccccccccccc",
                 "commit": {
                     "message": "Commit on feature branch",
                     "author": {"name": "Author", "email": "author@example.com", "date": "2024-01-08T00:00:00Z"},
@@ -883,3 +883,176 @@ class TestTreeItem:
 
         assert item.path == "deleted.py"
         assert item.sha is None
+
+
+class TestPathSegmentValidators:
+    """Tests for the path-segment validators that close py/partial-ssrf (#217).
+
+    These validators sit between user input (router query params) and
+    f-string-built GitHub API URLs. They enforce shape *and* return a
+    quote()-cleansed value so CodeQL recognizes the data flow as
+    sanitized.
+    """
+
+    def test_validate_repo_accepts_simple_owner_name(self):
+        from src.services.github_api import _validate_repo
+
+        assert _validate_repo("octocat/Hello-World") == "octocat/Hello-World"
+
+    def test_validate_repo_preserves_separator_slash(self):
+        from src.services.github_api import _validate_repo
+
+        # The single owner/name slash must remain unencoded so the URL
+        # still parses to the right path. The validator uses quote(safe="/").
+        result = _validate_repo("a.b_c-d/e.f_g-h")
+        assert result == "a.b_c-d/e.f_g-h"
+        assert "%2F" not in result
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../../etc/passwd",
+            "owner/../etc",
+            "owner/repo/extra",  # too many segments
+            "owner",  # no slash
+            "/owner/repo",  # leading slash
+            "owner/repo/",  # trailing slash
+            "owner/repo;@evil.com",
+            "owner/repo space",
+            "owner/repo?query=1",
+            "owner/repo#frag",
+            "owner/repo:8080",
+            "..",
+            "",
+        ],
+    )
+    def test_validate_repo_rejects_unsafe(self, bad):
+        from src.services.github_api import _validate_repo
+
+        with pytest.raises(ValueError, match="Invalid GitHub repo"):
+            _validate_repo(bad)
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "abc1234",  # 7-char abbreviated
+            "abc1234abc1234abc1234abc1234abc1234abcd",  # 40-char SHA-1
+            "0" * 64,  # 64-char SHA-256
+            "DEADBEEFCAFE" * 4 + "abcd",  # mixed case still hex
+        ],
+    )
+    def test_validate_sha_accepts_hex(self, good):
+        from src.services.github_api import _validate_sha
+
+        assert _validate_sha(good) == good
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "abc",  # too short
+            "g" * 40,  # non-hex
+            "abc1234..xyz",
+            "/abc1234",
+            "abc1234/branch",
+            "",
+        ],
+    )
+    def test_validate_sha_rejects_unsafe(self, bad):
+        from src.services.github_api import _validate_sha
+
+        with pytest.raises(ValueError, match="Invalid git SHA"):
+            _validate_sha(bad)
+
+    def test_validate_ref_accepts_branch_and_tag_paths(self):
+        from src.services.github_api import _validate_ref
+
+        assert _validate_ref("main") == "main"
+        assert _validate_ref("heads/main") == "heads/main"
+        assert _validate_ref("tags/v1.0.0") == "tags/v1.0.0"
+        assert _validate_ref("feature/foo-bar") == "feature/foo-bar"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../escape",
+            "main/../etc",
+            "-flag",
+            "/leading-slash",
+            "trailing-slash/",
+            "name with space",
+            "name?query",
+            "name#frag",
+            "name@{0}",  # git ref reflog suffix
+            "",
+        ],
+    )
+    def test_validate_ref_rejects_unsafe(self, bad):
+        from src.services.github_api import _validate_ref
+
+        with pytest.raises(ValueError, match="Invalid git ref"):
+            _validate_ref(bad)
+
+    @pytest.mark.parametrize(
+        "good",
+        ["octocat", "github", "a", "a-b-c", "Org123"],
+    )
+    def test_validate_org_accepts_logins(self, good):
+        from src.services.github_api import _validate_org
+
+        assert _validate_org(good) == good
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "-leading-dash",
+            "has space",
+            "has/slash",
+            "has.dot",
+            "has_underscore",
+            "x" * 40,  # too long
+            "",
+        ],
+    )
+    def test_validate_org_rejects_unsafe(self, bad):
+        from src.services.github_api import _validate_org
+
+        with pytest.raises(ValueError, match="Invalid GitHub organization"):
+            _validate_org(bad)
+
+    def test_validators_use_quote_for_codeql_sanitizer_recognition(self):
+        """Regression guard for #217.
+
+        Each validator must call urllib.parse.quote() on its return value.
+        CodeQL's py/partial-ssrf sanitizer model recognizes quote() return
+        as cleansed input — without it, the data-flow path from router
+        query params to httpx.AsyncClient.request(url=...) re-opens.
+
+        A future refactor that drops quote() would close this test AND
+        silently re-introduce the SSRF alert.
+        """
+        import ast
+        import inspect
+
+        from src.services import github_api
+
+        for name in ("_validate_repo", "_validate_sha", "_validate_ref", "_validate_org"):
+            fn = getattr(github_api, name)
+            src = inspect.getsource(fn)
+            tree = ast.parse(src.lstrip())
+            func = tree.body[0]
+            assert isinstance(func, ast.FunctionDef)
+
+            return_stmts = [n for n in ast.walk(func) if isinstance(n, ast.Return)]
+            assert return_stmts, f"{name} must have a return statement"
+
+            # Final return must be a call to quote() — CodeQL only sees
+            # quote()'s return as cleansed, not raw f-string concatenation.
+            final_return = return_stmts[-1]
+            assert isinstance(final_return.value, ast.Call), (
+                f"{name} final return must call quote()"
+            )
+            callee = final_return.value.func
+            assert isinstance(callee, ast.Name) and callee.id == "quote", (
+                f"{name} final return must call quote() — see #217 for why "
+                f"raw value passthrough re-opens py/partial-ssrf. Got: {callee}"
+            )


### PR DESCRIPTION
## Summary

Local CodeQL scan flagged `api/src/services/github_api.py:344` (`_request` HTTP sink) for `py/partial-ssrf` (security-severity **critical**). Same data-flow class as #216, but the alert is not yet in the GitHub Security tab — surfaced from a follow-up scan during #213's empirical verification.

The single CodeQL hit was the tip of a class issue: 11 call sites in `github_api.py` interpolate user-controlled identifiers (`repo`, `sha`, `ref`, `organization`) into URL paths.

## Fix

Adds per-identifier shape validators that enforce GitHub's documented shapes and route values through `urllib.parse.quote()`:

| Validator | Pattern | Used at |
|---|---|---|
| `_validate_repo` | `owner/name`, alphanumeric + `._-`, no `..` | 9 call sites |
| `_validate_sha` | 7–64 lowercase hex | `get_blob_content`, `get_commit`, `update_ref` |
| `_validate_ref` | branch/tag-safe (superset of hex) | `get_tree`, `get_ref`, `update_ref`, `list_commits(sha=...)` |
| `_validate_org` | GitHub login (alnum + dash, no leading dash, ≤39) | `create_repository` |

CodeQL's `py/partial-ssrf` sanitizer model recognizes `quote()` return values as cleansed input — same approach as #216's `urlunparse()` switch.

## Empirical verification

```
$ codeql database analyze ... PartialServerSideRequestForgery.ql
Before: py/partial-ssrf flags github_api.py:344
After:  zero py/partial-ssrf hits in api/
```

Verified with codeql v2.25.4 + python-queries@1.8.2 against this worktree.

This proactively closes the 10 latent SSRF paths CodeQL hadn't yet flagged, in addition to the one it had.

## Notes for review

- `get_tree(sha=...)` accepts a SHA *or* a ref per GitHub's docs ("The SHA1 value or ref (branch or tag) name of the tree"), so that one call site uses `_validate_ref` instead of `_validate_sha`. Tests cover both modes.
- Existing tests passed unrealistic fixtures like `"blob-sha"` and `"new-commit-sha"`. Those were lazy and the new strict-SHA validator correctly rejects them — fixed up to use full 40-char hex strings.
- The new `TestPathSegmentValidators` class includes 45 parametrized accept/reject cases plus an AST-shape regression guard that pins `quote()` in each validator's return statement. A future refactor that drops `quote()` would break tests, not silently re-introduce the SSRF.

## Test plan

- [x] `./test.sh tests/unit/services/test_github_api.py` (89 passing — 45 new validator tests + 44 updated/preserved API tests)
- [x] `ruff check` clean on edited files
- [x] Local CodeQL re-scan shows zero `py/partial-ssrf` hits
- [ ] CI: lint + type-check + unit + e2e
- [ ] CodeQL on main: alert closes (or, if it never made it to the GitHub UI, the proactive fix lands before it would have)

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)