### PR TITLE
test(docs): nav_via + goto_spa for SPA-routed captures

### DIFF
--- a/client/e2e/docs/capture.docs.spec.ts
+++ b/client/e2e/docs/capture.docs.spec.ts
@@ -109,6 +109,11 @@ async function runActions(
         await page.waitForTimeout(action.wait_ms);
       } else if ("scroll_into_view" in action) {
         await page.locator(action.scroll_into_view).scrollIntoViewIfNeeded();
+      } else if ("goto_spa" in action) {
+        await page.evaluate((path) => {
+          window.history.pushState({}, "", path);
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        }, action.goto_spa);
       } else {
         throw new Error(`unknown action shape: ${JSON.stringify(action)}`);
       }
@@ -238,11 +243,29 @@ if (!fs.existsSync(manifestPath)) {
           }
         }
 
-        const url = `${BASE_URL}${entry.route.startsWith("/") ? entry.route : "/" + entry.route}`;
-        await page.goto(url, {
-          waitUntil: "domcontentloaded",
-          timeout: 20000,
-        });
+        // Navigation. Default: hard page.goto to entry.route. If the entry
+        // declares nav_via, instead hard-load the `from` page (SPA shell)
+        // and click the named link to navigate via in-app routing — this
+        // sidesteps Vite proxy rules that prefix-match SPA paths in dev.
+        // Deeper destinations are reached afterward via the goto_spa action.
+        if (entry.nav_via) {
+          const fromUrl = `${BASE_URL}${entry.nav_via.from.startsWith("/") ? entry.nav_via.from : "/" + entry.nav_via.from}`;
+          await page.goto(fromUrl, {
+            waitUntil: "domcontentloaded",
+            timeout: 20000,
+          });
+          await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => undefined);
+          await page
+            .getByRole("link", { name: entry.nav_via.click, exact: true })
+            .first()
+            .click({ timeout: 10000 });
+        } else {
+          const url = `${BASE_URL}${entry.route.startsWith("/") ? entry.route : "/" + entry.route}`;
+          await page.goto(url, {
+            waitUntil: "domcontentloaded",
+            timeout: 20000,
+          });
+        }
         // Settle: wait for network idle, then a brief beat for animations.
         await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => undefined);
         await page.waitForTimeout(effectiveSettleMs(entry, manifest));

--- a/client/e2e/docs/manifest.ts
+++ b/client/e2e/docs/manifest.ts
@@ -48,7 +48,11 @@ export type ActionSpec =
   | { wait_for: string }
   | { wait_for_hidden: string }
   | { wait_ms: number }
-  | { scroll_into_view: string };
+  | { scroll_into_view: string }
+  // Push a path via the SPA's history without a hard reload. Use after a
+  // nav_via sidebar click to deep-link further (e.g. into /mcp-servers/<id>)
+  // without re-triggering Vite proxy rules that hard navigation would hit.
+  | { goto_spa: string };
 
 export interface CaptureSpec {
   selector?: string;
@@ -76,6 +80,12 @@ export interface ManifestEntry {
   seed?: string;
   viewport?: { width: number; height: number };
   capture?: CaptureSpec;
+  // Optional SPA navigation. When set, the spec navigates to `from` first,
+  // then clicks the named link/element to reach `route` via in-app routing.
+  // Use this for routes that share a prefix with a Vite proxy rule (e.g.
+  // /mcp-servers collides with the /mcp proxy in dev builds), where a hard
+  // page.goto() would be intercepted before the SPA can handle it.
+  nav_via?: { from: string; click: string };
   diataxis: Diataxis;
   source_globs?: string[];
   captured_at?: { bifrost_sha: string | null; timestamp: string | null } | null;


### PR DESCRIPTION
## Summary
Hard navigation to /mcp-servers/* in the test stack hits the Vite proxy /mcp rule (prefix match — production nginx is correctly anchored). This blocked capture for v0.9.0's MCP-client docs. Adds two manifest features that route captures through SPA navigation instead:

- `nav_via: { from, click }` — hard-load `from`, then click the named link to reach `route` via in-app routing. Used when the route shares a prefix with a Vite proxy rule.
- `goto_spa: <path>` action — push a path via the SPA's history. Used after `nav_via` to deep-link further (e.g. into /mcp-servers/<id>) without re-triggering proxy rules.

Used in production by the v0.9.0 MCP-client docs in the docs repo.

## Test plan
- [x] All 5 v0.9.0 MCP captures pass via the new path: mcp-external-servers-list, mcp-external-server-detail, mcp-external-connection-edit, mcp-agent-connections-panel, mcp-user-connections.
- [x] Existing captures unchanged (no nav_via field → original behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)