### PR TITLE
fix(cli): set User-Agent on version check so WAFs don't 403 it

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -141,8 +141,8 @@ def _check_cli_version() -> None:
     command runs.
     """
     try:
-        import urllib.request
-        import json as _json
+        import httpx
+
         from bifrost import __version__
 
         installed = __version__.lstrip("v")
@@ -164,12 +164,14 @@ def _check_cli_version() -> None:
         if not api_url:
             return
 
-        req = urllib.request.Request(
-            f"{api_url}/api/version",
-            headers={"User-Agent": f"bifrost-cli/{installed}"},
-        )
-        with urllib.request.urlopen(req, timeout=3) as resp:
-            data = _json.loads(resp.read())
+        # Use httpx (already a hard dep via BifrostClient), not urllib.
+        # CDNs/WAFs in front of prod Bifrost instances (Cloudflare on
+        # bifrost.gocovi.com being the live case) 403 the default
+        # `Python-urllib/X.Y` User-Agent. httpx's default UA gets through
+        # and matches what every other SDK request already sends.
+        resp = httpx.get(f"{api_url}/api/version", timeout=3)
+        resp.raise_for_status()
+        data = resp.json()
 
         server_version = (data.get("version") or "").lstrip("v")
         if not server_version:

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -164,7 +164,11 @@ def _check_cli_version() -> None:
         if not api_url:
             return
 
-        with urllib.request.urlopen(f"{api_url}/api/version", timeout=3) as resp:
+        req = urllib.request.Request(
+            f"{api_url}/api/version",
+            headers={"User-Agent": f"bifrost-cli/{installed}"},
+        )
+        with urllib.request.urlopen(req, timeout=3) as resp:
             data = _json.loads(resp.read())
 
         server_version = (data.get("version") or "").lstrip("v")

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -21,6 +21,7 @@ import io
 import json
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 
@@ -56,20 +57,18 @@ def _patch_version(monkeypatch, value: str) -> None:
     monkeypatch.setattr("bifrost.__version__", value, raising=False)
 
 
-def _make_url_response(payload: dict) -> object:
-    """Return a context-manager-shaped fake for ``urllib.request.urlopen``."""
+def _make_url_response(payload: dict, status_code: int = 200) -> httpx.Response:
+    """Return an httpx.Response matching what ``httpx.get`` would yield.
 
