### PR TITLE
chore(release): wire plugin manifest version to dev version

### DIFF
--- a/.claude/skills/bifrost-release/SKILL.md
+++ b/.claude/skills/bifrost-release/SKILL.md
@@ -224,6 +224,25 @@ grep -vE $'\t(jackmusick|app/dependabot|app/renovate|github-actions\\[bot\\])\t'
 - ❌ Crediting only in the Contributors section without per-bullet `(#NN by @user)` markers. Readers scanning the feature list shouldn't have to scroll to find out who shipped it.
 - ❌ Putting external contributors as a footnote. They led the work — lead with their name on the bullet that describes it.
 
+### 2c. Bump the Claude plugin manifest (REQUIRED)
+
+Claude Code's plugin marketplace only fetches plugin updates when `.claude-plugin/plugin.json`'s `version` field changes on the default branch. Without this step, users installed via the bifrost plugin will keep getting the old skill content.
+
+Run the helper, commit the bump to `main` via a normal PR, and merge it **before** tagging:
+
+```bash
+# <tag> is the version you're about to cut, e.g. v0.8.1 — strip the leading v.
+VERSION="${TAG#v}"
+./scripts/update-plugin-version.sh "$VERSION"
+git add .claude-plugin/plugin.json
+git commit -m "chore(release): bump plugin manifest to $VERSION"
+# PR + merge via the normal flow, then continue.
+```
+
+The tag-build CI job (`build-api`) has a hard guard that fails the release if the manifest version doesn't match the tag — so forgetting this step blocks the build, it doesn't silently ship stale skills.
+
+**Trade-off:** between releases the manifest reflects the last tagged version, not the current dev commit. Per-push commit-back was considered and rejected — main has branch protection with required PR review and no ruleset bypass, so CI cannot push directly, and an auto-PR loop would churn the merge queue on every commit. See issue #245 and PR #246 for the full rationale.
+
 ### 3. Run pre-tag checks
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,27 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
+      # Surface manifest drift to the job summary. The plugin manifest is
+      # updated at tag time (see bifrost-release skill) — between tags the
+      # `version` field reflects the last released version, not the current
+      # dev version. This step is informational only; it does not fail the
+      # build and does not commit anything back. See PR #246 for the
+      # rationale (branch protection + commit-back loop avoidance).
+      - name: Report plugin manifest drift
+        run: |
+          MANIFEST_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          DEV_VERSION="${{ steps.version.outputs.version }}"
+          {
+            echo "## Plugin manifest version"
+            echo ""
+            echo "- Manifest (.claude-plugin/plugin.json): \`${MANIFEST_VERSION}\`"
+            echo "- Computed dev version: \`${DEV_VERSION}\`"
+            if [[ "$MANIFEST_VERSION" != "$DEV_VERSION" ]]; then
+              echo ""
+              echo "Manifest reflects the last tagged release; it advances at tag time via the bifrost-release skill."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -419,6 +440,22 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      # Hard guard: the plugin manifest version must match the tag, otherwise
+      # Claude Code's plugin marketplace will keep serving stale skill content
+      # to users who installed via this repo. The bifrost-release skill runs
+      # `scripts/update-plugin-version.sh <version>` locally before tagging,
+      # so when this fails the maintainer either forgot the skill step or the
+      # bump commit didn't make it onto the tagged ref.
+      - name: Verify plugin manifest matches tag
+        run: |
+          MANIFEST_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+          TAG_VERSION="${{ steps.version.outputs.version }}"
+          if [[ "$MANIFEST_VERSION" != "$TAG_VERSION" ]]; then
+            echo "::error::.claude-plugin/plugin.json version ($MANIFEST_VERSION) does not match tag ($TAG_VERSION)."
+            echo "::error::Run 'scripts/update-plugin-version.sh $TAG_VERSION' on main, commit, then re-tag."
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/scripts/update-plugin-version.sh
+++ b/scripts/update-plugin-version.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Update `.claude-plugin/plugin.json`'s `version` field in place.
+#
+# Usage: scripts/update-plugin-version.sh <version>
+#
+# Claude Code's plugin marketplace only fetches plugin updates when the
+# manifest's `version` field changes. Wire this to the dev version
+# (`scripts/compute-dev-version.sh`) at release time so users on the plugin
+# actually get our latest skill content.
+#
+# Idempotent — if the file already matches, this is a no-op.
+# Requires: jq (standard in GitHub Actions runners and most dev environments).
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <version>" >&2
+  exit 2
+fi
+
+version="$1"
+
+# Resolve the manifest path relative to the repo root (this script lives in
+# scripts/, so go one directory up).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+manifest="${script_dir}/../.claude-plugin/plugin.json"
+
+if [[ ! -f "$manifest" ]]; then
+  echo "update-plugin-version: manifest not found at $manifest" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "update-plugin-version: jq is required but not installed" >&2
+  exit 1
+fi
+
+current=$(jq -r '.version' "$manifest")
+if [[ "$current" == "$version" ]]; then
+  echo "update-plugin-version: already at $version, no change"
+  exit 0
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+jq --arg v "$version" '.version = $v' "$manifest" > "$tmp"
+mv "$tmp" "$manifest"
+trap - EXIT
+
+echo "update-plugin-version: $current -> $version"


### PR DESCRIPTION
## Summary

Wires `.claude-plugin/plugin.json`'s `version` field to the Bifrost release cadence so Claude Code's plugin marketplace actually fetches new skill content for users installed via this repo.

- New `scripts/update-plugin-version.sh <version>` — idempotent `jq`-based in-place edit of the manifest.
- `bifrost-release` skill grew a "step 2c" that runs the script, commits the bump to `main` via a normal PR, and merges it **before** tagging.
- CI's tag-build job (`build-api`) has a new hard guard: if `plugin.json` version doesn't match the tag, the release fails loudly with instructions.
- CI's `build-dev` job writes plugin-manifest-vs-computed-dev-version drift to the job summary on each push (informational only).

Closes #245

## Approach chosen: tag-time bump, not per-push commit-back

The issue listed two paths — per-main-push commit-back vs tag-only. I went with **tag-only** for these reasons:

- `main` is protected by a ruleset with `pull_request` + `required_status_checks` rules, **zero bypass actors**, and `enforce_admins: true`. The standard `GITHUB_TOKEN` cannot push directly to `main`. (Verified via `gh api repos/jackmusick/bifrost/rulesets/15329014`.)
- A bot-driven auto-PR per push would churn the merge queue on every commit, and creates a chase loop (each bump commit advances the commit count, requiring another bump).
- Claude's plugin marketplace polls the default branch's manifest. At tag-time granularity, every release advances the version — which is what users on a plugin actually need. Between releases the manifest reflects the last tagged version. That's the same cadence as the `:latest` Docker tag.

**Trade-off** (called out in the skill and the PR description): dev pushes between tags do not roll the manifest forward. If we later want per-push bumps, the options are (a) configure a bypass actor on the ruleset for a dedicated bot identity, or (b) use a GitHub App token with the right permission and accept the queue churn. Both are out of scope here.

## Files

- `scripts/update-plugin-version.sh` — new
- `.claude/skills/bifrost-release/SKILL.md` — new step 2c
- `.github/workflows/ci.yml` — drift summary on dev build; hard guard on tag build

## Test plan

- [x] `bash scripts/update-plugin-version.sh 0.8.1-dev.99` rewrites `plugin.json` correctly.
- [x] Re-running with the same version is a no-op (`already at <v>, no change`).
- [x] Reverting via `git checkout` restores the static `0.1.0`.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- [ ] CI green on this PR (no dev/tag build paths are exercised, but lint + unit + e2e + ci-noop should all still pass).
- [ ] Next dev push to `main` after merge: `Build Dev Images` job summary shows the manifest-vs-dev drift block.
- [ ] Next `v*` tag push: if maintainer forgot step 2c, `Build API Image` fails with the error message pointing at `scripts/update-plugin-version.sh`. If they ran it, the build proceeds.