### PR TITLE
ci: exclude .claude-plugin/** from path filters

### DIFF
--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -34,6 +34,7 @@ on:
       - "**/*.webp"
       - "**/*.ico"
       - ".claude/**"
+      - ".claude-plugin/**"
       - "docs/**"
       - "LICENSE"
       - ".github/CODEOWNERS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ on:
       - "**/*.webp"
       - "**/*.ico"
       - ".claude/**"
+      - ".claude-plugin/**"
       - "docs/**"
       - "LICENSE"
       - ".github/CODEOWNERS"


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/**` to the `paths-ignore` lists in `ci.yml` and `ci-noop.yml`, mirroring the existing `.claude/**` exclusion.
- Edits to `plugin.json` / `marketplace.json` will no longer trigger the full CI matrix.

## Notes
- pytest, vitest, and playwright are already scoped tightly enough (`api/tests`, `client/src/**`, `client/e2e`) that `.claude-plugin/` is outside their discovery paths — no test-runner config changes needed.

## Test plan
- [ ] CI ci-noop workflow runs (and ci.yml does not) on a follow-up plugin-only edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)