### PR TITLE
fix(agents): roll up chat conversations into agent stats

### DIFF
--- a/api/src/services/agent_stats.py
+++ b/api/src/services/agent_stats.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.contracts.agent_stats import AgentStatsResponse, FleetStatsResponse
 from src.models.orm.agent_runs import AgentRun
-from src.models.orm.agents import Agent
+from src.models.orm.agents import Agent, Conversation
 from src.models.orm.ai_usage import AIUsage
 
 
@@ -24,6 +24,18 @@ async def get_agent_stats(
     timestamp, a per-day bucket histogram, and verdict-derived review
     counts. ``runs_by_day`` is oldest-first (index 0 = ``window_days`` days
     ago, index ``-1`` = today).
+
+    Chat-channel rollup (issue #200): the chat executor doesn't write
+    ``AgentRun`` rows — its ``AIUsage`` rows are tagged with
+    ``conversation_id`` only. To keep dashboard cards honest for chat
+    agents, this also counts each ``Conversation`` (windowed on
+    ``updated_at``) as one run and adds chat ``AIUsage.cost`` (windowed on
+    ``timestamp``, since cost is incurred at LLM-call time) to
+    ``total_cost_7d``. Fields without a chat-side analog
+    (``success_rate``, ``avg_duration_ms``, ``runs_by_day``,
+    ``needs_review``, ``unreviewed``) intentionally stay keyed on
+    ``AgentRun`` only — the deferred "tuning + chat conversations"
+    follow-up will revisit those.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
     runs_q = select(AgentRun).where(
@@ -61,6 +73,41 @@ async def get_agent_stats(
         total_cost if isinstance(total_cost, Decimal) else Decimal(total_cost)
     )
 
+    # Chat-channel rollup. Both queries hit ix_conversations_agent_id +
+    # ix_ai_usage_conversation; the cost query also benefits from
+    # ix_ai_usage_timestamp.
+    chat_count_q = select(func.count(Conversation.id)).where(
+        Conversation.agent_id == agent_id,
+        Conversation.updated_at >= cutoff,
+    )
+    chat_runs_count = (await db.execute(chat_count_q)).scalar() or 0
+
+    chat_cost_q = (
+        select(func.coalesce(func.sum(AIUsage.cost), 0))
+        .join(Conversation, Conversation.id == AIUsage.conversation_id)
+        .where(
+            Conversation.agent_id == agent_id,
+            AIUsage.timestamp >= cutoff,
+        )
+    )
+    chat_cost = (await db.execute(chat_cost_q)).scalar() or Decimal("0")
+    chat_cost_decimal = (
+        chat_cost if isinstance(chat_cost, Decimal) else Decimal(chat_cost)
+    )
+
+    last_chat_q = select(func.max(Conversation.updated_at)).where(
+        Conversation.agent_id == agent_id,
+        Conversation.updated_at >= cutoff,
+    )
+    last_chat_at = (await db.execute(last_chat_q)).scalar()
+
+    runs_count += chat_runs_count
+    total_cost_decimal += chat_cost_decimal
+    if last_chat_at is not None:
+        last_run_at = (
+            last_chat_at if last_run_at is None else max(last_run_at, last_chat_at)
+        )
+
     return AgentStatsResponse(
         agent_id=agent_id,
         runs_7d=runs_count,
@@ -86,6 +133,12 @@ async def get_fleet_stats(
 
     Optionally scoped to a single organization (org_id=None means
     cross-org, only allowed for superusers — the router enforces that).
+
+    Chat-channel rollup mirrors :func:`get_agent_stats`: each
+    ``Conversation`` updated in window counts as one run, and chat
+    ``AIUsage`` cost (windowed on ``AIUsage.timestamp``) is added to the
+    fleet spend. ``avg_success_rate`` stays keyed on ``AgentRun`` only —
+    there is no "success" concept on a chat conversation.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=window_days)
 
@@ -131,10 +184,33 @@ async def get_fleet_stats(
         total_cost if isinstance(total_cost, Decimal) else Decimal(total_cost)
     )
 
+    # Chat-channel rollup. Org scope is via the conversation's agent.
+    chat_conv_q = (
+        select(func.count(Conversation.id))
+        .join(Agent, Agent.id == Conversation.agent_id)
+        .where(Conversation.updated_at >= cutoff)
+    )
+    if org_id is not None:
+        chat_conv_q = chat_conv_q.where(Agent.organization_id == org_id)
+    chat_runs = (await db.execute(chat_conv_q)).scalar() or 0
+
+    chat_cost_q = (
+        select(func.coalesce(func.sum(AIUsage.cost), 0))
+        .join(Conversation, Conversation.id == AIUsage.conversation_id)
+        .join(Agent, Agent.id == Conversation.agent_id)
+        .where(AIUsage.timestamp >= cutoff)
+    )
+    if org_id is not None:
+        chat_cost_q = chat_cost_q.where(Agent.organization_id == org_id)
+    chat_cost = (await db.execute(chat_cost_q)).scalar() or Decimal("0")
+    chat_cost_decimal = (
+        chat_cost if isinstance(chat_cost, Decimal) else Decimal(chat_cost)
+    )
+
     return FleetStatsResponse(
-        total_runs=total_runs,
+        total_runs=total_runs + chat_runs,
         avg_success_rate=(completed / total_runs) if total_runs else 0.0,
-        total_cost_7d=total_cost_decimal,
+        total_cost_7d=total_cost_decimal + chat_cost_decimal,
         active_agents=active_agents,
         needs_review=needs_review,
     )

--- a/api/tests/unit/test_agent_stats_service.py
+++ b/api/tests/unit/test_agent_stats_service.py
@@ -9,7 +9,7 @@ from sqlalchemy import delete
 
 from src.models.enums import AgentAccessLevel
 from src.models.orm.agent_runs import AgentRun
-from src.models.orm.agents import Agent
+from src.models.orm.agents import Agent, Conversation
 from src.models.orm.ai_usage import AIUsage
 from src.services.agent_stats import get_agent_stats, get_fleet_stats
 
@@ -205,3 +205,246 @@ async def test_summarizer_cost_is_included_in_total_cost_7d(
     await db_session.execute(delete(AIUsage).where(AIUsage.agent_run_id == run.id))
     await db_session.execute(delete(AgentRun).where(AgentRun.id == run.id))
     await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Chat-channel rollup (issue #200)
+#
+# Chat agents don't write AgentRun rows — their AIUsage rows are tagged with
+# conversation_id only. Without a chat-aware rollup, every dashboard card on
+# a chat agent shows zero. These tests pin the per-conversation count and
+# cost-via-conversation sum so the cards stop lying.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seed_chat_conversations_for_agent(db_session, seed_agent, seed_user):
+    """Two conversations on `seed_agent`, each with an AIUsage row.
+
+    One conversation is recent (updated today); the other was updated 4 days
+    ago. Both fall inside the 7-day window so they count toward the rollup.
+    """
+    now = datetime.now(timezone.utc)
+    convs = []
+    usages = []
+
+    # Recent conversation, two AIUsage rows (multi-message)
+    c1 = Conversation(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        user_id=seed_user.id,
+        channel="chat",
+        is_active=True,
+        created_at=now - timedelta(days=1),
+        updated_at=now,
+    )
+    db_session.add(c1)
+    await db_session.flush()
+    convs.append(c1)
+    for cost in (Decimal("0.02"), Decimal("0.03")):
+        u = AIUsage(
+            conversation_id=c1.id,
+            organization_id=None,
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=100,
+            output_tokens=50,
+            cost=cost,
+            timestamp=now,
+        )
+        db_session.add(u)
+        usages.append(u)
+
+    # Older conversation, one AIUsage row
+    c2 = Conversation(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        user_id=seed_user.id,
+        channel="chat",
+        is_active=True,
+        created_at=now - timedelta(days=5),
+        updated_at=now - timedelta(days=4),
+    )
+    db_session.add(c2)
+    await db_session.flush()
+    convs.append(c2)
+    u = AIUsage(
+        conversation_id=c2.id,
+        organization_id=None,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        input_tokens=80,
+        output_tokens=40,
+        cost=Decimal("0.05"),
+        timestamp=now - timedelta(days=4),
+    )
+    db_session.add(u)
+    usages.append(u)
+
+    await db_session.commit()
+    yield {"conversations": convs, "usages": usages}
+
+    for u in usages:
+        await db_session.execute(delete(AIUsage).where(AIUsage.id == u.id))
+    for c in convs:
+        await db_session.execute(delete(Conversation).where(Conversation.id == c.id))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_per_agent_stats_counts_chat_conversations(
+    db_session, seed_agent, seed_chat_conversations_for_agent
+):
+    """Chat agent with no AgentRun rows still reports non-zero runs_7d.
+
+    A run for a chat agent is one Conversation. The fixture seeds two
+    conversations, so runs_7d should be 2.
+    """
+    stats = await get_agent_stats(seed_agent.id, db_session, window_days=7)
+    assert stats.runs_7d == 2, (
+        f"Expected 2 conversations counted as runs, got {stats.runs_7d}. "
+        "If this is 0, the chat-channel rollup is missing — chat agents "
+        "will continue to display RUNS 0 on the dashboard."
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_agent_stats_sums_chat_ai_usage_cost(
+    db_session, seed_agent, seed_chat_conversations_for_agent
+):
+    """Chat agent total_cost_7d sums AIUsage.cost via conversation_id.
+
+    The fixture seeds 0.02 + 0.03 + 0.05 = 0.10 inside the 7-day window.
+    """
+    stats = await get_agent_stats(seed_agent.id, db_session, window_days=7)
+    assert stats.total_cost_7d == Decimal("0.10"), (
+        f"Expected 0.10 (sum of chat AIUsage.cost), got {stats.total_cost_7d}. "
+        "Chat-channel cost is being silently dropped from the Spend (7d) card."
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_agent_stats_chat_last_run_at_uses_conversation_updated_at(
+    db_session, seed_agent, seed_chat_conversations_for_agent
+):
+    """last_run_at for a chat agent is max(Conversation.updated_at).
+
+    The fixture seeds one conversation updated today and one updated 4 days
+    ago. last_run_at should be ~now (within 1 minute).
+    """
+    stats = await get_agent_stats(seed_agent.id, db_session, window_days=7)
+    assert stats.last_run_at is not None
+    drift = abs((datetime.now(timezone.utc) - stats.last_run_at).total_seconds())
+    assert drift < 60, (
+        f"last_run_at drifted {drift}s from now; expected ~0s. "
+        "Chat agent's last_run_at should track the most-recent "
+        "Conversation.updated_at, not Conversation.created_at."
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_agent_stats_chat_window_excludes_old_conversations(
+    db_session, seed_agent, seed_user
+):
+    """Conversations updated outside the window don't count toward runs_7d.
+
+    Window is on Conversation.updated_at (matches the "active recently"
+    semantic chosen for #200). An ancient conversation must not pollute
+    the count even if it has fresh AIUsage rows from a re-summarize or
+    historical re-pull.
+    """
+    now = datetime.now(timezone.utc)
+    ancient = Conversation(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        user_id=seed_user.id,
+        channel="chat",
+        is_active=True,
+        created_at=now - timedelta(days=30),
+        updated_at=now - timedelta(days=30),
+    )
+    db_session.add(ancient)
+    await db_session.flush()
+    await db_session.commit()
+
+    try:
+        stats = await get_agent_stats(seed_agent.id, db_session, window_days=7)
+        assert stats.runs_7d == 0, (
+            f"Conversation outside the 7d window must not count, got runs_7d={stats.runs_7d}. "
+            "Window-on-updated_at semantics are not being applied."
+        )
+    finally:
+        await db_session.execute(
+            delete(Conversation).where(Conversation.id == ancient.id)
+        )
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_per_agent_stats_chat_cost_window_uses_ai_usage_timestamp(
+    db_session, seed_agent, seed_user
+):
+    """total_cost_7d windows on AIUsage.timestamp, not Conversation.updated_at.
+
+    A conversation updated yesterday but with an AIUsage row stamped 30
+    days ago should NOT have that ancient cost in the 7d card. Runs count
+    on conversation lifecycle; cost counts on when money was actually spent.
+    """
+    now = datetime.now(timezone.utc)
+    conv = Conversation(
+        id=uuid4(),
+        agent_id=seed_agent.id,
+        user_id=seed_user.id,
+        channel="chat",
+        is_active=True,
+        created_at=now - timedelta(days=30),
+        updated_at=now - timedelta(days=1),  # in window
+    )
+    db_session.add(conv)
+    await db_session.flush()
+
+    ancient_usage = AIUsage(
+        conversation_id=conv.id,
+        organization_id=None,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        input_tokens=100,
+        output_tokens=50,
+        cost=Decimal("0.99"),
+        timestamp=now - timedelta(days=30),  # outside window
+    )
+    db_session.add(ancient_usage)
+    await db_session.commit()
+
+    try:
+        stats = await get_agent_stats(seed_agent.id, db_session, window_days=7)
+        assert stats.total_cost_7d == Decimal("0"), (
+            f"Expected 0 (ancient AIUsage outside 7d window), got {stats.total_cost_7d}. "
+            "Cost is incurred at AIUsage time — window should be on AIUsage.timestamp, "
+            "not Conversation.updated_at."
+        )
+    finally:
+        await db_session.execute(delete(AIUsage).where(AIUsage.id == ancient_usage.id))
+        await db_session.execute(delete(Conversation).where(Conversation.id == conv.id))
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_fleet_stats_includes_chat_conversations(
+    db_session, seed_agent, seed_chat_conversations_for_agent
+):
+    """Fleet total_runs and total_cost_7d include chat-channel activity.
+
+    With 2 chat conversations on the seeded agent and no autonomous runs,
+    fleet total_runs must be ≥ 2 and total_cost_7d must include the chat
+    AIUsage cost (0.10).
+    """
+    s = await get_fleet_stats(db_session, org_id=None, window_days=7)
+    assert s.total_runs >= 2, (
+        f"Fleet total_runs={s.total_runs} excludes chat conversations. "
+        "RUNS (7D) card on the fleet dashboard will undercount."
+    )
+    assert s.total_cost_7d >= Decimal("0.10"), (
+        f"Fleet total_cost_7d={s.total_cost_7d} excludes chat AIUsage cost. "
+        "Fleet Spend card will undercount."
+    )


### PR DESCRIPTION
## Summary

- Per-agent and fleet stats cards reported `RUNS 0 / SPEND $0` for chat-channel agents because `get_agent_stats` / `get_fleet_stats` only counted `AgentRun` rows, which the chat executor never writes.
- Add a chat-channel rollup: each `Conversation` (windowed on `updated_at`) counts as one run, and `AIUsage.cost` joined via `conversation_id` (windowed on `AIUsage.timestamp`) is added to `total_cost_7d`. `last_run_at` picks the more-recent of the autonomous and chat sides.
- Other `AgentRun`-derived fields (`success_rate`, `avg_duration_ms`, `runs_by_day`, `needs_review`, `unreviewed`) intentionally stay autonomous-only. Those need a separate "tuning + chat conversations" follow-up — captured in the issue thread.

## Notes

- After this lands, the **Spend (7d)** card will jump on first deploy: chat usage that was previously $0 starts counting. This is the bug being fixed; not a regression.
- Both new queries hit existing indexes (`ix_conversations_agent_id`, `ix_ai_usage_conversation`, `ix_ai_usage_timestamp`).

## Test plan

- [x] New tests in `api/tests/unit/test_agent_stats_service.py`:
  - `test_per_agent_stats_counts_chat_conversations` — runs_7d includes conversation count
  - `test_per_agent_stats_sums_chat_ai_usage_cost` — total_cost_7d sums chat AIUsage
  - `test_per_agent_stats_chat_last_run_at_uses_conversation_updated_at`
  - `test_per_agent_stats_chat_window_excludes_old_conversations` — window-on-updated_at honored
  - `test_per_agent_stats_chat_cost_window_uses_ai_usage_timestamp` — distinct windowing for cost
  - `test_fleet_stats_includes_chat_conversations`
- [x] All 6 pre-existing `test_agent_stats_service.py` tests still pass (no autonomous-side regression).
- [x] Full unit suite green (3764 passed).
- [x] `pyright` clean on changed files; `ruff check` clean.

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)