### PR TITLE
fix(llm): use max_completion_tokens for OpenAI test completion

### DIFF
--- a/api/src/services/llm_config_service.py
+++ b/api/src/services/llm_config_service.py
@@ -387,7 +387,7 @@ class LLMConfigService:
 
             await client.chat.completions.create(
                 model=model,
-                max_tokens=1,
+                max_completion_tokens=1,
                 messages=[{"role": "user", "content": "ping"}],
             )
             return LLMTestResult(

--- a/api/tests/unit/services/test_llm_config_service.py
+++ b/api/tests/unit/services/test_llm_config_service.py
@@ -452,6 +452,32 @@ class TestLLMConfigServiceTestConnection:
         assert "rejected a test completion" in result.message
         assert "insufficient_quota" in result.message
 
+    @pytest.mark.asyncio
+    async def test_complete_openai_uses_max_completion_tokens(self, mock_session):
+        """OpenAI test completion must send max_completion_tokens, not max_tokens.
+
+        Regression for #239: modern reasoning models (o1, o3, gpt-5.x) reject
+        the legacy `max_tokens` param with a 400. The newer
+        `max_completion_tokens` is accepted by all current OpenAI models.
+        """
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock()
+            mock_openai.return_value = mock_client
+
+            service = LLMConfigService(mock_session)
+            result = await service._complete_openai(
+                api_key="sk-test-key", model="gpt-5.4"
+            )
+
+        assert result.success is True
+        mock_client.chat.completions.create.assert_awaited_once()
+        await_args = mock_client.chat.completions.create.await_args
+        assert await_args is not None
+        assert "max_completion_tokens" in await_args.kwargs
+        assert "max_tokens" not in await_args.kwargs
+        assert await_args.kwargs["max_completion_tokens"] == 1
+
 
 class TestLLMConfigServiceListModels:
     """Test LLMConfigService list_models method."""


### PR DESCRIPTION
## Summary
- Fixes #239 — saving a modern OpenAI model (o1/o3/gpt-5.x) in Settings → AI failed because the test-completion call sent the legacy `max_tokens` parameter, which those models reject with a 400.
- Switches `LLMConfigService._complete_openai` to send `max_completion_tokens=1`. Per OpenAI's docs and SDK, `max_completion_tokens` is accepted by all current Chat Completions models (gpt-4o, gpt-4-turbo, gpt-3.5-turbo, o1, o3, gpt-5.x), so the change is unconditional.
- The real OpenAI client (`api/src/services/llm/openai_client.py`) already uses `max_completion_tokens` — this was an isolated regression in the config "Test" path.

## Test plan
- [x] New unit test asserts `_complete_openai` sends `max_completion_tokens` and not `max_tokens`
- [x] `./test.sh tests/unit/services/test_llm_config_service.py` — 20 passed
- [x] `ruff check` on the changed file — passes

## Notes
- The Anthropic test completion intentionally still sends `max_tokens`; that's the parameter name Anthropic's SDK requires.
- Custom OpenAI-compatible endpoints (Azure legacy, vLLM, LM Studio, etc.) may only know `max_tokens`. Not addressed here — tracked as a possible followup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)