### PR TITLE
fix: reap completed process pool workers

### DIFF
--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -1157,6 +1157,7 @@ class ProcessPoolManager:
                         await self._handle_result(handle, result)
                         continue
                 except Empty:
+                    # No queued result: handle this dead process as a crash below.
                     pass
 
                 # Case A: unexpected crash

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -33,7 +33,7 @@ import subprocess
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from queue import Empty
 from typing import Any, Awaitable, Callable
@@ -47,6 +47,8 @@ from src.services.execution.simple_worker import install_requirements
 from src.services.execution.template_process import TemplateProcess
 
 logger = logging.getLogger(__name__)
+
+_CLEAN_EXIT_RESULT_GRACE = timedelta(seconds=2)
 
 
 def _get_installed_packages() -> list[dict[str, str]]:
@@ -147,6 +149,9 @@ class ProcessHandle:
     # Used by the orphan sweep to wait out the grace-sleep window before treating
     # a KILLED handle as truly stuck.
     killed_at: datetime | None = None
+    # Timestamp set when health checks first observe a cleanly exited process
+    # whose result has not reached the result queue yet.
+    clean_exit_observed_at: datetime | None = None
 
     @property
     def is_alive(self) -> bool:
@@ -724,6 +729,7 @@ class ProcessPoolManager:
             timeout_seconds=timeout,
         )
         idle.result_reported = False
+        idle.clean_exit_observed_at = None
 
         # Send to process
         idle.work_queue.put_nowait(execution_id)
@@ -1157,8 +1163,17 @@ class ProcessPoolManager:
                         await self._handle_result(handle, result)
                         continue
                 except Empty:
-                    # No queued result: handle this dead process as a crash below.
-                    pass
+                    if (
+                        handle.process.exitcode == 0
+                        and handle.current_execution
+                        and not handle.result_reported
+                    ):
+                        now = datetime.now(timezone.utc)
+                        if handle.clean_exit_observed_at is None:
+                            handle.clean_exit_observed_at = now
+
+                        if now - handle.clean_exit_observed_at < _CLEAN_EXIT_RESULT_GRACE:
+                            continue
 
                 # Case A: unexpected crash
                 logger.warning(

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -171,7 +171,24 @@ class _PidWrapper:
         self.pid = pid
         self.exitcode: int | None = None
 
+    def _reap_if_exited(self) -> bool:
+        """Reap the child if it has exited, returning True when no child remains."""
+        if self.exitcode is not None:
+            return True
+        try:
+            pid, status = os.waitpid(self.pid, os.WNOHANG)
+            if pid == 0:
+                return False
+            self.exitcode = os.waitstatus_to_exitcode(status)
+            return True
+        except ChildProcessError:
+            # Already reaped elsewhere.
+            self.exitcode = 0 if self.exitcode is None else self.exitcode
+            return True
+
     def is_alive(self) -> bool:
+        if self._reap_if_exited():
+            return False
         try:
             os.kill(self.pid, 0)
             return True
@@ -185,11 +202,10 @@ class _PidWrapper:
                 # Non-blocking waitpid with polling
                 deadline = time.monotonic() + timeout
                 while time.monotonic() < deadline:
-                    pid, status = os.waitpid(self.pid, os.WNOHANG)
-                    if pid != 0:
-                        self.exitcode = os.waitstatus_to_exitcode(status)
+                    if self._reap_if_exited():
                         return
                     time.sleep(0.1)
+                self._reap_if_exited()
             else:
                 _, status = os.waitpid(self.pid, 0)
                 self.exitcode = os.waitstatus_to_exitcode(status)
@@ -607,6 +623,13 @@ class ProcessPoolManager:
                 # Process died between is_alive() check and kill — that's fine
                 pass
             handle.process.join(timeout=1)
+
+    async def _reap_process(self, handle: ProcessHandle, timeout: float = 1.0) -> None:
+        """Reap a raw forked child so completed on-demand work does not become a zombie."""
+        try:
+            await asyncio.to_thread(handle.process.join, timeout)
+        except Exception as e:
+            logger.debug(f"Failed to reap process {handle.id}: {e}")
 
     def _get_idle_process(self) -> ProcessHandle | None:
         """
@@ -1126,8 +1149,16 @@ class ProcessPoolManager:
         """
         to_remove: list[str] = []
 
-        for process_id, handle in self.processes.items():
+        for process_id, handle in list(self.processes.items()):
             if not handle.is_alive and handle.state != ProcessState.KILLED:
+                try:
+                    result = handle.result_queue.get_nowait()
+                    if isinstance(result, dict):
+                        await self._handle_result(handle, result)
+                        continue
+                except Empty:
+                    pass
+
                 # Case A: unexpected crash
                 logger.warning(
                     f"Process {process_id} crashed "
@@ -1160,6 +1191,8 @@ class ProcessPoolManager:
 
         # Remove crashed/orphaned processes
         for process_id in to_remove:
+            handle = self.processes[process_id]
+            await self._reap_process(handle)
             del self.processes[process_id]
 
         # Spawn replacements to maintain min_workers
@@ -1323,6 +1356,7 @@ class ProcessPoolManager:
 
         # On-demand mode: child exits after one execution, just clean up
         if self.min_workers == 0:
+            await self._reap_process(handle)
             if handle.id in self.processes:
                 del self.processes[handle.id]
             # Forward result to callback

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -25,6 +25,7 @@ from src.services.execution.process_pool import (
     ProcessHandle,
     ProcessPoolManager,
     ProcessState,
+    _PidWrapper,
 )
 
 
@@ -992,6 +993,65 @@ class TestMinWorkersZero:
                     assert len(pool_zero.processes) == 0
                     mock_spawn.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_handle_result_reaps_completed_child(self):
+        """On-demand children should be joined after returning a result."""
+        callback = AsyncMock()
+        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
+
+        mock_process = MagicMock()
+        handle = ProcessHandle(
+            id="process-1",
+            process=mock_process,
+            pid=12345,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=MagicMock(),
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-123",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=300,
+            ),
+        )
+        pool.processes[handle.id] = handle
+
+        result = {
+            "type": "result",
+            "execution_id": "exec-123",
+            "success": True,
+            "result": {},
+        }
+
+        await pool._handle_result(handle, result)
+
+        mock_process.join.assert_called_once_with(1.0)
+        assert handle.id not in pool.processes
+        callback.assert_awaited_once_with(result)
+
+
+class TestPidWrapper:
+    """Tests for raw PID lifecycle handling."""
+
+    def test_is_alive_reaps_exited_child(self):
+        """A zombie child should be reaped and reported not alive."""
+        wrapper = _PidWrapper(12345)
+
+        with patch("src.services.execution.process_pool.os.waitpid", return_value=(12345, 0)):
+            assert wrapper.is_alive() is False
+
+        assert wrapper.exitcode == 0
+
+    def test_is_alive_keeps_running_child_alive(self):
+        """A running child should still be reported alive."""
+        wrapper = _PidWrapper(12345)
+
+        with patch("src.services.execution.process_pool.os.waitpid", return_value=(0, 0)):
+            with patch("src.services.execution.process_pool.os.kill") as mock_kill:
+                assert wrapper.is_alive() is True
+
+        mock_kill.assert_called_once_with(12345, 0)
+
 
 class TestAdmissionControl:
     """Tests for cgroup-based admission control."""
@@ -1269,3 +1329,44 @@ class TestCrashedProcessReport:
 
         # Handle still removed from pool (cleanup still happens)
         assert "process-sigkill-2" not in pool.processes
+
+    @pytest.mark.asyncio
+    async def test_exited_worker_with_queued_result_is_not_reported_as_crash(self):
+        """A completed child can exit before the result loop reads its pipe."""
+        callback = AsyncMock()
+        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
+
+        mock_process = MagicMock()
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = 0
+
+        result = {
+            "type": "result",
+            "execution_id": "exec-finished",
+            "success": True,
+            "result": {},
+        }
+        result_queue = MagicMock()
+        result_queue.get_nowait.return_value = result
+
+        handle = ProcessHandle(
+            id="process-finished",
+            process=mock_process,
+            pid=99997,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=result_queue,
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-finished",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=300,
+            ),
+        )
+        pool.processes[handle.id] = handle
+
+        await pool._check_process_health()
+
+        callback.assert_awaited_once_with(result)
+        mock_process.join.assert_called_once_with(1.0)
+        assert handle.id not in pool.processes

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -16,6 +16,7 @@ NOTE: These tests use mocks to avoid spawning real processes.
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from queue import Empty
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1368,5 +1369,77 @@ class TestCrashedProcessReport:
         await pool._check_process_health()
 
         callback.assert_awaited_once_with(result)
