### PR TITLE
fix(mcp): allow platform admins to list tools for role-based agents

### DIFF
--- a/api/src/services/mcp_server/tool_access.py
+++ b/api/src/services/mcp_server/tool_access.py
@@ -346,7 +346,7 @@ class MCPToolAccessService:
             agent_role_names = {role.name for role in agent.roles}
             if not agent_role_names:
                 return is_superuser
-            return bool(set(user_roles) & agent_role_names)
+            return is_superuser or bool(set(user_roles) & agent_role_names)
 
         return False
 
@@ -360,9 +360,10 @@ class MCPToolAccessService:
 
         Rules:
         - AUTHENTICATED: Any authenticated user can access
-        - ROLE_BASED with roles: User must share at least one role with the agent
+        - ROLE_BASED with roles: User must share at least one role with the agent,
+          OR be a platform admin (superuser)
         - ROLE_BASED with no roles: Only superusers can access
-        - Platform admins (superusers) are ALSO filtered by agent access (no bypass)
+        - Platform admins (superusers) bypass ROLE_BASED role checks (issue #244)
         """
         # Query all active agents with their tools and roles eagerly loaded
         query = (
@@ -394,8 +395,9 @@ class MCPToolAccessService:
                     # ROLE_BASED with no roles = only superusers can access
                     if is_superuser:
                         accessible_agents.append(agent)
-                elif user_role_set & agent_role_names:
-                    # User has at least one matching role
+                elif is_superuser or (user_role_set & agent_role_names):
+                    # User has at least one matching role, or is a platform
+                    # admin (superuser bypass — issue #244)
                     accessible_agents.append(agent)
 
             # Note: PUBLIC agents are not included for MCP access

--- a/api/tests/unit/services/mcp_server/test_tool_access.py
+++ b/api/tests/unit/services/mcp_server/test_tool_access.py
@@ -225,8 +225,13 @@ class TestGetAccessibleAgents:
         assert len(result) == 1
 
     @pytest.mark.asyncio
-    async def test_platform_admin_still_filtered_by_agent_access(self, service, mock_session, mock_agent):
-        """Platform admins should NOT bypass agent role requirements."""
+    async def test_platform_admin_bypasses_role_based_agent(self, service, mock_session, mock_agent):
+        """Platform admins (superusers) bypass ROLE_BASED agent role requirements (issue #244).
+
+        Previously, platform admins listing tools via /mcp/{agent_id} for a ROLE_BASED agent
+        whose roles they did not share would receive an empty tools list. Superusers must
+        be able to see tools for any agent, matching their behavior elsewhere in the platform.
+        """
         agent = mock_agent(
             access_level=AgentAccessLevel.ROLE_BASED,
             system_tools=["search_knowledge"],
@@ -235,13 +240,37 @@ class TestGetAccessibleAgents:
 
         mock_session.execute = AsyncMock(return_value=mock_query_result([agent]))
 
-        # Platform admin without the role should NOT see the agent
+        # Platform admin without the role SHOULD now see the agent
         result = await service._get_accessible_agents(
             user_roles=["Platform Admin"],  # Not "Secret Team"
             is_superuser=True,
         )
 
-        assert len(result) == 0
+        assert len(result) == 1
+        assert result[0].id == agent.id
+
+    def test_check_agent_access_superuser_bypass_role_based(self, service, mock_agent):
+        """_check_agent_access: superuser without matching roles still gets access (issue #244)."""
+        agent = mock_agent(
+            access_level=AgentAccessLevel.ROLE_BASED,
+            roles=["Secret Team"],
+        )
+
+        # Superuser without matching role -> True (the fix)
+        assert service._check_agent_access(
+            agent, user_roles=["Other"], is_superuser=True
+        ) is True
+
+    def test_check_agent_access_non_superuser_without_matching_role(self, service, mock_agent):
+        """_check_agent_access: non-superuser without matching roles is denied."""
+        agent = mock_agent(
+            access_level=AgentAccessLevel.ROLE_BASED,
+            roles=["Secret Team"],
+        )
+
+        assert service._check_agent_access(
+            agent, user_roles=["Other"], is_superuser=False
+        ) is False
 
     @pytest.mark.asyncio
     async def test_multiple_roles_matching(self, service, mock_session, mock_agent):


### PR DESCRIPTION
Fixes #244

## Summary
- `MCPToolAccessService._check_agent_access` and `_get_accessible_agents` filtered `ROLE_BASED` agents purely by role intersection — platform admins with no matching role received an empty tools list when listing tools via `/mcp/{agent_id}`.
- Adds an `is_superuser` bypass in both spots so platform admins can always see tools attached to `ROLE_BASED` agents, matching their treatment elsewhere in the platform.
- The `agent_role_names is empty -> superuser only` branch is unchanged.

## Test plan
- [x] Updated `test_platform_admin_bypasses_role_based_agent` to assert the new bypass (was previously encoding the buggy behavior).
- [x] Added direct `_check_agent_access` positive (superuser bypass) + negative (non-superuser without matching role denied) coverage.
- [x] `./test.sh tests/unit/services/mcp_server/test_tool_access.py` — 31 passed.
- [x] `./test.sh unit` — full suite, 3773 passed.
- [x] `pyright api/src/services/mcp_server/tool_access.py` — 0 errors.
- [x] `ruff check api/src/services/mcp_server/tool_access.py` — clean.