-    class _Resp:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_a):
-            return False
-
-        def read(self):
-            return json.dumps(payload).encode()
-
-    return _Resp()
+    ``request=`` must be set or ``raise_for_status()`` raises a
+    ``RuntimeError`` instead of evaluating the status code.
+    """
+    return httpx.Response(
+        status_code=status_code,
+        content=json.dumps(payload).encode(),
+        headers={"content-type": "application/json"},
+        request=httpx.Request("GET", "http://test.example/api/version"),
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -83,7 +82,7 @@ class TestSkipCases:
         _patch_version(monkeypatch, "unknown")
         from bifrost import cli
 
-        with patch("urllib.request.urlopen") as urlopen:
+        with patch("httpx.get") as urlopen:
             cli._check_cli_version()
             urlopen.assert_not_called()
 
@@ -92,7 +91,7 @@ class TestSkipCases:
         _patch_version(monkeypatch, "0.0.0+source")
         from bifrost import cli
 
-        with patch("urllib.request.urlopen") as urlopen:
+        with patch("httpx.get") as urlopen:
             cli._check_cli_version()
             urlopen.assert_not_called()
 
@@ -102,7 +101,7 @@ class TestSkipCases:
         from bifrost import cli
 
         with patch("bifrost.credentials._resolve_url", return_value=None), \
-             patch("urllib.request.urlopen") as urlopen:
+             patch("httpx.get") as urlopen:
             cli._check_cli_version()
             urlopen.assert_not_called()
 
@@ -114,7 +113,7 @@ class TestSkipCases:
         with patch(
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
-        ), patch("urllib.request.urlopen", side_effect=OSError("network down")):
+        ), patch("httpx.get", side_effect=OSError("network down")):
             cli._check_cli_version()  # must not raise SystemExit
 
     def test_skips_on_malformed_response(self, monkeypatch):
@@ -122,20 +121,16 @@ class TestSkipCases:
         _patch_version(monkeypatch, "1.2.3")
         from bifrost import cli
 
-        class _BadResp:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_a):
-                return False
-
-            def read(self):
-                return b"<html>not json</html>"
-
+        bad = httpx.Response(
+            status_code=200,
+            content=b"<html>not json</html>",
+            headers={"content-type": "text/html"},
+            request=httpx.Request("GET", "http://server.example/api/version"),
+        )
         with patch(
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
-        ), patch("urllib.request.urlopen", return_value=_BadResp()):
+        ), patch("httpx.get", return_value=bad):
             cli._check_cli_version()  # must not raise SystemExit
 
     def test_skips_when_server_version_missing(self, monkeypatch):
@@ -147,7 +142,7 @@ class TestSkipCases:
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({}),
         ):
             cli._check_cli_version()  # must not raise SystemExit
@@ -169,7 +164,7 @@ class TestVersionComparison:
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "1.2.3"}),
         ), patch("sys.stderr", stderr):
             cli._check_cli_version()
@@ -185,7 +180,7 @@ class TestVersionComparison:
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "v1.2.3"}),
         ):
             cli._check_cli_version()  # no SystemExit
@@ -199,7 +194,7 @@ class TestVersionComparison:
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "1.3.0"}),
         ):
             with pytest.raises(SystemExit) as excinfo:
@@ -226,7 +221,7 @@ class TestVersionComparison:
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "1.9.9"}),
         ):
             with pytest.raises(SystemExit) as excinfo:
@@ -246,7 +241,7 @@ class TestVersionComparison:
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "0.8.1-dev.47"}),
         ):
             cli._check_cli_version()  # no SystemExit
@@ -261,7 +256,7 @@ class TestVersionComparison:
             "bifrost.credentials._resolve_url",
             return_value="http://server.example",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "0.8.1-dev.48"}),
         ):
             with pytest.raises(SystemExit) as excinfo:
@@ -292,14 +287,14 @@ class TestUrlResolution:
             "bifrost.credentials._resolve_url",
             return_value="http://from-credentials.example",
         ) as resolve, patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "1.2.3"}),
         ) as urlopen:
             cli._check_cli_version()
             resolve.assert_called_once()
             # The /api/version GET should target the URL credentials returned.
-            req = urlopen.call_args[0][0]
-            assert req.full_url == "http://from-credentials.example/api/version"
+            url = urlopen.call_args[0][0]
+            assert url == "http://from-credentials.example/api/version"
 
     def test_loads_dotenv_before_resolving(self, monkeypatch, tmp_path):
         """A project ``.env`` containing BIFROST_API_URL is honored.
@@ -325,7 +320,7 @@ class TestUrlResolution:
         with patch(
             "bifrost.credentials.get_persistent_backend"
         ) as get_backend, patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "1.2.3"}),
         ) as urlopen:
             backend = get_backend.return_value
@@ -333,22 +328,24 @@ class TestUrlResolution:
             backend.get.return_value = None
             cli._check_cli_version()
 
-        # urlopen should have been called against the URL from .env.
-        assert urlopen.called, "urlopen never called — dotenv URL not resolved"
-        req = urlopen.call_args[0][0]
-        assert req.full_url == "http://from-dotenv.example/api/version"
+        # httpx.get should have been called against the URL from .env.
+        assert urlopen.called, "httpx.get never called — dotenv URL not resolved"
+        url = urlopen.call_args[0][0]
+        assert url == "http://from-dotenv.example/api/version"
 
 
-class TestRequestHeaders:
-    def test_sets_non_default_user_agent(self, monkeypatch):
-        """The request must override the default Python-urllib User-Agent.
+class TestTransport:
+    def test_uses_httpx_not_urllib(self, monkeypatch):
+        """Regression: the request must go through httpx, not urllib.
 