+        mock_process.join.assert_called_once_with(1.0)
+        assert handle.id not in pool.processes
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_waits_for_result_queue_delivery(self):
+        """A cleanly exited worker gets a short grace period for result delivery."""
+        pool = ProcessPoolManager(min_workers=0, max_workers=2)
+        pool.on_result = AsyncMock()
+
+        mock_process = MagicMock()
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = 0
+
+        result_queue = MagicMock()
+        result_queue.get_nowait.side_effect = Empty
+
+        handle = ProcessHandle(
+            id="process-clean-exit",
+            process=mock_process,
+            pid=99996,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=result_queue,
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-clean-exit",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=300,
+            ),
+        )
+        pool.processes[handle.id] = handle
+
+        await pool._check_process_health()
+
+        pool.on_result.assert_not_awaited()
+        assert handle.id in pool.processes
+        assert handle.clean_exit_observed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_without_result_after_grace_is_reported(self):
+        """A clean exit without a delivered result eventually reports failure."""
+        pool = ProcessPoolManager(min_workers=0, max_workers=2)
+        pool.on_result = AsyncMock()
+
+        mock_process = MagicMock()
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = 0
+        mock_process.join = MagicMock()
+
+        result_queue = MagicMock()
+        result_queue.get_nowait.side_effect = Empty
+
+        handle = ProcessHandle(
+            id="process-stale-clean-exit",
+            process=mock_process,
+            pid=99995,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=result_queue,
+            started_at=datetime.now(timezone.utc),
+            current_execution=ExecutionInfo(
+                execution_id="exec-stale-clean-exit",
+                started_at=datetime.now(timezone.utc),
+                timeout_seconds=300,
+            ),
+            clean_exit_observed_at=datetime.now(timezone.utc) - timedelta(seconds=3),
+        )
+        pool.processes[handle.id] = handle
+
+        await pool._check_process_health()
+
+        pool.on_result.assert_awaited_once()
         mock_process.join.assert_called_once_with(1.0)
         assert handle.id not in pool.processes


### PR DESCRIPTION
## Summary
- reap raw forked process-pool children when they exit
- join completed on-demand workers before removing them from pool state
- avoid reporting a completed child as crashed when its result is already queued

## Testing
- `python3 -m py_compile src/services/execution/process_pool.py tests/unit/execution/test_process_pool.py`
- `PYTHONPATH=$PWD/api pytest api/tests/unit/execution/test_process_pool.py -q -k "PidWrapper or reaps_completed_child or queued_result or crash_detection_replaces_process or sigkilled_worker"` (7 passed)

Note: the full `test_process_pool.py` run reached 42/43 in my ad hoc WSL venv; the remaining failure is an existing admission-control test trying to resolve `redis:6379` without the compose test environment.