### PR TITLE
chore(release): bump plugin manifest to 0.9.2-dev.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI. Includes :build (create and debug artifacts) and :setup (install CLI, authenticate, configure MCP).",
-  "version": "0.1.0",
+  "version": "0.9.2-dev.2",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/jackmusick/bifrost"


### PR DESCRIPTION
## Summary
Manifest was stuck at `0.1.0`. Bumps `.claude-plugin/plugin.json` to `0.9.2-dev.2` (output of `scripts/compute-dev-version.sh` at HEAD) so Claude Code's plugin marketplace serves the current skill content to existing installs.

This is the manual flow #246 wired up. Follow-up to fully automate per-push bumps is still TBD.

## Test plan
- [ ] CI green
- [ ] After merge, verify a Claude Code instance with the bifrost plugin installed sees a version update on next refresh