### PR TITLE
fix(tables): promote documents PK to (table_id, id)

### DIFF
--- a/api/alembic/versions/20260518_documents_composite_pk.py
+++ b/api/alembic/versions/20260518_documents_composite_pk.py
@@ -1,0 +1,51 @@
+"""Promote documents PK to composite (table_id, id).
+
+Revision ID: 20260518_documents_composite_pk
+Revises: 20260506_knowledge_dim
+Create Date: 2026-05-18
+
+The original schema (20260101) put the primary key on ``id`` alone, then
+20260102_010000 added a composite unique index ``ix_documents_table_id_id_unique``
+on ``(table_id, id)``. The narrower PK meant document ids were globally
+unique across all tables, which broke any workflow using a shared
+doc-id convention (e.g. ``cache-<org_id>`` across multiple cache tables):
+
+- The second table's write hit ``ON CONFLICT (table_id, id) DO UPDATE``,
+  which only handles the composite unique index — not the PK.
+- The INSERT then violated ``documents_pkey`` on ``id`` alone, raising
+  IntegrityError → global handler → 409 "Resource already exists".
+- Reads filter by ``(table_id, id)`` so the colliding row was invisible
+  to the calling table — appearing as a 404 read / 409 write "zombie".
+
+The fix promotes the PK to ``(table_id, id)``. The composite unique index
+becomes redundant and is dropped.
+
+Since the narrower PK already enforced global uniqueness of ``id``, no
+data prep is needed — every existing row satisfies the wider composite
+PK by construction.
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260518_documents_composite_pk"
+down_revision = "20260506_knowledge_dim"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The composite unique index is redundant once (table_id, id) is the PK.
+    op.drop_index("ix_documents_table_id_id_unique", table_name="documents")
+    op.drop_constraint("documents_pkey", "documents", type_="primary")
+    op.create_primary_key("documents_pkey", "documents", ["table_id", "id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("documents_pkey", "documents", type_="primary")
+    op.create_primary_key("documents_pkey", "documents", ["id"])
+    op.create_index(
+        "ix_documents_table_id_id_unique",
+        "documents",
+        ["table_id", "id"],
+        unique=True,
+    )

--- a/api/src/models/orm/tables.py
+++ b/api/src/models/orm/tables.py
@@ -9,7 +9,15 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, text
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    PrimaryKeyConstraint,
+    String,
+    Text,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -81,9 +89,11 @@ class Document(Base):
 
     __tablename__ = "documents"
 
-    id: Mapped[str] = mapped_column(
-        String(255), primary_key=True, default=lambda: str(uuid4())
-    )
+    # Composite PK ``(table_id, id)`` — declared in ``__table_args__`` below.
+    # Document ids are unique *per table*, not globally; the narrower PK on
+    # ``id`` alone (pre-#256) broke any workflow using a shared doc-id
+    # convention across multiple tables (e.g. ``cache-<org_id>``).
+    id: Mapped[str] = mapped_column(String(255), default=lambda: str(uuid4()))
     table_id: Mapped[UUID] = mapped_column(
         ForeignKey("tables.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False
     )
@@ -104,7 +114,7 @@ class Document(Base):
     table: Mapped["Table"] = relationship("Table", back_populates="documents")
 
     __table_args__ = (
+        PrimaryKeyConstraint("table_id", "id", name="documents_pkey"),
         Index("ix_documents_table_id", "table_id"),
-        # Unique constraint on (table_id, id) handled in migration
         # GIN index on data handled in migration
     )

--- a/api/tests/e2e/platform/test_tables.py
+++ b/api/tests/e2e/platform/test_tables.py
@@ -1144,3 +1144,133 @@ class TestDocumentQueryPaginationStable:
         )
         assert sorted(walked) == sorted(full_ids)
         assert len(set(walked)) == n
+
+
+@pytest.mark.e2e
+class TestDocumentIdUniquePerTable:
+    """Document `id` must be unique *per table*, not platform-wide.
+
+    Regression for #256: the original schema put the primary key on `id`
+    alone, which made document ids globally unique across tables. Workflows
+    using a shared doc-id convention (e.g. ``cache-<org_id>`` across multiple
+    cache tables) would hit a 409 on the second write — because the PK on
+    `id` alone collided with the row from the first table, even though the
+    `(table_id, id)` composite was unique. The fix moves the PK to
+    ``(table_id, id)``.
+
+    The repro path is the SDK-style cache pattern Covi tripped over: same
+    doc id, two different tables, both global scope.
+    """
+
+    def test_same_doc_id_in_two_tables_via_upsert(
+        self, e2e_client, platform_admin
+    ):
+        """Two tables, one doc id — both upserts must succeed and stay independent."""
+        suffix = uuid4().hex[:8]
+        table_a = _create_table(
+            e2e_client, platform_admin.headers, f"pk_a_{suffix}"
+        )
+        table_b = _create_table(
+            e2e_client, platform_admin.headers, f"pk_b_{suffix}"
+        )
+        # The cache-<org_id> shape that Covi hit in prod.
+        doc_id = f"cache-{uuid4()}"
+
+        a = e2e_client.post(
+            f"/api/tables/{table_a}/documents/upsert",
+            headers=platform_admin.headers,
+            json={"id": doc_id, "data": {"table": "a"}},
+        )
+        assert a.status_code == 200, a.text
+
+        b = e2e_client.post(
+            f"/api/tables/{table_b}/documents/upsert",
+            headers=platform_admin.headers,
+            json={"id": doc_id, "data": {"table": "b"}},
+        )
+        assert b.status_code == 200, b.text
+
+        # Each row reads back independently from its own table.
+        get_a = e2e_client.get(
+            f"/api/tables/{table_a}/documents/{doc_id}",
+            headers=platform_admin.headers,
+        )
+        assert get_a.status_code == 200, get_a.text
+        assert get_a.json()["data"] == {"table": "a"}
+
+        get_b = e2e_client.get(
+            f"/api/tables/{table_b}/documents/{doc_id}",
+            headers=platform_admin.headers,
+        )
+        assert get_b.status_code == 200, get_b.text
+        assert get_b.json()["data"] == {"table": "b"}
+
+    def test_same_doc_id_in_two_tables_via_insert(
+        self, e2e_client, platform_admin
+    ):
+        """Same regression via the plain INSERT verb (no upsert flag)."""
+        suffix = uuid4().hex[:8]
+        table_a = _create_table(
+            e2e_client, platform_admin.headers, f"pk_ins_a_{suffix}"
+        )
+        table_b = _create_table(
+            e2e_client, platform_admin.headers, f"pk_ins_b_{suffix}"
+        )
+        doc_id = f"cache-{uuid4()}"
+
+        a = e2e_client.post(
+            f"/api/tables/{table_a}/documents",
+            headers=platform_admin.headers,
+            json={"id": doc_id, "data": {"table": "a"}},
+        )
+        assert a.status_code == 201, a.text
+
+        b = e2e_client.post(
+            f"/api/tables/{table_b}/documents",
+            headers=platform_admin.headers,
+            json={"id": doc_id, "data": {"table": "b"}},
+        )
+        assert b.status_code == 201, b.text
+
+    def test_delete_doc_in_one_table_leaves_other_intact(
+        self, e2e_client, platform_admin
+    ):
+        """Deleting `(table_a, doc_id)` must NOT delete `(table_b, doc_id)`."""
+        suffix = uuid4().hex[:8]
+        table_a = _create_table(
+            e2e_client, platform_admin.headers, f"pk_del_a_{suffix}"
+        )
+        table_b = _create_table(
+            e2e_client, platform_admin.headers, f"pk_del_b_{suffix}"
+        )
+        doc_id = f"cache-{uuid4()}"
+
+        for table_id, payload in ((table_a, "a"), (table_b, "b")):
+            resp = e2e_client.post(
+                f"/api/tables/{table_id}/documents/upsert",
+                headers=platform_admin.headers,
+                json={"id": doc_id, "data": {"table": payload}},
+            )
+            assert resp.status_code == 200, resp.text
+
+        # Delete from table_a only.
+        del_resp = e2e_client.delete(
+            f"/api/tables/{table_a}/documents/{doc_id}",
+            headers=platform_admin.headers,
+        )
+        assert del_resp.status_code == 204, del_resp.text
+
+        # table_a is now empty for this id.
+        get_a = e2e_client.get(
+            f"/api/tables/{table_a}/documents/{doc_id}",
+            headers=platform_admin.headers,
+        )
+        assert get_a.status_code == 404
+
+        # table_b still has its row.
+        get_b = e2e_client.get(
+            f"/api/tables/{table_b}/documents/{doc_id}",
+            headers=platform_admin.headers,
+        )
+        assert get_b.status_code == 200, get_b.text
+        assert get_b.json()["data"] == {"table": "b"}


### PR DESCRIPTION
## Summary
- Document ids are now unique **per table**, not platform-wide.
- Migration drops `documents_pkey` on `(id)` and the redundant `ix_documents_table_id_id_unique`, then creates the composite PK `(table_id, id)`.
- ORM (`api/src/models/orm/tables.py`) updated to match — `id` no longer carries `primary_key=True`; PK declared via `PrimaryKeyConstraint("table_id", "id")` in `__table_args__`.
- E2E regression coverage in `tests/e2e/platform/test_tables.py::TestDocumentIdUniquePerTable` — three cases (upsert, plain insert, delete-isolation) that reproduce the `cache-<org_id>` pattern Covi tripped over.

## Why
The original schema put the PK on `id` alone; a later migration added a composite unique index on `(table_id, id)` but the narrower PK stuck around. `DocumentRepository.upsert` uses `INSERT ... ON CONFLICT (table_id, id) DO UPDATE` — that conflict target matches the composite unique index, not the PK. When a second table tried to write the same doc id, the actual INSERT violated `documents_pkey`, the global handler in `main.py:327` translated the IntegrityError into 409 "Resource already exists", and reads (filtered by `(table_id, id)`) couldn't see the colliding row — surfacing as the 404-read / 409-write "cache zombies" reported on 2026-05-18 (131/222 affected probes in Covi prod).

## Test plan
- [x] `./test.sh tests/e2e/platform/test_tables.py::TestDocumentIdUniquePerTable -v` — three new tests, all pass (verified failing on main first)
- [x] `./test.sh tests/e2e/platform/test_tables.py` — full tables suite, 32/32 pass
- [x] `./test.sh all` — 5039 passed, 49 skipped, 0 failures
- [x] `pyright` + `ruff check` clean on changed files

## Notes
- No data prep needed: the narrower PK already enforced global uniqueness of `id`, so every existing row satisfies the wider composite by construction.
- After this lands, Covi's existing zombie rows can stay where they are — they're real data, just blocking writes to other tables. Once the PK is wider, each table writes independently and the next workflow pass fills in the missing rows.

Fixes #256