### PR TITLE
feat(skills): bifrost:copilot-cowork-package — M365 Copilot Cowork packager

### DIFF
--- a/.claude/skills/copilot-cowork-package/SKILL.md
+++ b/.claude/skills/copilot-cowork-package/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: bifrost:copilot-cowork-package
+description: |
+  Use when the user wants to turn a Bifrost agent into a Microsoft 365 Copilot Cowork
+  plugin (.zip with manifest.json + skills/SKILL.md + agentConnectors pointing at the
+  agent's MCP server). Trigger phrases — "/copilot-cowork-package", "turn my <agent> into a
+  Copilot skill", "package this agent for M365 Copilot", "make a Cowork plugin for
+  <agent>", "convert agent to Copilot plugin".
+---
+
+# copilot-cowork-package
+
+Convert a Bifrost agent into a Microsoft 365 Copilot **Cowork** plugin package
+(devPreview M365 unified app manifest with `agentSkills` + `agentConnectors`).
+
+The agent's `system_prompt` becomes the `SKILL.md` body, the agent's `description`
+becomes the skill description, and `agentConnectors[0]` points at the agent's MCP
+endpoint at `https://<bifrost-host>/mcp/{agent_id}`. The host is resolved from
+`bifrost auth list` (the "current" entry) unless `--bifrost-host` is passed.
+
+## When to use
+
+User says any of:
+- `/copilot-plugin-converter <agent name>`
+- "turn the <agent name> agent into a Copilot skill / Cowork plugin"
+- "package <agent> for Microsoft 365 Copilot"
+
+## Workflow
+
+1. **Identify the agent.** Ask `bifrost agents list --json` if the name is fuzzy; pick the closest match. The script accepts either the agent name or UUID.
+2. **Reuse the shared Bifrost OAuth registration if available.** All Bifrost agents share the same host, so ONE Teams Dev Portal OAuth client registration named "Bifrost" covers every agent. If you have a saved referenceId from a previous run, pass it to `pack.py --ref-id <id>` automatically. Otherwise walk the user through the one-time registration (see "Auth picker" below).
+3. **Run the packager** (path is relative to this skill directory):
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/.claude/skills/copilot-cowork-package/pack.py" "<agent name or id>" --out ./out
+   ```
+   If `CLAUDE_PLUGIN_ROOT` isn't set, fall back to the absolute path of the skill's `pack.py` (the file sitting next to this `SKILL.md`).
+
+   Optional flags:
+   - `--auth None|OAuthPluginVault|ApiKeyPluginVault|DynamicClientRegistration`
+   - `--ref-id <token-vault-id>`
+   - `--bifrost-host <host>` (override the host resolved from `bifrost auth list`)
+   - `--app-id <guid>` (override the deterministic UUID v5)
+4. **Surface the zip path AND the TL;DR.** The script prints JSON on stdout, then a "Upload to Copilot Cowork (TL;DR)" block. Show both to the user — do NOT swallow the TL;DR.
+5. **Flag the placeholders.** The script writes solid-color 192×192 / 32×32 PNG icons — fine for sideloading, must be replaced before App Store submission.
+
+## What the script produces
+
+```
+<skill-name>-cowork/
+├── manifest.json          # devPreview, agentSkills + agentConnectors
+├── color.png              # 192×192 solid placeholder
+├── outline.png            # 32×32 solid placeholder
+└── skills/
+    └── <skill-name>/
+        └── SKILL.md       # frontmatter + agent system_prompt
+<skill-name>-cowork.zip     # zipped, ready to sideload
+```
+
+The script's stdout is JSON: `{zip, package_dir, app_id, mcp_url, skill_name, auth_type, ref_id}`. Surface the `zip` path and `mcp_url` to the user.
+
+## Conventions
+
+- Skill folder name = `kebab(agent.name)` and must match the `name:` field in `SKILL.md` (M365 validation rule ASKILL-P006).
+- `app_id` is `uuid5(cowork_namespace, agent.id)` — deterministic, so re-running on the same agent produces the same M365 app GUID.
+- `packageName` is `com.bifrost.<flattened-agent-name>`.
+- Description in `SKILL.md` frontmatter is forced to start with "Use when:" if the agent description doesn't already (M365 best practice).
+- Long agent descriptions are truncated to 1000 chars for the frontmatter, full description goes into `manifest.json` `description.full` (4000 char cap).
+
+## Auth picker — what actually works in Cowork
+
+Per Microsoft's [cowork-manage-plugins](https://learn.microsoft.com/en-us/microsoft-365/copilot/cowork/cowork-manage-plugins#plugin-support-for-mcp-servers) doc, Cowork's MCP runtime supports ONLY:
+
+- `None` (anonymous)
+- `OAuthPluginVault`
+- `ApiKeyPluginVault`
+
+**`DynamicClientRegistration` is in the broader manifest schema but Cowork's MCP runtime does NOT support it today.** Even though Bifrost MCP servers natively support RFC 7591 DCR (which is why Claude.ai's "add MCP" flow just works), don't use it for Cowork — the upload will be rejected with `Invalid encoded OAuthConfigurationId`.
+
+For Bifrost agents specifically, recommend in this order:
+
+1. **`OAuthPluginVault` against Bifrost's native OAuth** (default, works today, no Bifrost-side changes). Bifrost's MCP server exposes an OAuth 2.1 authorization server at `https://<bifrost-host>/authorize` + `/token` (RFC 8414 discoverable). Critically, Bifrost is permissive about client identity: `_authorize` accepts any `client_id`, `_token` uses `token_endpoint_auth_method: "none"` (no client_secret check), and `_authorize` accepts any `redirect_uri`. So you can register in [Teams Dev Portal → OAuth client registration](https://dev.teams.microsoft.com/tools) with:
+   - **Authorization endpoint:** `https://<bifrost-host>/authorize`
+   - **Token endpoint:** `https://<bifrost-host>/token`
+   - **Refresh endpoint:** `https://<bifrost-host>/token`
+   - **Client ID:** any string (Bifrost doesn't validate)
+   - **Client secret:** any string (Bifrost ignores it; Dev Portal requires the field)
+   - **Scope:** `mcp:access`
+   - **Enable PKCE:** ON (required — Bifrost only accepts S256)
+
+   Save → copy the generated **OAuth client registration ID** → pass to `pack.py --ref-id <id>`.
+
+2. **`OAuthPluginVault` with Entra SSO registration** — proper long-term path for M365-native tenants. Register the Bifrost MCP as an Entra-protected API, register a Microsoft Entra SSO client in Teams Dev Portal, add `ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b` (Microsoft's enterprise token store client ID) as an authorized client in the Entra app registration. Requires Bifrost-side work: MCP must accept Entra-issued JWTs audience-validated.
+
+3. **`ApiKeyPluginVault`** — viable if Bifrost adds static-bearer support on MCP endpoints. Not currently supported by Bifrost; recommend only if Entra SSO is blocked.
+
+4. **`None`** — sideload smoke tests only. Bifrost MCP itself will reject unauthenticated calls.
+
+`referenceId` is always the opaque base64 token the Teams Developer Portal generates — never a friendly string. M365 returns `Invalid encoded OAuthConfigurationId` if it's not a valid Dev Portal–issued ID.
+
+## Gotchas
+
+- M365 requires `referenceId` for any auth type other than `None`, AND forbids `referenceId` when auth is `None`. The script enforces this.
+- The agent's MCP server must be reachable from Microsoft's cloud — Netbird-fronted or private hosts will NOT work. If `bifrost auth list` resolves to an internal host, pass `--bifrost-host` pointing at a public Bifrost instance.
+- Skills-folder limit is 20 entries; companion files limit is 20 per skill, 5 MB each, 10 MB total. This script only emits one skill so those limits aren't a concern.
+- The official Microsoft conversion script is PowerShell and converts Claude-Code-plugin directories. This skill does NOT depend on it — it talks to Bifrost directly via the CLI and builds the package in Python.
+- Junk files (`.DS_Store`, `Thumbs.db`, `desktop.ini`, AppleDouble `._*`) are stripped from both the staged package dir and the zip. Sync clients (iCloud, Dropbox, Syncthing) drop these in shared folders constantly — the filter prevents them from ending up in the uploaded manifest.
+
+## Real-world example
+
+```
+$ python3 "${CLAUDE_PLUGIN_ROOT}/.claude/skills/copilot-cowork-package/pack.py" "Cyber Questionnaire Assistant" --out /tmp
+{
+  "zip": "/tmp/cyber-questionnaire-assistant-cowork.zip",
+  "app_id": "...",
+  "mcp_url": "https://<resolved-host>/mcp/eb0e7492-...",
+  "skill_name": "cyber-questionnaire-assistant",
+  "auth_type": "OAuthPluginVault",
+  "ref_id": null
+}
+```
+
+User then:
+1. Has tenant admin register an OAuth client for the printed `mcp_url` in M365 Enterprise Token Store and note the reference id.
+2. Edits `manifest.json` `authorization.referenceId` to that id (or re-runs with `--ref-id <id>`).
+3. Re-zips and uploads.

--- a/.claude/skills/copilot-cowork-package/pack.py
+++ b/.claude/skills/copilot-cowork-package/pack.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Package a Bifrost agent as a Microsoft 365 Copilot Cowork plugin .zip.
+
+Reads agent metadata via `bifrost agents get`, emits a devPreview
+manifest.json + skills/<name>/SKILL.md + placeholder icons, zips it.
+
+Usage:
+    pack.py <agent-name-or-id> [--out DIR] [--auth TYPE] [--ref-id ID]
+            [--bifrost-host HOST] [--app-id GUID]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import struct
+import subprocess
+import sys
+import os
+import shutil
+import tempfile
+import urllib.parse
+import uuid
+import zipfile
+import zlib
+from pathlib import Path
+
+
+COWORK_NAMESPACE = uuid.UUID("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+
+JUNK_NAMES = {".DS_Store", "Thumbs.db", "desktop.ini", ".AppleDouble", ".Spotlight-V100", ".Trashes"}
+
+
+def is_junk(path: Path) -> bool:
+    return path.name in JUNK_NAMES or path.name.startswith("._") or any(
+        part in JUNK_NAMES for part in path.parts
+    )
+
+
+def kebab(s: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9]+", "-", s).strip("-").lower()
+    s = re.sub(r"-+", "-", s)
+    return s or "agent"
+
+
+def reverse_dns(name: str) -> str:
+    return f"com.bifrost.{kebab(name).replace('-', '')}"
+
+
+def get_bifrost_host() -> str:
+    """Resolve the Bifrost API host the CLI is currently pointed at."""
+    env = os.environ.get("BIFROST_API_URL")
+    if env:
+        return urllib.parse.urlparse(env).hostname or env
+    out = subprocess.run(
+        ["bifrost", "auth", "list"], check=True, capture_output=True, text=True,
+    ).stdout
+    for line in out.splitlines():
+        if "(current" in line:
+            url = line.strip().split()[0]
+            return urllib.parse.urlparse(url).hostname or url
+    raise RuntimeError(
+        "Could not determine the current Bifrost host from `bifrost auth list`. "
+        "Pass --bifrost-host explicitly or set BIFROST_API_URL."
+    )
+
+
+def get_agent(ref: str) -> dict:
+    out = subprocess.run(
+        ["bifrost", "agents", "get", ref, "--json"],
+        check=True, capture_output=True, text=True,
+    )
+    return json.loads(out.stdout)
+
+
+def render_icon(src: Path, size: int, dest: Path) -> None:
+    """Rasterize/resize any ImageMagick-readable file (PNG, SVG, JPG, …) to a square PNG."""
+    if not src.exists():
+        raise RuntimeError(f"Icon source not found: {src}")
+    subprocess.run(
+        [
+            "convert", "-background", "none", str(src),
+            "-resize", f"{size}x{size}",
+            "-gravity", "center",
+            "-extent", f"{size}x{size}",
+            str(dest),
+        ],
+        check=True, capture_output=True,
+    )
+
+
+def solid_png(size: int, rgb: tuple[int, int, int]) -> bytes:
+    """Minimal valid PNG, solid color, no deps."""
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        crc = zlib.crc32(tag + data)
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", crc)
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 2, 0, 0, 0)  # 8-bit RGB
+    row = b"\x00" + bytes(rgb) * size
+    raw = row * size
+    idat = zlib.compress(raw, 9)
+    return sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def load_skill_source(path: Path) -> tuple[Path, str, str, Path | None]:
+    """Resolve a SKILL.md source (folder, .zip, or .skill) to (skill_dir, name, description, tmp_cleanup).
+
+    Returns the directory containing SKILL.md (with companion files alongside),
+    the `name:` from frontmatter, the `description:` from frontmatter, and an
+    optional tmpdir handle for the caller to clean up.
+    """
+    cleanup: Path | None = None
+    if path.is_file() and zipfile.is_zipfile(path):
+        tmp = Path(tempfile.mkdtemp(prefix="copilot-skill-src-"))
+        cleanup = tmp
+        with zipfile.ZipFile(path) as z:
+            z.extractall(tmp)
+        # Look for a single top-level folder containing SKILL.md.
+        candidates = [p.parent for p in tmp.rglob("SKILL.md")]
+        if not candidates:
+            raise RuntimeError(f"No SKILL.md found inside {path}")
+        skill_dir = candidates[0]
+    elif path.is_dir():
+        if (path / "SKILL.md").exists():
+            skill_dir = path
+        else:
+            candidates = [p.parent for p in path.rglob("SKILL.md")]
+            if not candidates:
+                raise RuntimeError(f"No SKILL.md found under {path}")
+            skill_dir = candidates[0]
+    else:
+        raise RuntimeError(f"--skill-source must be a folder, .zip, or .skill: {path}")
+
+    text = (skill_dir / "SKILL.md").read_text()
+    if not text.startswith("---"):
+        raise RuntimeError(f"SKILL.md missing YAML frontmatter: {skill_dir/'SKILL.md'}")
+    _, fm, _ = text.split("---", 2)
+    name = ""
+    desc = ""
+    in_desc = False
+    desc_lines: list[str] = []
+    for line in fm.splitlines():
+        if line.startswith("name:"):
+            name = line.split(":", 1)[1].strip()
+            in_desc = False
+        elif line.startswith("description:"):
+            tail = line.split(":", 1)[1].strip()
+            if tail in ("", "|", ">", "|-", ">-"):
+                in_desc = True
+            else:
+                desc = tail
+                in_desc = False
+        elif in_desc:
+            if line and not line.startswith(" ") and not line.startswith("\t"):
+                in_desc = False
+            else:
+                desc_lines.append(line.strip())
+    if desc_lines:
+        desc = " ".join(l for l in desc_lines if l)
+    if not name:
+        raise RuntimeError("SKILL.md frontmatter missing `name:`")
+    return skill_dir, name, desc, cleanup
+
+
+def build_skill_md(agent: dict, skill_name: str) -> str:
+    desc = (agent.get("description") or "").strip().replace("\n", " ")
+    if len(desc) > 1000:
+        desc = desc[:1000].rsplit(" ", 1)[0] + "..."
+    if not desc:
+        desc = f"Use when the user wants to invoke the {agent['name']} agent."
+    elif not desc.lower().startswith("use when"):
+        desc = f"Use when: {desc}"
+
+    prompt = (agent.get("system_prompt") or "").strip()
+    if not prompt:
+        prompt = f"# {agent['name']}\n\nNo system prompt configured."
+
+    frontmatter = (
+        "---\n"
+        f"name: {skill_name}\n"
+        f"description: |\n"
+        + "".join(f"  {line}\n" for line in desc.splitlines() or [desc])
+        + "metadata:\n"
+        f"  author: Bifrost\n"
+        f"  agent_id: {agent['id']}\n"
+        f"  version: \"1.0\"\n"
+        "---\n\n"
+    )
+    return frontmatter + prompt + "\n"
+
+
+def next_version(out_root: Path, skill_name: str) -> str:
+    """Auto-bump patch version per skill_name. Persists alongside the zip."""
+    state_file = out_root / f".{skill_name}.version"
+    if state_file.exists():
+        parts = state_file.read_text().strip().split(".")
+        major, minor, patch = (int(p) for p in parts)
+        patch += 1
+    else:
+        major, minor, patch = 1, 0, 0
+    version = f"{major}.{minor}.{patch}"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(version)
+    return version
+
+
+def build_manifest(agent: dict, skill_name: str, app_id: str,
+                   mcp_url: str, auth_type: str, ref_id: str | None,
+                   version: str,
+                   display_name: str | None = None,
+                   description: str | None = None) -> dict:
+    name = display_name or agent["name"]
+    desc_full = description or agent.get("description") or name
+    short_desc = desc_full.split(".")[0][:80]
+    auth_block: dict = {"type": auth_type}
+    if auth_type != "None":
+        auth_block["referenceId"] = ref_id or f"{kebab(name)}-auth"
+
+    return {
+        "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
+        "manifestVersion": "devPreview",
+        "version": version,
+        "id": app_id,
+        "packageName": reverse_dns(name),
+        "developer": {
+            "name": "Bifrost",
+            "websiteUrl": "https://gobifrost.com",
+            "privacyUrl": "https://gobifrost.com/privacy",
+            "termsOfUseUrl": "https://gobifrost.com/terms",
+        },
+        "name": {"short": name[:30], "full": name[:100]},
+        "description": {
+            "short": short_desc,
+            "full": desc_full[:4000],
+        },
+        "icons": {"color": "color.png", "outline": "outline.png"},
+        "accentColor": "#4F46E5",
+        "agentSkills": [{"folder": f"./skills/{skill_name}"}],
+        "agentConnectors": [{
+            "id": f"{kebab(name)}-mcp",
+            "displayName": f"{name} MCP",
+            "description": f"Remote MCP server backing the {name} agent.",
+            "toolSource": {
+                "remoteMcpServer": {
+                    "mcpServerUrl": mcp_url,
+                    "authorization": auth_block,
+                }
+            },
+        }],
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("ref", help="Agent name or UUID")
+    p.add_argument("--out", default=".", help="Output directory")
+    p.add_argument("--auth", default="OAuthPluginVault",
+                   choices=["None", "OAuthPluginVault", "ApiKeyPluginVault", "DynamicClientRegistration"])
+    p.add_argument("--ref-id", default=None, help="Token vault referenceId (required unless --auth None)")
+    p.add_argument("--bifrost-host", default=None,
+                   help="Bifrost MCP host (default: resolved from `bifrost auth list`)")
+    p.add_argument("--app-id", default=None, help="Override M365 app GUID")
+    p.add_argument("--icon", default=None,
+                   help="Path to color icon source (PNG, SVG, JPG — anything ImageMagick reads). "
+                        "Auto-resized to 192x192. Defaults to a solid-color placeholder.")
+    p.add_argument("--outline-icon", default=None,
+                   help="Path to outline icon source. Auto-resized to 32x32. "
+                        "Defaults to a solid-color placeholder.")
+    p.add_argument("--skill-source", default=None,
+                   help="Path to existing skill folder, .zip, or .skill bundle. "
+                        "If set, its SKILL.md + companion files are used verbatim "
+                        "instead of building SKILL.md from agent.system_prompt.")
+    args = p.parse_args()
+
+    agent = get_agent(args.ref)
+    app_id = args.app_id or str(uuid.uuid5(COWORK_NAMESPACE, agent["id"]))
+    host = args.bifrost_host or get_bifrost_host()
+    mcp_url = f"https://{host}/mcp/{agent['id']}"
+
+    src_cleanup: Path | None = None
+    src_skill_dir: Path | None = None
+    src_name = src_desc = None
+    if args.skill_source:
+        src_skill_dir, src_name, src_desc, src_cleanup = load_skill_source(
+            Path(args.skill_source).expanduser().resolve()
+        )
+        skill_name = src_name
+    else:
+        skill_name = kebab(agent["name"])
+
+    icon_src = Path(args.icon).expanduser().resolve() if args.icon else None
+    outline_src = Path(args.outline_icon).expanduser().resolve() if args.outline_icon else None
+    for label, p in (("--icon", icon_src), ("--outline-icon", outline_src)):
+        if p and not p.exists():
+            raise RuntimeError(f"{label} not found: {p}")
+
+    out_root = Path(args.out).resolve()
+    out_root.mkdir(parents=True, exist_ok=True)
+    pkg_dir = out_root / f"{skill_name}-cowork"
+    # If an icon source lives inside the staging dir we're about to wipe, stash it first.
+    stash_dir: Path | None = None
+    for var_name in ("icon_src", "outline_src"):
+        p = locals()[var_name]
+        if p and pkg_dir in p.parents:
+            if stash_dir is None:
+                stash_dir = Path(tempfile.mkdtemp(prefix="copilot-skill-stash-"))
+            new = stash_dir / p.name
+            shutil.copy2(p, new)
+            if var_name == "icon_src":
+                icon_src = new
+            else:
+                outline_src = new
+    if pkg_dir.exists():
+        shutil.rmtree(pkg_dir)
+    skills_dir = pkg_dir / "skills" / skill_name
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    version = next_version(out_root, skill_name)
+    manifest = build_manifest(
+        agent, skill_name, app_id, mcp_url, args.auth, args.ref_id,
+        version=version,
+        display_name=agent["name"],
+        description=src_desc or agent.get("description"),
+    )
+    (pkg_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+
+    if src_skill_dir:
+        for entry in src_skill_dir.rglob("*"):
+            if entry.is_file() and not is_junk(entry):
+                dest = skills_dir / entry.relative_to(src_skill_dir)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(entry, dest)
+    else:
+        (skills_dir / "SKILL.md").write_text(build_skill_md(agent, skill_name))
+
+    if icon_src:
+        render_icon(icon_src, 192, pkg_dir / "color.png")
+    else:
+        (pkg_dir / "color.png").write_bytes(solid_png(192, (79, 70, 229)))
+    if outline_src:
+        render_icon(outline_src, 32, pkg_dir / "outline.png")
+    else:
+        (pkg_dir / "outline.png").write_bytes(solid_png(32, (255, 255, 255)))
+
+    if src_cleanup:
+        shutil.rmtree(src_cleanup, ignore_errors=True)
+    if stash_dir:
+        shutil.rmtree(stash_dir, ignore_errors=True)
+
+    zip_path = out_root / f"{skill_name}-cowork.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
+        for f in sorted(pkg_dir.rglob("*")):
+            if f.is_file() and not is_junk(f):
+                z.write(f, f.relative_to(pkg_dir))
+
+    result = {
+        "zip": str(zip_path),
+        "package_dir": str(pkg_dir),
+        "app_id": app_id,
+        "version": version,
+        "mcp_url": mcp_url,
+        "skill_name": skill_name,
+        "auth_type": args.auth,
+        "ref_id": args.ref_id,
+    }
+    print(json.dumps(result, indent=2))
+
+    needs_auth = args.auth != "None" and not args.ref_id
+    tldr = f"""
+--- Upload to Copilot Cowork (TL;DR) ---
+
+1. Frontier preview: tenant must be enrolled in the Frontier program
+   (Microsoft 365 Admin Center → Copilot → Settings → Frontier).
+
+2. Auth setup ({args.auth}):
+{'   - Register an OAuth client for the Bifrost MCP endpoint in the' if args.auth == 'OAuthPluginVault' else '   - Create the API key entry in the' if args.auth == 'ApiKeyPluginVault' else '   - No auth setup required.'}
+{'     Microsoft Enterprise Token Store, then re-run this script with' if needs_auth else ''}
+{f'     --ref-id <token-vault-id> (current placeholder: {kebab(agent["name"])}-auth)' if needs_auth else ''}
+
+3. Sideload the package (verified May 2026):
+   admin.microsoft.com → Manage Apps → Upload custom app → Upload
+   "{zip_path.name}".
+   Then deploy: Copilot → Agents → All agents → find the plugin →
+   Deploy to → Entire organization or Specific users/groups → Deploy.
+
+4. Verify in Cowork → Added Plugins → plugin should show
+   "Managed by your organization". Users enable/disable per device
+   via Sources & Skills.
+
+5. Replace placeholder icons (color.png 192×192, outline.png 32×32)
+   before submitting to the Microsoft 365 App Store via Partner Center.
+
+MCP endpoint Microsoft will call:
+   {mcp_url}
+   (must be reachable from the public internet — Netbird-fronted hosts will NOT
+    work. If the resolved host is internal-only, re-run with --bifrost-host
+    pointing at a publicly-reachable Bifrost instance.)
+""".rstrip()
+    print(tldr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New plugin-distributed skill `bifrost:copilot-cowork-package` that turns a Bifrost agent into a Microsoft 365 Copilot Cowork plugin (.zip with `manifest.json` + `agentSkills` + `agentConnectors` pointing at the agent's MCP endpoint).
- Replaces the user-level `~/.claude/skills/copilot-skill/` so every Bifrost plugin user gets the packager — no manual install.
- Ships `pack.py` next to `SKILL.md` and resolves it via `${CLAUDE_PLUGIN_ROOT}`.

## Why
Same intent as the existing user-level skill, but distribution-friendly: anyone on the Bifrost plugin can now run `/copilot-cowork-package <agent>` against their own agents.

## Version
Manifest version bump intentionally omitted — `.claude-plugin/plugin.json` is bumped at tag time via `scripts/update-plugin-version.sh` (driven by the `bifrost-release` skill), not per-PR. This PR only changes `.claude/skills/**`, which CI already excludes from heavy path filters.

## Test plan
- [ ] `/copilot-cowork-package <agent-name>` produces a valid sideloadable .zip
- [ ] Skill appears as `bifrost:copilot-cowork-package` after plugin reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)