-        WAFs in front of production deployments (e.g. Cloudflare on
-        gocovi.com) block the default ``Python-urllib/X.Y`` UA with HTTP
-        403. The exception is swallowed by the best-effort except clause,
-        so the entire version check silently no-ops in prod. Pin a
-        ``bifrost-cli/<version>`` UA so the request actually reaches the
-        server.
+        urllib's default ``Python-urllib/X.Y`` User-Agent is blocked with
+        HTTP 403 by CDNs/WAFs in front of production Bifrost instances
+        (Cloudflare on bifrost.gocovi.com is the live case). The 403 was
+        swallowed by the best-effort except clause, so the entire version
+        check silently no-op'd in prod. httpx's UA gets through and matches
+        what every other SDK request already sends.
+
+        Patch both transports — only the httpx mock should be hit.
         """
         _patch_version(monkeypatch, "1.2.3")
         from bifrost import cli
@@ -357,17 +354,10 @@ class TestRequestHeaders:
             "bifrost.credentials._resolve_url",
             return_value="http://example.com",
         ), patch(
-            "urllib.request.urlopen",
+            "httpx.get",
             return_value=_make_url_response({"version": "1.2.3"}),
-        ) as urlopen:
+        ) as httpx_get, patch("urllib.request.urlopen") as urlopen:
             cli._check_cli_version()
 
-        req = urlopen.call_args[0][0]
-        ua = req.get_header("User-agent")  # urllib normalizes header names
-        assert ua is not None, "request was sent with no User-Agent override"
-        assert not ua.lower().startswith("python-urllib"), (
-            f"User-Agent must not be the urllib default; got {ua!r}"
-        )
-        assert "bifrost-cli" in ua and "1.2.3" in ua, (
-            f"expected bifrost-cli/<version> UA, got {ua!r}"
-        )
+        assert httpx_get.called, "version check did not route through httpx"
+        urlopen.assert_not_called()

--- a/api/tests/unit/cli/test_cli_version_check.py
+++ b/api/tests/unit/cli/test_cli_version_check.py
@@ -298,8 +298,8 @@ class TestUrlResolution:
             cli._check_cli_version()
             resolve.assert_called_once()
             # The /api/version GET should target the URL credentials returned.
-            url = urlopen.call_args[0][0]
-            assert url == "http://from-credentials.example/api/version"
+            req = urlopen.call_args[0][0]
+            assert req.full_url == "http://from-credentials.example/api/version"
 
     def test_loads_dotenv_before_resolving(self, monkeypatch, tmp_path):
         """A project ``.env`` containing BIFROST_API_URL is honored.
@@ -335,5 +335,39 @@ class TestUrlResolution:
 
         # urlopen should have been called against the URL from .env.
         assert urlopen.called, "urlopen never called — dotenv URL not resolved"
-        url = urlopen.call_args[0][0]
-        assert url == "http://from-dotenv.example/api/version"
+        req = urlopen.call_args[0][0]
+        assert req.full_url == "http://from-dotenv.example/api/version"
+
+
+class TestRequestHeaders:
+    def test_sets_non_default_user_agent(self, monkeypatch):
+        """The request must override the default Python-urllib User-Agent.
+
+        WAFs in front of production deployments (e.g. Cloudflare on
+        gocovi.com) block the default ``Python-urllib/X.Y`` UA with HTTP
+        403. The exception is swallowed by the best-effort except clause,
+        so the entire version check silently no-ops in prod. Pin a
+        ``bifrost-cli/<version>`` UA so the request actually reaches the
+        server.
+        """
+        _patch_version(monkeypatch, "1.2.3")
+        from bifrost import cli
+
+        with patch(
+            "bifrost.credentials._resolve_url",
+            return_value="http://example.com",
+        ), patch(
+            "urllib.request.urlopen",
+            return_value=_make_url_response({"version": "1.2.3"}),
+        ) as urlopen:
+            cli._check_cli_version()
+
+        req = urlopen.call_args[0][0]
+        ua = req.get_header("User-agent")  # urllib normalizes header names
+        assert ua is not None, "request was sent with no User-Agent override"
+        assert not ua.lower().startswith("python-urllib"), (
+            f"User-Agent must not be the urllib default; got {ua!r}"
+        )
+        assert "bifrost-cli" in ua and "1.2.3" in ua, (
+            f"expected bifrost-cli/<version> UA, got {ua!r}"
+        )


### PR DESCRIPTION
## Summary

- The CLI version check (`_check_cli_version`) used raw `urllib.request.urlopen()` with no User-Agent override.
- CDNs/WAFs in front of prod (live case: Cloudflare in front of `bifrost.gocovi.com`) block the default `Python-urllib/X.Y` UA with HTTP 403. The exception was swallowed by the best-effort `except`, so the check silently no-op'd and stale CLIs never got prompted to upgrade.
- Send a `bifrost-cli/<version>` UA so the request actually reaches the server. Regression test asserts the request carries a non-default UA in the right shape.

Caught while debugging why `bifrost sync` against `bifrost.gocovi.com` wasn't prompting an upgrade despite a CLI/server version mismatch (`0.9.2-dev.13` vs `0.9.2-dev.14`).

## Test plan

- [x] `./test.sh tests/unit/cli/test_cli_version_check.py -v` — 15/15 pass (14 existing + 1 new)
- [x] `ruff check` on changed files
- [x] Verified against prod: with the fix applied, `_check_cli_version()` now reaches `https://bifrost.gocovi.com/api/version` and fires the upgrade prompt instead of being silently 403'd

🤖 Generated with [Claude Code](https://claude.com/claude-code)