### PR TITLE
refactor(policies): domain-agnostic engine with Resolver/Binding protocols

### DIFF
--- a/api/shared/policies/ast.py
+++ b/api/shared/policies/ast.py
@@ -1,0 +1,204 @@
+"""Pydantic AST types for policy expressions. Domain-agnostic.
+
+The AST validator enforces structural correctness. `{user: ...}` references
+are validated against `KNOWN_USER_FIELDS`; all other single-key namespaces
+(`{row: ...}`, `{file: ...}`, etc.) are accepted structurally as domain
+references — the Resolver validates the field name at evaluate time.
+"""
+from __future__ import annotations
+
+from typing import Any, Final
+
+from pydantic import (
+    BaseModel,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
+
+from shared.policies.functions import FUNCTIONS
+
+KNOWN_USER_FIELDS: Final[frozenset[str]] = frozenset({
+    "user_id",
+    "email",
+    "organization_id",
+    "is_platform_admin",
+    "role_ids",
+    "role_names",
+})
+
+_LOGIC_OPS: Final[frozenset[str]] = frozenset({"and", "or", "not"})
+_COMPARE_OPS: Final[frozenset[str]] = frozenset({"eq", "neq", "lt", "lte", "gt", "gte"})
+# `call` is NOT included here — it is intercepted in _validate_operand
+# before the operator branch, since {"call": ..., "args": ...} can have
+# two keys and doesn't fit the single-key operator shape.
+_OTHER_OPS: Final[frozenset[str]] = frozenset({"in", "is_null"})
+_ALL_OPS: Final[frozenset[str]] = _LOGIC_OPS | _COMPARE_OPS | _OTHER_OPS
+
+_DEPTH_LIMIT: Final[int] = 64
+
+
+def _validate_operand(node: Any, depth: int = 0, path: str = "$") -> None:
+    if depth >= _DEPTH_LIMIT:
+        raise ValueError(
+            f"{path}: expression nested too deeply (>{_DEPTH_LIMIT} levels)"
+        )
+    if isinstance(node, (str, int, float, bool)) or node is None:
+        return
+    if isinstance(node, list):
+        for i, item in enumerate(node):
+            _validate_operand(item, depth + 1, f"{path}[{i}]")
+        return
+    if not isinstance(node, dict):
+        raise ValueError(f"{path}: unexpected operand type: {type(node).__name__}")
+
+    keys = set(node.keys())
+    if keys == {"user"}:
+        ref = node["user"]
+        if ref not in KNOWN_USER_FIELDS:
+            raise ValueError(
+                f"{path}: unknown user field {ref!r}; "
+                f"available: {sorted(KNOWN_USER_FIELDS)}"
+            )
+        return
+    # `call` is handled here (before the single-key operator branch) because
+    # it can carry an `args` key, making it a two-key dict rather than the
+    # single-key shape used by every other operator.
+    if keys == {"call", "args"} or keys == {"call"}:
+        _validate_call(node, depth=depth, path=path)
+        return
+    if len(keys) == 1:
+        op = next(iter(keys))
+        if op in _ALL_OPS:
+            _validate_op_node(op, node[op], depth=depth, path=path)
+            return
+        # Treat as a domain reference: `{ <namespace>: "path.path" }`.
+        # We validate the *shape* here; the Resolver validates the field name.
+        ref = node[op]
+        if not isinstance(ref, str) or not ref:
+            raise ValueError(
+                f"{path}: {op!r} reference must be a non-empty string, got {ref!r}"
+            )
+        return
+    raise ValueError(
+        f"{path}: operator node must have exactly one key, got {sorted(keys)}"
+    )
+
+
+def _validate_op_node(op: str, value: Any, depth: int, path: str) -> None:
+    if op in _LOGIC_OPS - {"not"}:
+        if not isinstance(value, list) or len(value) < 2:
+            raise ValueError(f"{path}.{op}: {op} requires at least two operands")
+        for i, item in enumerate(value):
+            _validate_operand(item, depth + 1, f"{path}.{op}[{i}]")
+        return
+    if op == "not":
+        if isinstance(value, list):
+            raise ValueError(
+                f"{path}.{op}: not requires exactly one operand (not a list)"
+            )
+        _validate_operand(value, depth + 1, f"{path}.{op}")
+        return
+    if op in _COMPARE_OPS:
+        if not isinstance(value, list) or len(value) != 2:
+            raise ValueError(f"{path}.{op}: {op} requires exactly two operands")
+        if op in {"eq", "neq"}:
+            for operand in value:
+                if operand is None:
+                    raise ValueError(
+                        f"{path}.{op}: {op} does not accept null literals "
+                        "(NULL semantics differ between evaluator and SQL "
+                        "pushdown); use is_null instead"
+                    )
+        for i, item in enumerate(value):
+            _validate_operand(item, depth + 1, f"{path}.{op}[{i}]")
+        return
+    if op == "in":
+        if not isinstance(value, list) or len(value) != 2:
+            raise ValueError(f"{path}.{op}: in requires [operand, [literal, ...]]")
+        left, right = value
+        _validate_operand(left, depth + 1, f"{path}.{op}[0]")
+        if not isinstance(right, list) or not right:
+            raise ValueError(
+                f"{path}.{op}: in requires a non-empty literal list as second arg"
+            )
+        for i, item in enumerate(right):
+            if not isinstance(item, (str, int, float, bool)) and item is not None:
+                raise ValueError(
+                    f"{path}.{op}[1][{i}]: in literal list items must be scalars or null"
+                )
+        return
+    if op == "is_null":
+        if isinstance(value, list):
+            raise ValueError(
+                f"{path}.{op}: is_null requires exactly one operand (not a list)"
+            )
+        _validate_operand(value, depth + 1, f"{path}.{op}")
+        return
+
+
+def _validate_call(node: dict, depth: int, path: str) -> None:
+    target = node.get("call")
+    args = node.get("args", [])
+    if not isinstance(target, str):
+        raise ValueError(f"{path}: call target must be a string")
+    if target not in FUNCTIONS:
+        raise ValueError(
+            f"{path}: unknown function {target!r}; available: {sorted(FUNCTIONS)}"
+        )
+    fn = FUNCTIONS[target]
+    if len(args) != len(fn.arg_types):
+        raise ValueError(
+            f"{path}: function {target!r} expects {len(fn.arg_types)} args, "
+            f"got {len(args)}"
+        )
+    for i, (arg, t) in enumerate(zip(args, fn.arg_types)):
+        # `arg_types` is the contract for LITERAL args only. Reference args
+        # ({"row": "..."}, {"user": "..."}) bypass the type check here because
+        # their resolved value is only known at evaluate time. The evaluator
+        # is responsible for handling type mismatches at the row.
+        if isinstance(arg, dict):
+            _validate_operand(arg, depth + 1, f"{path}.args[{i}]")
+            continue
+        if not isinstance(arg, t):
+            raise ValueError(
+                f"{path}.args[{i}]: function {target!r} arg {i} expected "
+                f"{t.__name__}, got {type(arg).__name__}"
+            )
+
+
+class Expr(RootModel[dict]):
+    """Policy expression AST. Validated at construction."""
+
+    @model_validator(mode="after")
+    def _validate(self):
+        _validate_operand(self.root, depth=0, path="$")
+        return self
+
+
+class Policy(BaseModel):
+    """One rule in a policy document. Domain-agnostic.
+
+    `actions` is `list[str]`. Each domain re-types this via Literal at its
+    boundary (e.g. `contracts/policies.py` defines a tables-narrowed Policy
+    where `actions` is `list[Literal["read","create","update","delete"]]`).
+    """
+
+    name: str = Field(min_length=1, max_length=100)
+    description: str | None = None
+    actions: list[str] = Field(min_length=1)
+    when: Expr | None = None
+
+    @field_validator("actions")
+    @classmethod
+    def _no_dup_actions(cls, v: list[str]) -> list[str]:
+        if len(set(v)) != len(v):
+            raise ValueError("actions must not contain duplicates")
+        return v
+
+
+class PolicyDocument(BaseModel):
+    """Container for a list of rules. Resolution is additive OR per action."""
+
+    policies: list[Policy] = Field(default_factory=list)

--- a/api/shared/policies/ast.py
+++ b/api/shared/policies/ast.py
@@ -36,6 +36,13 @@ _COMPARE_OPS: Final[frozenset[str]] = frozenset({"eq", "neq", "lt", "lte", "gt",
 _OTHER_OPS: Final[frozenset[str]] = frozenset({"in", "is_null"})
 _ALL_OPS: Final[frozenset[str]] = _LOGIC_OPS | _COMPARE_OPS | _OTHER_OPS
 
+# Known domain-reference namespaces. The validator accepts these as opaque
+# `{ <namespace>: "field.path" }` references and trusts the domain's Resolver
+# to validate the field name at evaluate time. Adding a new domain (e.g. for
+# documents, runs) means adding its namespace here so the AST validator stops
+# silently accepting `{"<typo>": ...}` as a domain reference.
+_KNOWN_NAMESPACES: Final[frozenset[str]] = frozenset({"row", "file"})
+
 _DEPTH_LIMIT: Final[int] = 64
 
 
@@ -73,14 +80,19 @@ def _validate_operand(node: Any, depth: int = 0, path: str = "$") -> None:
         if op in _ALL_OPS:
             _validate_op_node(op, node[op], depth=depth, path=path)
             return
-        # Treat as a domain reference: `{ <namespace>: "path.path" }`.
-        # We validate the *shape* here; the Resolver validates the field name.
-        ref = node[op]
-        if not isinstance(ref, str) or not ref:
-            raise ValueError(
-                f"{path}: {op!r} reference must be a non-empty string, got {ref!r}"
-            )
-        return
+        if op in _KNOWN_NAMESPACES:
+            # Domain reference: `{ <namespace>: "path.path" }`.
+            # Shape validated here; the Resolver validates the field name.
+            ref = node[op]
+            if not isinstance(ref, str) or not ref:
+                raise ValueError(
+                    f"{path}: {op!r} reference must be a non-empty string, got {ref!r}"
+                )
+            return
+        raise ValueError(
+            f"{path}: unknown operator or namespace {op!r}; "
+            f"operators: {sorted(_ALL_OPS)}, namespaces: {sorted(_KNOWN_NAMESPACES)}"
+        )
     raise ValueError(
         f"{path}: operator node must have exactly one key, got {sorted(keys)}"
     )

--- a/api/shared/policies/binding.py
+++ b/api/shared/policies/binding.py
@@ -1,0 +1,30 @@
+"""Binding protocol — domain-agnostic reference resolution at compile time.
+
+Domains with a SQL surface (tables) implement a Binding that maps
+`{<namespace>: path}` references to SQLAlchemy column expressions. Domains
+without a SQL surface (files — list operations are S3 prefix-bound; the
+evaluator filters in Python) do not implement Binding.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+from sqlalchemy.sql import ColumnElement
+
+
+@runtime_checkable
+class Binding(Protocol):
+    """Resolves `{<namespace>: path}` references to SQLAlchemy columns."""
+
+    namespace: ClassVar[str] = ""
+    """Must match the matching Resolver's namespace for the same domain.
+
+    The default empty string satisfies Protocol structural checks (a bare
+    `ClassVar` annotation on a Protocol is not visible to `hasattr` or
+    `isinstance`). Concrete bindings must override with a non-empty domain
+    string.
+    """
+
+    def resolve_reference(self, path: str) -> ColumnElement[Any]:
+        """Map a dot-path into a SQLAlchemy column expression."""
+        ...

--- a/api/shared/policies/compile.py
+++ b/api/shared/policies/compile.py
@@ -1,11 +1,14 @@
-"""SQL compiler for policy expressions.
+"""SQL compiler for policy expressions. Domain-agnostic.
 
-Compiles an Expr to a SQLAlchemy boolean expression suitable for ANDing
-into a SELECT against the documents table. User-side facts and function
-calls are resolved at compile time; the resulting SQL contains only
-parameterized literals against the `documents` table.
+Reference resolution at compile time is delegated to a Binding. The compiler
+walker knows literals, the `{user: ...}` namespace, `{call: ...}`, and
+operators; everything else under a single-key dict is treated as a domain
+reference and dispatched to the Binding.
+
+User-side facts and function calls are resolved at compile time. The
+resulting SQL contains only parameterized literals against the columns the
+Binding produces.
 """
-
 from __future__ import annotations
 
 from typing import Any
@@ -19,72 +22,41 @@ from sqlalchemy import or_ as sa_or
 from sqlalchemy import true as sa_true
 from sqlalchemy.sql import ColumnElement
 
+from shared.policies.ast import Expr
+from shared.policies.binding import Binding
 from shared.policies.functions import FUNCTIONS
-from src.models.contracts.policies import Expr
-from src.models.orm.tables import Document
-
-# Column-mapped row references — read from the SQL column, not JSONB.
-_COLUMN_MAPPED_ROW_FIELDS: dict[str, Any] = {
-    "id": Document.id,
-    "organization_id": None,  # documents has no organization_id; comes from join — see note below
-    "created_by": Document.created_by,
-    "updated_by": Document.updated_by,
-    "created_at": Document.created_at,
-    "updated_at": Document.updated_at,
-    "table_id": Document.table_id,
-}
-
-# NOTE on `organization_id`: documents are scoped via their parent table.
-# When the compiler is invoked from a query handler, the handler already
-# applies a `Table.organization_id` filter at the join. References to
-# `row.organization_id` in policies fall through to the data JSONB lookup
-# (`data->>'organization_id'`) — apps that need this should denormalize
-# the org id into the row's data JSONB at insert time.
 
 
-def compile_to_sql(expr: Expr, user: Any) -> ColumnElement:
-    """Compile an Expr to a SQLAlchemy boolean expression."""
-    return _compile_node(expr.root, user)
+def compile_to_sql(expr: Expr, user: Any, binding: Binding) -> ColumnElement[Any]:
+    """Compile an Expr to a SQLAlchemy boolean expression for the binding's domain."""
+    return _compile_node(expr.root, user, binding)
 
 
-def _compile_node(node: Any, user: Any) -> ColumnElement:
+def _compile_node(node: Any, user: Any, binding: Binding) -> ColumnElement[Any]:
     if isinstance(node, dict):
         keys = set(node.keys())
         if keys == {"user"}:
             return _resolve_user_to_literal(user, node["user"])
-        if keys == {"row"}:
-            return _resolve_row_to_column(node["row"])
+        if keys == {binding.namespace}:
+            return binding.resolve_reference(node[binding.namespace])
         if "call" in keys:
             return _compile_call(node, user)
         if len(keys) == 1:
             op = next(iter(keys))
-            return _compile_op(op, node[op], user)
+            return _compile_op(op, node[op], user, binding)
     if isinstance(node, (str, int, float, bool)) or node is None:
         return literal(node)
     raise ValueError(f"unrendable node: {node!r}")
 
 
-def _resolve_user_to_literal(user: Any, field: str) -> ColumnElement:
+def _resolve_user_to_literal(user: Any, field: str) -> ColumnElement[Any]:
     val = getattr(user, field, None)
     if isinstance(val, UUID):
         val = str(val)
     return literal(val)
 
 
-def _resolve_row_to_column(path: str) -> ColumnElement:
-    parts = path.split(".")
-    if len(parts) == 1 and parts[0] in _COLUMN_MAPPED_ROW_FIELDS:
-        col = _COLUMN_MAPPED_ROW_FIELDS[parts[0]]
-        if col is not None:
-            return col
-    # JSONB path
-    if len(parts) == 1:
-        return Document.data[parts[0]].astext
-    # Nested: data #>> '{a,b,c}'
-    return Document.data[parts].astext  # SQLAlchemy supports list keys
-
-
-def _compile_call(node: dict, user: Any) -> ColumnElement:
+def _compile_call(node: dict, user: Any) -> ColumnElement[Any]:
     target = node["call"]
     args = [_resolve_arg_for_call(a, user) for a in node.get("args", [])]
     fn = FUNCTIONS[target]
@@ -95,10 +67,11 @@ def _compile_call(node: dict, user: Any) -> ColumnElement:
 def _resolve_arg_for_call(arg: Any, user: Any) -> Any:
     """Resolve a call arg to its concrete Python value at compile time.
 
-    Function args must be literals or {"user": ...} references — row
-    references can't be resolved at compile time. The validator allows
-    {"row": ...} structurally, but reaching it here is a programming error;
-    surfacing as ValueError prevents silently-wrong SQL.
+    Function args must be literals or {"user": ...} references — domain
+    references (e.g. {"row": ...}, {"file": ...}) can't be resolved at compile
+    time because they need a row context. The validator accepts dict args
+    structurally; reaching here with anything other than {"user": ...} is a
+    programming error.
     """
     if isinstance(arg, dict):
         keys = set(arg.keys())
@@ -111,31 +84,31 @@ def _resolve_arg_for_call(arg: Any, user: Any) -> Any:
     return arg  # literal
 
 
-def _compile_op(op: str, value: Any, user: Any) -> ColumnElement:
+def _compile_op(op: str, value: Any, user: Any, binding: Binding) -> ColumnElement[Any]:
     if op == "and":
-        return sa_and(*(_compile_node(item, user) for item in value))
+        return sa_and(*(_compile_node(item, user, binding) for item in value))
     if op == "or":
-        return sa_or(*(_compile_node(item, user) for item in value))
+        return sa_or(*(_compile_node(item, user, binding) for item in value))
     if op == "not":
         # `.self_group()` prevents SQLAlchemy from collapsing
         # `not_(x == y)` into `x != y`; we want a literal NOT(...) so
         # NULL-as-false semantics survive the negation.
-        return sa_not(_compile_node(value, user).self_group())
+        return sa_not(_compile_node(value, user, binding).self_group())
     if op == "eq":
-        return _compile_node(value[0], user) == _compile_node(value[1], user)
+        return _compile_node(value[0], user, binding) == _compile_node(value[1], user, binding)
     if op == "neq":
-        return _compile_node(value[0], user) != _compile_node(value[1], user)
+        return _compile_node(value[0], user, binding) != _compile_node(value[1], user, binding)
     if op == "lt":
-        return _compile_node(value[0], user) < _compile_node(value[1], user)
+        return _compile_node(value[0], user, binding) < _compile_node(value[1], user, binding)
     if op == "lte":
-        return _compile_node(value[0], user) <= _compile_node(value[1], user)
+        return _compile_node(value[0], user, binding) <= _compile_node(value[1], user, binding)
     if op == "gt":
-        return _compile_node(value[0], user) > _compile_node(value[1], user)
+        return _compile_node(value[0], user, binding) > _compile_node(value[1], user, binding)
     if op == "gte":
-        return _compile_node(value[0], user) >= _compile_node(value[1], user)
+        return _compile_node(value[0], user, binding) >= _compile_node(value[1], user, binding)
     if op == "in":
-        left = _compile_node(value[0], user)
+        left = _compile_node(value[0], user, binding)
         return left.in_(value[1])
     if op == "is_null":
-        return _compile_node(value, user).is_(None)
+        return _compile_node(value, user, binding).is_(None)
     raise ValueError(f"unknown operator {op!r}")

--- a/api/shared/policies/evaluate.py
+++ b/api/shared/policies/evaluate.py
@@ -1,65 +1,43 @@
-"""Pure-function policy evaluator.
+"""Pure-function policy evaluator. Domain-agnostic.
 
-Takes an Expr, a row dict, and a user-like object; returns bool.
-No DB access. No side effects. Used at REST handler call sites for
-per-row decisions and at websocket fanout for per-message filtering.
+Reference resolution is delegated to a Resolver. The walker only knows
+about literals, the `{user: ...}` namespace, `{call: ...}`, operators,
+and "everything else is a domain reference handled by the Resolver".
 """
-
 from __future__ import annotations
 
 from typing import Any
 from uuid import UUID
 
+from shared.policies.ast import Expr
 from shared.policies.functions import FUNCTIONS
-from src.models.contracts.policies import Expr
+from shared.policies.resolver import Resolver
 
 
-def evaluate(expr: Expr, row: dict | None, user: Any) -> bool:
-    """Evaluate an expression against a row + user, return bool.
-
-    `row` may be a dict (the typical case) or None (e.g., DELETE events
-    with no payload). Missing keys resolve to None. UUID-typed values
-    in user are stringified before comparison.
-    """
-    return bool(_eval_node(expr.root, row, user))
+def evaluate(expr: Expr, ctx: Any, user: Any, resolver: Resolver) -> bool:
+    """Evaluate an expression against a domain ctx + user, return bool."""
+    return bool(_eval_node(expr.root, ctx, user, resolver))
 
 
-def _eval_node(node: Any, row: dict | None, user: Any) -> Any:
-    """Resolve a node to its value (literal, reference, or operator result)."""
-    # Literals
+def _eval_node(node: Any, ctx: Any, user: Any, resolver: Resolver) -> Any:
     if isinstance(node, (str, int, float, bool)) or node is None:
         return node
     if isinstance(node, list):
-        return [_eval_node(item, row, user) for item in node]
+        return [_eval_node(item, ctx, user, resolver) for item in node]
 
-    # References
     if isinstance(node, dict):
         keys = set(node.keys())
-        if keys == {"row"}:
-            return _resolve_row_path(row, node["row"])
         if keys == {"user"}:
             return _resolve_user_field(user, node["user"])
+        if keys == {resolver.namespace}:
+            return resolver.resolve(node[resolver.namespace], ctx)
         if "call" in keys:
-            return _eval_call(node, row, user)
-        # Operators: single-key dict
+            return _eval_call(node, ctx, user, resolver)
         if len(keys) == 1:
             op = next(iter(keys))
-            return _eval_op(op, node[op], row, user)
+            return _eval_op(op, node[op], ctx, user, resolver)
 
     raise ValueError(f"unevaluatable node: {node!r}")
-
-
-def _resolve_row_path(row: dict | None, path: str) -> Any:
-    """Resolve dot-path against the row dict; missing keys return None."""
-    parts = path.split(".")
-    cur: Any = row
-    for part in parts:
-        if not isinstance(cur, dict):
-            return None
-        cur = cur.get(part)
-        if cur is None:
-            return None
-    return cur
 
 
 def _resolve_user_field(user: Any, field: str) -> Any:
@@ -73,33 +51,44 @@ def _resolve_user_field(user: Any, field: str) -> Any:
     return val
 
 
-def _eval_call(node: dict, row: dict | None, user: Any) -> bool:
+def _eval_call(node: dict, ctx: Any, user: Any, resolver: Resolver) -> bool:
     target = node["call"]
-    args = [_eval_node(a, row, user) for a in node.get("args", [])]
+    args = [_eval_node(a, ctx, user, resolver) for a in node.get("args", [])]
     fn = FUNCTIONS[target]
-    return fn.evaluate(args, user, row)
+    # FunctionDef.evaluate is typed `(args, user, dict) -> bool` because the only
+    # registered function (has_role) doesn't use the row. When ctx is not a dict
+    # (e.g., a DELETE event with no payload, or a non-row domain like files),
+    # pass {} — registering a future function that needs row data requires
+    # widening FunctionDef.evaluate's third arg to Any.
+    return fn.evaluate(args, user, ctx if isinstance(ctx, dict) else {})
 
 
-def _eval_op(op: str, value: Any, row: dict | None, user: Any) -> bool:
+def _eval_op(op: str, value: Any, ctx: Any, user: Any, resolver: Resolver) -> bool:
     if op == "and":
         for item in value:
-            if not _eval_node(item, row, user):
+            if not _eval_node(item, ctx, user, resolver):
                 return False
         return True
     if op == "or":
         for item in value:
-            if _eval_node(item, row, user):
+            if _eval_node(item, ctx, user, resolver):
                 return True
         return False
     if op == "not":
-        return not _eval_node(value, row, user)
+        return not _eval_node(value, ctx, user, resolver)
     if op == "eq":
-        return _scalar_eq(_eval_node(value[0], row, user), _eval_node(value[1], row, user))
+        return _scalar_eq(
+            _eval_node(value[0], ctx, user, resolver),
+            _eval_node(value[1], ctx, user, resolver),
+        )
     if op == "neq":
-        return not _scalar_eq(_eval_node(value[0], row, user), _eval_node(value[1], row, user))
+        return not _scalar_eq(
+            _eval_node(value[0], ctx, user, resolver),
+            _eval_node(value[1], ctx, user, resolver),
+        )
     if op in ("lt", "lte", "gt", "gte"):
-        a = _eval_node(value[0], row, user)
-        b = _eval_node(value[1], row, user)
+        a = _eval_node(value[0], ctx, user, resolver)
+        b = _eval_node(value[1], ctx, user, resolver)
         if a is None or b is None:
             return False
         try:
@@ -114,21 +103,21 @@ def _eval_op(op: str, value: Any, row: dict | None, user: Any) -> bool:
         except TypeError:
             return False
     if op == "in":
-        a = _eval_node(value[0], row, user)
+        a = _eval_node(value[0], ctx, user, resolver)
         if a is None:
             return False
         return a in value[1]
     if op == "is_null":
-        return _eval_node(value, row, user) is None
+        return _eval_node(value, ctx, user, resolver) is None
     raise ValueError(f"unknown operator {op!r}")
 
 
 def _scalar_eq(a: Any, b: Any) -> bool:
     """Equality with NULL-as-false semantics (matches SQL).
 
-    If either operand resolves to None at evaluate time (e.g. a {"row": ...}
-    reference to a missing field), returns False. Literal None is rejected at
-    validate time, so the only legitimate caller of this guard is a reference
+    If either operand resolves to None at evaluate time (e.g. a reference
+    to a missing field), returns False. Literal None is rejected at validate
+    time, so the only legitimate caller of this guard is a reference
     resolving to None. Use `is_null` to test for null.
     """
     if a is None or b is None:

--- a/api/shared/policies/probe.py
+++ b/api/shared/policies/probe.py
@@ -36,6 +36,33 @@ class _RowResolverForEngine:
         return cur
 
 
+# TEMPORARY: Task 6 replaces this with `from shared.table_policies import TableBinding`.
+# Mirrors the pre-Task-5 hardcoded column mapping inside compile.py.
+class _TableBindingForEngine:
+    """Mirrors the pre-Task-5 hardcoded {row: ...} → Document column logic."""
+    namespace = "row"
+
+    def resolve_reference(self, path):
+        from src.models.orm.tables import Document
+        _COLUMN_MAPPED_ROW_FIELDS = {
+            "id": Document.id,
+            "organization_id": None,
+            "created_by": Document.created_by,
+            "updated_by": Document.updated_by,
+            "created_at": Document.created_at,
+            "updated_at": Document.updated_at,
+            "table_id": Document.table_id,
+        }
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in _COLUMN_MAPPED_ROW_FIELDS:
+            col = _COLUMN_MAPPED_ROW_FIELDS[parts[0]]
+            if col is not None:
+                return col
+        if len(parts) == 1:
+            return Document.data[parts[0]].astext
+        return Document.data[parts].astext
+
+
 def evaluate_action(
     action: str,
     policies: TablePolicies,
@@ -68,7 +95,7 @@ def compile_read_filter(
         if policy.when is None:
             fragments.append(sa_true())
             continue
-        fragments.append(compile_to_sql(policy.when, user))
+        fragments.append(compile_to_sql(policy.when, user, _TableBindingForEngine()))
     if not fragments:
         return None
     if len(fragments) == 1:

--- a/api/shared/policies/probe.py
+++ b/api/shared/policies/probe.py
@@ -17,6 +17,25 @@ from shared.policies.evaluate import evaluate
 from src.models.contracts.policies import TablePolicies
 
 
+# TEMPORARY: Task 6 replaces this with `from shared.table_policies import RowResolver`.
+# Defined inline here so the engine refactor of Task 4 keeps tests green without
+# requiring shared.table_policies (which doesn't exist yet).
+class _RowResolverForEngine:
+    """Mirrors the pre-Task-4 hardcoded {row: ...} resolution semantics."""
+    namespace = "row"
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        parts = path.split(".")
+        cur = ctx
+        for p in parts:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(p)
+            if cur is None:
+                return None
+        return cur
+
+
 def evaluate_action(
     action: str,
     policies: TablePolicies,
@@ -29,7 +48,7 @@ def evaluate_action(
             continue
         if policy.when is None:
             return True
-        if evaluate(policy.when, row=row, user=user):
+        if evaluate(policy.when, ctx=row, user=user, resolver=_RowResolverForEngine()):
             return True
     return False
 
@@ -71,7 +90,7 @@ def is_subscribe_authorized(policies: TablePolicies, user: Any) -> bool:
             return True
         if _is_purely_user_dependent(policy.when.root):
             # Resolve immediately — no row context affects the answer
-            if evaluate(policy.when, row={}, user=user):
+            if evaluate(policy.when, ctx={}, user=user, resolver=_RowResolverForEngine()):
                 return True
             continue
         # Row-data-dependent → conservatively allow

--- a/api/shared/policies/probe.py
+++ b/api/shared/policies/probe.py
@@ -1,73 +1,25 @@
-"""High-level policy helpers used by REST handlers and the websocket layer.
+"""Action-level policy helpers. Domain-agnostic.
 
-These wrap the evaluator and compiler with action-aware logic and provide
-the seeded admin-bypass default.
+`evaluate_action` and `is_subscribe_authorized` walk the rules in a
+PolicyDocument and dispatch to `evaluate` (which itself dispatches to a
+Resolver). Domain-specific helpers (e.g. `compile_read_filter`,
+`make_seed_admin_bypass`) live in the domain module.
 """
-
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import or_ as sa_or
-from sqlalchemy import true as sa_true
-from sqlalchemy.sql import ColumnElement
-
-from shared.policies.compile import compile_to_sql
+from shared.policies.ast import PolicyDocument
 from shared.policies.evaluate import evaluate
-from src.models.contracts.policies import TablePolicies
-
-
-# TEMPORARY: Task 6 replaces this with `from shared.table_policies import RowResolver`.
-# Defined inline here so the engine refactor of Task 4 keeps tests green without
-# requiring shared.table_policies (which doesn't exist yet).
-class _RowResolverForEngine:
-    """Mirrors the pre-Task-4 hardcoded {row: ...} resolution semantics."""
-    namespace = "row"
-
-    def resolve(self, path: str, ctx: Any) -> Any:
-        parts = path.split(".")
-        cur = ctx
-        for p in parts:
-            if not isinstance(cur, dict):
-                return None
-            cur = cur.get(p)
-            if cur is None:
-                return None
-        return cur
-
-
-# TEMPORARY: Task 6 replaces this with `from shared.table_policies import TableBinding`.
-# Mirrors the pre-Task-5 hardcoded column mapping inside compile.py.
-class _TableBindingForEngine:
-    """Mirrors the pre-Task-5 hardcoded {row: ...} → Document column logic."""
-    namespace = "row"
-
-    def resolve_reference(self, path):
-        from src.models.orm.tables import Document
-        _COLUMN_MAPPED_ROW_FIELDS = {
-            "id": Document.id,
-            "organization_id": None,
-            "created_by": Document.created_by,
-            "updated_by": Document.updated_by,
-            "created_at": Document.created_at,
-            "updated_at": Document.updated_at,
-            "table_id": Document.table_id,
-        }
-        parts = path.split(".")
-        if len(parts) == 1 and parts[0] in _COLUMN_MAPPED_ROW_FIELDS:
-            col = _COLUMN_MAPPED_ROW_FIELDS[parts[0]]
-            if col is not None:
-                return col
-        if len(parts) == 1:
-            return Document.data[parts[0]].astext
-        return Document.data[parts].astext
+from shared.policies.resolver import Resolver
 
 
 def evaluate_action(
     action: str,
-    policies: TablePolicies,
-    row: dict,
+    policies: PolicyDocument,
+    ctx: Any,
     user: Any,
+    resolver: Resolver,
 ) -> bool:
     """OR across all rules whose `actions` includes `action`. Default deny."""
     for policy in policies.policies:
@@ -75,88 +27,44 @@ def evaluate_action(
             continue
         if policy.when is None:
             return True
-        if evaluate(policy.when, ctx=row, user=user, resolver=_RowResolverForEngine()):
+        if evaluate(policy.when, ctx=ctx, user=user, resolver=resolver):
             return True
     return False
 
 
-def compile_read_filter(
-    policies: TablePolicies,
+def is_subscribe_authorized(
+    policies: PolicyDocument,
     user: Any,
-) -> ColumnElement | None:
-    """Compile the OR of all read-allowing rules into a single WHERE clause.
-
-    Returns None if no policy grants read (the handler must deny).
-    """
-    fragments: list[ColumnElement] = []
-    for policy in policies.policies:
-        if "read" not in policy.actions:
-            continue
-        if policy.when is None:
-            fragments.append(sa_true())
-            continue
-        fragments.append(compile_to_sql(policy.when, user, _TableBindingForEngine()))
-    if not fragments:
-        return None
-    if len(fragments) == 1:
-        return fragments[0]
-    return sa_or(*fragments)
-
-
-def is_subscribe_authorized(policies: TablePolicies, user: Any) -> bool:
-    """Probe: would ANY read message ever reach this user on this table?
-
-    For row-data-dependent policies, we conservatively allow subscribe and
-    let the per-message filter do the actual gating. For user-only policies
-    (e.g. is_platform_admin), we resolve at probe time.
-    """
+    resolver: Resolver,
+) -> bool:
+    """Probe: would ANY read message ever reach this user?"""
     for policy in policies.policies:
         if "read" not in policy.actions:
             continue
         if policy.when is None:
             return True
-        if _is_purely_user_dependent(policy.when.root):
-            # Resolve immediately — no row context affects the answer
-            if evaluate(policy.when, ctx={}, user=user, resolver=_RowResolverForEngine()):
+        if _is_purely_user_dependent(policy.when.root, resolver):
+            if evaluate(policy.when, ctx={}, user=user, resolver=resolver):
                 return True
             continue
-        # Row-data-dependent → conservatively allow
         return True
     return False
 
 
-def _is_purely_user_dependent(node: Any) -> bool:
+def _is_purely_user_dependent(node: Any, resolver: Resolver) -> bool:
     """True if the expression references only USER fields and literals."""
     if isinstance(node, (str, int, float, bool)) or node is None:
         return True
     if isinstance(node, list):
-        return all(_is_purely_user_dependent(x) for x in node)
+        return all(_is_purely_user_dependent(x, resolver) for x in node)
     if isinstance(node, dict):
         keys = set(node.keys())
-        if keys == {"row"}:
+        if keys == {resolver.namespace}:
             return False
         if keys == {"user"}:
             return True
         if "call" in keys:
-            return all(_is_purely_user_dependent(a) for a in node.get("args", []))
+            return all(_is_purely_user_dependent(a, resolver) for a in node.get("args", []))
         if len(keys) == 1:
-            return _is_purely_user_dependent(node[next(iter(keys))])
+            return _is_purely_user_dependent(node[next(iter(keys))], resolver)
     return False
-
-
-def make_seed_admin_bypass() -> dict:
-    """The default policies dict for a freshly-created table.
-
-    Stored verbatim into Table.access at create time. Visible/editable
-    in the policy editor; can be removed if an org wants strict audit.
-    """
-    return {
-        "policies": [
-            {
-                "name": "admin_bypass",
-                "description": "Platform admins bypass all checks. Edit or delete to enforce stricter audit.",
-                "actions": ["read", "create", "update", "delete"],
-                "when": {"user": "is_platform_admin"},
-            }
-        ]
-    }

--- a/api/shared/policies/resolver.py
+++ b/api/shared/policies/resolver.py
@@ -1,0 +1,24 @@
+"""Resolver protocol — domain-agnostic reference resolution at evaluate time.
+
+Each domain (tables, files, ...) implements a Resolver that knows how to look
+up `{<namespace>: path}` references against its context shape. The evaluator
+walker treats Resolver opaquely; the namespace string is the only piece of
+domain knowledge the walker carries.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Resolver(Protocol):
+    """Resolves `{<namespace>: path}` references against a domain context."""
+
+    namespace: ClassVar[str]
+    """The reference namespace key this resolver handles. E.g. "row" for tables,
+    "file" for files. The walker compares against `set(node.keys()) == {namespace}`.
+    """
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        """Resolve a dot-path against the domain ctx. Missing returns None."""
+        ...

--- a/api/shared/policies/subscription.py
+++ b/api/shared/policies/subscription.py
@@ -25,6 +25,25 @@ from shared.policies.evaluate import evaluate
 from shared.policies.probe import evaluate_action
 from src.models.contracts.policies import Expr, TablePolicies
 
+
+# TEMPORARY: Task 6 replaces this with `from shared.table_policies import RowResolver`.
+# Defined inline here so the engine refactor of Task 4 keeps tests green without
+# requiring shared.table_policies (which doesn't exist yet).
+class _RowResolverForEngine:
+    """Mirrors the pre-Task-4 hardcoded {row: ...} resolution semantics."""
+    namespace = "row"
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        parts = path.split(".")
+        cur = ctx
+        for p in parts:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(p)
+            if cur is None:
+                return None
+        return cur
+
 Action = Literal["insert", "update", "delete"]
 
 
@@ -42,7 +61,7 @@ def is_row_visible(
         return False
     if not evaluate_action("read", policies, row, user):
         return False
-    if user_filter is not None and not evaluate(user_filter, row=row, user=user):
+    if user_filter is not None and not evaluate(user_filter, ctx=row, user=user, resolver=_RowResolverForEngine()):
         return False
     return True
 

--- a/api/shared/policies/subscription.py
+++ b/api/shared/policies/subscription.py
@@ -1,93 +1,54 @@
-"""Per-message visibility decision for table subscriptions.
+"""Per-message visibility decision for subscriptions.
 
-The websocket layer receives `document_change` events with both the pre-mutation
-row (`old_row`) and the post-mutation row (`new_row`). For each subscriber, the
-visibility of these two rows under the table's policies (and any user-supplied
-filter) determines which event — if any — to deliver:
-
-    old_visible | new_visible | emitted action
-    ----------- | ----------- | --------------
-    False       | False       | (nothing — row stays out of view)
-    False       | True        | "insert" (row becomes visible)
-    True        | False       | "delete" (row leaves visibility)
-    True        | True        | "update" (row stays in view, content changed)
-
-This module centralizes that logic so it can be unit-tested without standing
-up a websocket connection. The websocket router calls `decide_visibility_change`
-once per message per subscriber.
+Domain-agnostic. The four-way visibility transition table
+(old_visible × new_visible → emitted action) is the same for any
+domain that ships row-like change events.
 """
-
 from __future__ import annotations
 
 from typing import Any, Literal
 
+from shared.policies.ast import Expr, PolicyDocument
 from shared.policies.evaluate import evaluate
 from shared.policies.probe import evaluate_action
-from src.models.contracts.policies import Expr, TablePolicies
-
-
-# TEMPORARY: Task 6 replaces this with `from shared.table_policies import RowResolver`.
-# Defined inline here so the engine refactor of Task 4 keeps tests green without
-# requiring shared.table_policies (which doesn't exist yet).
-class _RowResolverForEngine:
-    """Mirrors the pre-Task-4 hardcoded {row: ...} resolution semantics."""
-    namespace = "row"
-
-    def resolve(self, path: str, ctx: Any) -> Any:
-        parts = path.split(".")
-        cur = ctx
-        for p in parts:
-            if not isinstance(cur, dict):
-                return None
-            cur = cur.get(p)
-            if cur is None:
-                return None
-        return cur
+from shared.policies.resolver import Resolver
 
 Action = Literal["insert", "update", "delete"]
 
 
 def is_row_visible(
-    row: dict | None,
-    policies: TablePolicies,
+    ctx: dict | None,
+    policies: PolicyDocument,
     user: Any,
+    resolver: Resolver,
     user_filter: Expr | None = None,
 ) -> bool:
-    """True iff the row is readable AND passes the user-supplied filter.
-
-    A None row is never visible (used for inserts' old side and deletes' new side).
-    """
-    if row is None:
+    """True iff ctx is readable AND passes the user-supplied filter."""
+    if ctx is None:
         return False
-    if not evaluate_action("read", policies, row, user):
+    if not evaluate_action("read", policies, ctx, user, resolver):
         return False
-    if user_filter is not None and not evaluate(user_filter, ctx=row, user=user, resolver=_RowResolverForEngine()):
+    if user_filter is not None and not evaluate(user_filter, ctx=ctx, user=user, resolver=resolver):
         return False
     return True
 
 
 def decide_visibility_change(
-    old_row: dict | None,
-    new_row: dict | None,
-    policies: TablePolicies,
+    old_ctx: dict | None,
+    new_ctx: dict | None,
+    policies: PolicyDocument,
     user: Any,
+    resolver: Resolver,
     user_filter: Expr | None = None,
 ) -> tuple[Action, dict | str | None] | None:
-    """Compute the four-way fanout decision.
-
-    Returns:
-        None if the row is not (and was not) visible to this user.
-        ("insert", new_row) if visibility was gained.
-        ("update", new_row) if visibility persisted.
-        ("delete", old_row_id) if visibility was lost.
-    """
-    old_visible = is_row_visible(old_row, policies, user, user_filter)
-    new_visible = is_row_visible(new_row, policies, user, user_filter)
+    """Compute the four-way fanout decision."""
+    old_visible = is_row_visible(old_ctx, policies, user, resolver, user_filter)
+    new_visible = is_row_visible(new_ctx, policies, user, resolver, user_filter)
 
     if not old_visible and not new_visible:
         return None
     if not old_visible and new_visible:
-        return ("insert", new_row)
+        return ("insert", new_ctx)
     if old_visible and not new_visible:
-        return ("delete", (old_row or {}).get("id"))
-    return ("update", new_row)
+        return ("delete", (old_ctx or {}).get("id"))
+    return ("update", new_ctx)

--- a/api/shared/table_policies.py
+++ b/api/shared/table_policies.py
@@ -1,0 +1,121 @@
+"""Table-domain bindings for the shared policy engine.
+
+This module is the only thing that knows about `Document`, the
+`_COLUMN_MAPPED_ROW_FIELDS` mapping, the table action vocab (`read`,
+`create`, `update`, `delete`), and the seeded admin-bypass shape for
+tables. The shared engine in `shared/policies/` consumes these via the
+Resolver and Binding protocols.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from sqlalchemy import or_ as sa_or
+from sqlalchemy import true as sa_true
+from sqlalchemy.sql import ColumnElement
+
+from shared.policies.ast import PolicyDocument
+from shared.policies.compile import compile_to_sql
+from src.models.orm.tables import Document
+
+# Re-export so handlers can import the tables-typed name.
+TablePolicies = PolicyDocument
+
+# Column-mapped row references — read from the SQL column, not JSONB.
+_COLUMN_MAPPED_ROW_FIELDS: dict[str, Any] = {
+    "id": Document.id,
+    "organization_id": None,  # documents has no organization_id; comes from join
+    "created_by": Document.created_by,
+    "updated_by": Document.updated_by,
+    "created_at": Document.created_at,
+    "updated_at": Document.updated_at,
+    "table_id": Document.table_id,
+}
+
+# NOTE on `organization_id`: documents are scoped via their parent table.
+# When the compiler is invoked from a query handler, the handler already
+# applies a `Table.organization_id` filter at the join. References to
+# `row.organization_id` in policies fall through to the data JSONB lookup
+# (`data->>'organization_id'`) — apps that need this should denormalize
+# the org id into the row's data JSONB at insert time.
+
+
+class RowResolver:
+    """Resolves `{row: path}` references against a Document row dict."""
+
+    namespace: ClassVar[str] = "row"
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        parts = path.split(".")
+        cur: Any = ctx
+        for part in parts:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(part)
+            if cur is None:
+                return None
+        return cur
+
+
+class TableBinding:
+    """Resolves `{row: path}` references to SQLAlchemy columns on Document."""
+
+    namespace: ClassVar[str] = "row"
+
+    def resolve_reference(self, path: str) -> ColumnElement[Any]:
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in _COLUMN_MAPPED_ROW_FIELDS:
+            col = _COLUMN_MAPPED_ROW_FIELDS[parts[0]]
+            if col is not None:
+                return col
+        if len(parts) == 1:
+            return Document.data[parts[0]].astext
+        return Document.data[parts].astext
+
+
+def compile_read_filter(
+    policies: PolicyDocument,
+    user: Any,
+) -> ColumnElement[Any] | None:
+    """Compile the OR of all read-allowing rules into a single WHERE clause.
+
+    Returns None if no policy grants read (the handler must deny). Table-specific
+    because files have no SQL pushdown.
+    """
+    binding = TableBinding()
+    fragments: list[ColumnElement[Any]] = []
+    for policy in policies.policies:
+        if "read" not in policy.actions:
+            continue
+        if policy.when is None:
+            fragments.append(sa_true())
+            continue
+        fragments.append(compile_to_sql(policy.when, user, binding))
+    if not fragments:
+        return None
+    if len(fragments) == 1:
+        return fragments[0]
+    return sa_or(*fragments)
+
+
+def make_seed_admin_bypass() -> dict:
+    """Seeded policy for a freshly-created table. Table-specific action vocab."""
+    return {
+        "policies": [
+            {
+                "name": "admin_bypass",
+                "description": "Platform admins bypass all checks. Edit or delete to enforce stricter audit.",
+                "actions": ["read", "create", "update", "delete"],
+                "when": {"user": "is_platform_admin"},
+            },
+        ],
+    }
+
+
+__all__ = [
+    "RowResolver",
+    "TableBinding",
+    "TablePolicies",
+    "compile_read_filter",
+    "make_seed_admin_bypass",
+]

--- a/api/src/models/contracts/policies.py
+++ b/api/src/models/contracts/policies.py
@@ -1,182 +1,35 @@
-"""Pydantic types for table policies — the AST validates here."""
+"""Backward-compat shim for table-specific policy types.
 
+The engine types live in `shared.policies.ast`. This module re-exports
+them under tables-specific names AND defines a tables-narrowed `Policy`
+class that restricts `actions` to the table action vocab. New code should
+import from `shared.table_policies` (TablePolicies alias) or
+`shared.policies.ast` (PolicyDocument).
+"""
 from __future__ import annotations
 
-from typing import Any, Final, Literal
+from typing import Literal
 
-from pydantic import (
-    BaseModel,
-    Field,
-    RootModel,
-    field_validator,
-    model_validator,
+from pydantic import BaseModel, Field, field_validator
+
+from shared.policies.ast import (
+    KNOWN_USER_FIELDS,
+    Expr,
+    PolicyDocument,
 )
 
-from shared.policies.functions import FUNCTIONS
-
-# Known fields on the USER namespace — the validator rejects anything else.
-KNOWN_USER_FIELDS: Final[frozenset[str]] = frozenset({
-    "user_id",
-    "email",
-    "organization_id",
-    "is_platform_admin",
-    "role_ids",
-    "role_names",
-})
-
-# Operators that produce boolean results.
-_LOGIC_OPS: Final[frozenset[str]] = frozenset({"and", "or", "not"})
-_COMPARE_OPS: Final[frozenset[str]] = frozenset({"eq", "neq", "lt", "lte", "gt", "gte"})
-_OTHER_OPS: Final[frozenset[str]] = frozenset({"in", "is_null", "call"})
-_ALL_OPS: Final[frozenset[str]] = _LOGIC_OPS | _COMPARE_OPS | _OTHER_OPS
-
-# Bound on AST recursion depth. Prevents pathological deeply-nested imports
-# (e.g., manifest expressions from an untrusted source) from hitting Python's
-# recursion limit and surfacing as an opaque RecursionError → 500.
-_DEPTH_LIMIT: Final[int] = 64
-
-
-def _validate_operand(node: Any, depth: int = 0, path: str = "$") -> None:
-    """Recursively validate that a node is a literal, reference, or expression."""
-    if depth >= _DEPTH_LIMIT:
-        raise ValueError(
-            f"{path}: expression nested too deeply (>{_DEPTH_LIMIT} levels)"
-        )
-    if isinstance(node, (str, int, float, bool)) or node is None:
-        return
-    if isinstance(node, list):
-        for i, item in enumerate(node):
-            _validate_operand(item, depth + 1, f"{path}[{i}]")
-        return
-    if not isinstance(node, dict):
-        raise ValueError(f"{path}: unexpected operand type: {type(node).__name__}")
-
-    keys = set(node.keys())
-    if keys == {"row"}:
-        ref = node["row"]
-        if not isinstance(ref, str) or not ref:
-            raise ValueError(
-                f"{path}: row reference must be a non-empty string, got {ref!r}"
-            )
-        return
-    if keys == {"user"}:
-        ref = node["user"]
-        if ref not in KNOWN_USER_FIELDS:
-            raise ValueError(
-                f"{path}: unknown user field {ref!r}; "
-                f"available: {sorted(KNOWN_USER_FIELDS)}"
-            )
-        return
-    if keys == {"call", "args"} or keys == {"call"}:
-        _validate_call(node, depth=depth, path=path)
-        return
-    # Any other operator dict
-    if len(keys) != 1:
-        raise ValueError(
-            f"{path}: operator node must have exactly one key, got {sorted(keys)}"
-        )
-    op = next(iter(keys))
-    if op not in _ALL_OPS:
-        raise ValueError(f"{path}: unknown operator {op!r}")
-    _validate_op_node(op, node[op], depth=depth, path=path)
-
-
-def _validate_op_node(op: str, value: Any, depth: int, path: str) -> None:
-    if op in _LOGIC_OPS - {"not"}:
-        if not isinstance(value, list) or len(value) < 2:
-            raise ValueError(f"{path}.{op}: {op} requires at least two operands")
-        for i, item in enumerate(value):
-            _validate_operand(item, depth + 1, f"{path}.{op}[{i}]")
-        return
-    if op == "not":
-        if isinstance(value, list):
-            raise ValueError(
-                f"{path}.{op}: not requires exactly one operand (not a list)"
-            )
-        _validate_operand(value, depth + 1, f"{path}.{op}")
-        return
-    if op in _COMPARE_OPS:
-        if not isinstance(value, list) or len(value) != 2:
-            raise ValueError(f"{path}.{op}: {op} requires exactly two operands")
-        if op in {"eq", "neq"}:
-            for operand in value:
-                if operand is None:
-                    raise ValueError(
-                        f"{path}.{op}: {op} does not accept null literals "
-                        "(NULL semantics differ between evaluator and SQL "
-                        "pushdown); use is_null instead"
-                    )
-        for i, item in enumerate(value):
-            _validate_operand(item, depth + 1, f"{path}.{op}[{i}]")
-        return
-    if op == "in":
-        if not isinstance(value, list) or len(value) != 2:
-            raise ValueError(f"{path}.{op}: in requires [operand, [literal, ...]]")
-        left, right = value
-        _validate_operand(left, depth + 1, f"{path}.{op}[0]")
-        if not isinstance(right, list) or not right:
-            raise ValueError(
-                f"{path}.{op}: in requires a non-empty literal list as second arg"
-            )
-        for i, item in enumerate(right):
-            if not isinstance(item, (str, int, float, bool)) and item is not None:
-                raise ValueError(
-                    f"{path}.{op}[1][{i}]: in literal list items must be scalars or null"
-                )
-        return
-    if op == "is_null":
-        # Single operand (not a list)
-        if isinstance(value, list):
-            raise ValueError(
-                f"{path}.{op}: is_null requires exactly one operand (not a list)"
-            )
-        _validate_operand(value, depth + 1, f"{path}.{op}")
-        return
-
-
-def _validate_call(node: dict, depth: int, path: str) -> None:
-    target = node.get("call")
-    args = node.get("args", [])
-    if not isinstance(target, str):
-        raise ValueError(f"{path}: call target must be a string")
-    if target not in FUNCTIONS:
-        raise ValueError(
-            f"{path}: unknown function {target!r}; available: {sorted(FUNCTIONS)}"
-        )
-    fn = FUNCTIONS[target]
-    if len(args) != len(fn.arg_types):
-        raise ValueError(
-            f"{path}: function {target!r} expects {len(fn.arg_types)} args, "
-            f"got {len(args)}"
-        )
-    for i, (arg, t) in enumerate(zip(args, fn.arg_types)):
-        # `arg_types` is the contract for LITERAL args only. Reference args
-        # ({"row": "..."}, {"user": "..."}) bypass the type check here because
-        # their resolved value is only known at evaluate time. The evaluator
-        # is responsible for handling type mismatches at the row.
-        if isinstance(arg, dict):
-            _validate_operand(arg, depth + 1, f"{path}.args[{i}]")
-            continue
-        if not isinstance(arg, t):
-            raise ValueError(
-                f"{path}.args[{i}]: function {target!r} arg {i} expected "
-                f"{t.__name__}, got {type(arg).__name__}"
-            )
-
-
-class Expr(RootModel[dict]):
-    """Policy expression AST. Validated at construction."""
-
-    @model_validator(mode="after")
-    def _validate(self):
-        _validate_operand(self.root, depth=0, path="$")
-        return self
-
-
+# Table-specific action vocab. File-policies has its own.
 Action = Literal["read", "create", "update", "delete"]
 
 
 class Policy(BaseModel):
+    """Table-narrowed Policy: actions must be from the table action vocab.
+
+    Same shape as `shared.policies.ast.Policy` but `actions` is restricted
+    to the four table actions. Existing call sites continue to import this
+    from `src.models.contracts.policies` and get the narrow type.
+    """
+
     name: str = Field(min_length=1, max_length=100)
     description: str | None = None
     actions: list[Action] = Field(min_length=1)
@@ -191,30 +44,36 @@ class Policy(BaseModel):
 
 
 class TablePolicies(BaseModel):
+    """Tables-typed policy document.
+
+    Mirrors `PolicyDocument` shape but uses the tables-narrowed `Policy`
+    so action vocab validation survives at this boundary.
+    """
+
     policies: list[Policy] = Field(default_factory=list)
 
 
 class PolicyValidationError(BaseModel):
-    """Single structured validation error for a policy document.
-
-    `path` is a JSONPath-like string pointing into the document (e.g.
-    ``$.policies[0].when.eq[1]``); `message` is the validator's prose
-    error stripped of any embedded path prefix.
-    """
+    """Single structured validation error for a policy document."""
 
     path: str
     message: str
 
 
 class PolicyValidationResponse(BaseModel):
-    """Outcome of a `POST /api/tables/policies/validate` call.
-
-    `ok` mirrors whether the document validated cleanly. On failure, every
-    error from the AST validator is surfaced via `errors`. Endpoint always
-    returns 200 — callers parse this body to render structured feedback,
-    which is why the validator's `ValueError` is not allowed to escape into
-    a FastAPI 422.
-    """
+    """Outcome of a POST /api/tables/policies/validate call."""
 
     ok: bool
     errors: list[PolicyValidationError] = Field(default_factory=list)
+
+
+__all__ = [
+    "KNOWN_USER_FIELDS",
+    "Action",
+    "Expr",
+    "Policy",
+    "PolicyDocument",
+    "TablePolicies",
+    "PolicyValidationError",
+    "PolicyValidationResponse",
+]

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -2522,7 +2522,7 @@ async def cli_create_table(
     # Seed admin_bypass so platform admins can still operate on tables
     # created via the SDK. SDK callers can override this later by setting
     # explicit policies through the REST `PATCH /api/tables/{id}` endpoint.
-    from shared.policies.probe import make_seed_admin_bypass
+    from shared.table_policies import make_seed_admin_bypass
 
     table = Table(
         name=request.name,

--- a/api/src/routers/export_import.py
+++ b/api/src/routers/export_import.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import selectinload
 
 from src.core.auth import CurrentSuperuser
 from src.core.database import DbSession
-from shared.policies.probe import make_seed_admin_bypass
+from shared.table_policies import make_seed_admin_bypass
 from src.core.security import decrypt_with_key, encrypt_secret
 from src.models.enums import ConfigType
 from src.models.orm.config import Config

--- a/api/src/routers/tables.py
+++ b/api/src/routers/tables.py
@@ -20,9 +20,11 @@ from sqlalchemy import String, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import ColumnElement
 
-from shared.policies.probe import (
+from shared.policies.probe import evaluate_action
+from shared.table_policies import (
+    RowResolver,
+    TablePolicies,
     compile_read_filter,
-    evaluate_action,
     make_seed_admin_bypass,
 )
 from src.core.auth import Context, CurrentSuperuser, UserPrincipal
@@ -32,7 +34,6 @@ from src.core.org_filter import OrgFilterType, resolve_org_filter, resolve_targe
 from src.models.contracts.policies import (
     PolicyValidationError,
     PolicyValidationResponse,
-    TablePolicies,
 )
 from src.models.contracts.tables import (
     DocumentBatchCreate,
@@ -156,7 +157,7 @@ async def _check_action_or_403(
     mutation or only after read-only operations.
     """
     policies = _load_policies(table)
-    if evaluate_action(action, policies, row, user):
+    if evaluate_action(action, policies, row, user, resolver=RowResolver()):
         return
 
     # Resolve the row id only when it's actually a UUID.
@@ -1321,7 +1322,7 @@ async def batch_documents(
             if existing is not None:
                 pre_existing[i] = existing
                 if not evaluate_action(
-                    "update", policies, _row_from_doc(existing), ctx.user
+                    "update", policies, _row_from_doc(existing), ctx.user, resolver=RowResolver()
                 ):
                     denied.append(i)
                 continue
@@ -1331,7 +1332,7 @@ async def batch_documents(
             "created_by": item_created_by,
             "updated_by": item_updated_by,
         }
-        if not evaluate_action("create", policies, candidate_row, ctx.user):
+        if not evaluate_action("create", policies, candidate_row, ctx.user, resolver=RowResolver()):
             denied.append(i)
 
     if denied:
@@ -1419,7 +1420,7 @@ async def batch_delete_documents(
             continue
         existing_by_index[i] = existing
         if not evaluate_action(
-            "delete", policies, _row_from_doc(existing), ctx.user
+            "delete", policies, _row_from_doc(existing), ctx.user, resolver=RowResolver()
         ):
             denied.append(i)
 

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -19,12 +19,13 @@ from sqlalchemy.orm import selectinload
 from shared.policies.probe import is_subscribe_authorized
 from shared.policies.subscription import decide_visibility_change
 from shared.role_cache import get_user_roles
+from shared.table_policies import RowResolver, TablePolicies
 from src.core.auth import UserPrincipal, get_current_user_ws
 from src.core.database import get_db_context
 from src.core.log_safety import log_safe
 from src.core.pubsub import manager
 from src.models import Conversation, Execution
-from src.models.contracts.policies import Expr, TablePolicies
+from src.models.contracts.policies import Expr
 from src.models.orm import Agent
 from src.models.orm.applications import Application
 from src.models.orm.tables import Table as TableOrm
@@ -253,10 +254,11 @@ async def _handle_table_message(
         return
 
     decision = decide_visibility_change(
-        old_row=payload.get("old_row"),
-        new_row=payload.get("new_row"),
+        old_ctx=payload.get("old_row"),
+        new_ctx=payload.get("new_row"),
         policies=policies,
         user=user,
+        resolver=RowResolver(),
         user_filter=sub.get("filter"),
     )
     if decision is None:
@@ -286,7 +288,7 @@ async def _re_evaluate_subscription(
 ) -> None:
     """Re-run subscribe-time authorization after a policy edit; revoke if no."""
     policies = await _load_policies_for_table(table_id)
-    if policies is None or not is_subscribe_authorized(policies, user):
+    if policies is None or not is_subscribe_authorized(policies, user, resolver=RowResolver()):
         await websocket.send_json({
             "type": "subscription_revoked",
             "channel": f"table:{table_id}",
@@ -338,7 +340,7 @@ async def _authorize_table_subscribe(
         return None
 
     await _populate_user_roles(user)
-    if not is_subscribe_authorized(policies, user):
+    if not is_subscribe_authorized(policies, user, resolver=RowResolver()):
         await websocket.send_json({
             "type": "error",
             "channel": spec.name,

--- a/api/src/services/manifest_import.py
+++ b/api/src/services/manifest_import.py
@@ -2254,8 +2254,7 @@ class ManifestResolver:
         from sqlalchemy import update
         from sqlalchemy.dialects.postgresql import insert
 
-        from shared.policies.probe import make_seed_admin_bypass
-        from src.models.contracts.policies import TablePolicies
+        from shared.table_policies import make_seed_admin_bypass, TablePolicies
         from src.models.orm.tables import Table
         from src.services.sync_ops import SyncOp  # noqa: F401
 

--- a/api/src/services/mcp_server/tools/tables.py
+++ b/api/src/services/mcp_server/tools/tables.py
@@ -219,7 +219,7 @@ async def create_table(
     """Create a new table with explicit scope."""
     from sqlalchemy import select
 
-    from shared.policies.probe import make_seed_admin_bypass
+    from shared.table_policies import make_seed_admin_bypass
     from src.models.orm.tables import Table
 
     logger.info(f"MCP create_table called with name={name}, scope={scope}")

--- a/api/tests/unit/policies/test_compile.py
+++ b/api/tests/unit/policies/test_compile.py
@@ -20,10 +20,37 @@ class FakeUser:
     role_names: list[str] = field(default_factory=list)
 
 
+class _TableBindingForTest:
+    """Local stub mirroring the pre-Task-5 hardcoded {row: ...} → Document
+    column logic. Replaced by the real TableBinding from
+    shared.table_policies in Task 6."""
+    namespace = "row"
+
+    _COLUMN_MAPPED_ROW_FIELDS = {
+        "id": Document.id,
+        "organization_id": None,
+        "created_by": Document.created_by,
+        "updated_by": Document.updated_by,
+        "created_at": Document.created_at,
+        "updated_at": Document.updated_at,
+        "table_id": Document.table_id,
+    }
+
+    def resolve_reference(self, path):
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in self._COLUMN_MAPPED_ROW_FIELDS:
+            col = self._COLUMN_MAPPED_ROW_FIELDS[parts[0]]
+            if col is not None:
+                return col
+        if len(parts) == 1:
+            return Document.data[parts[0]].astext
+        return Document.data[parts].astext
+
+
 def _compile(d: dict, user=None) -> str:
     """Compile to SQL, return the rendered string."""
     expr = Expr.model_validate(d)
-    sql_expr = compile_to_sql(expr, user or FakeUser())
+    sql_expr = compile_to_sql(expr, user or FakeUser(), _TableBindingForTest())
     # Use a SELECT to render WHERE clause for inspection
     stmt = select(Document.id).where(sql_expr)
     return str(stmt.compile(compile_kwargs={"literal_binds": True}))
@@ -142,4 +169,4 @@ def test_call_with_row_reference_arg_raises():
     user = FakeUser()
     expr = Expr.model_validate({"call": "has_role", "args": [{"row": "x"}]})
     with pytest.raises(ValueError, match="cannot resolve"):
-        compile_to_sql(expr, user)
+        compile_to_sql(expr, user, _TableBindingForTest())

--- a/api/tests/unit/policies/test_compile.py
+++ b/api/tests/unit/policies/test_compile.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 from sqlalchemy import select
 
 from shared.policies.compile import compile_to_sql
+from shared.table_policies import TableBinding
 from src.models.contracts.policies import Expr
 from src.models.orm.tables import Document
 
@@ -20,37 +21,10 @@ class FakeUser:
     role_names: list[str] = field(default_factory=list)
 
 
-class _TableBindingForTest:
-    """Local stub mirroring the pre-Task-5 hardcoded {row: ...} → Document
-    column logic. Replaced by the real TableBinding from
-    shared.table_policies in Task 6."""
-    namespace = "row"
-
-    _COLUMN_MAPPED_ROW_FIELDS = {
-        "id": Document.id,
-        "organization_id": None,
-        "created_by": Document.created_by,
-        "updated_by": Document.updated_by,
-        "created_at": Document.created_at,
-        "updated_at": Document.updated_at,
-        "table_id": Document.table_id,
-    }
-
-    def resolve_reference(self, path):
-        parts = path.split(".")
-        if len(parts) == 1 and parts[0] in self._COLUMN_MAPPED_ROW_FIELDS:
-            col = self._COLUMN_MAPPED_ROW_FIELDS[parts[0]]
-            if col is not None:
-                return col
-        if len(parts) == 1:
-            return Document.data[parts[0]].astext
-        return Document.data[parts].astext
-
-
 def _compile(d: dict, user=None) -> str:
     """Compile to SQL, return the rendered string."""
     expr = Expr.model_validate(d)
-    sql_expr = compile_to_sql(expr, user or FakeUser(), _TableBindingForTest())
+    sql_expr = compile_to_sql(expr, user or FakeUser(), TableBinding())
     # Use a SELECT to render WHERE clause for inspection
     stmt = select(Document.id).where(sql_expr)
     return str(stmt.compile(compile_kwargs={"literal_binds": True}))
@@ -69,16 +43,22 @@ def test_eq_row_user_reference():
     assert str(uid) in sql
 
 
-def test_eq_row_organization_id_uses_column():
-    """organization_id is a column on documents.tables, not in JSONB."""
+def test_eq_row_organization_id_falls_through_to_jsonb():
+    """`{row: organization_id}` has no column mapping — falls through to JSONB lookup.
+
+    documents has no `organization_id` column; org scoping is applied via the
+    parent table at the join. Apps that need `{row: organization_id}` in policies
+    should denormalize it into the row's `data` JSONB at insert time.
+    """
     org_id = uuid4()
     user = FakeUser(organization_id=org_id)
     sql = _compile(
         {"eq": [{"row": "organization_id"}, {"user": "organization_id"}]},
         user=user,
     )
-    # Implementation detail: should reference the column, not data->>
-    # Looser check: the org_id literal appears
+    # The user-side literal lands in the rendered SQL regardless of binding
+    # path. The actual column-vs-JSONB choice is verified by the table-binding
+    # tests in test_table_policies_binding.py.
     assert str(org_id) in sql
 
 
@@ -169,4 +149,4 @@ def test_call_with_row_reference_arg_raises():
     user = FakeUser()
     expr = Expr.model_validate({"call": "has_role", "args": [{"row": "x"}]})
     with pytest.raises(ValueError, match="cannot resolve"):
-        compile_to_sql(expr, user, _TableBindingForTest())
+        compile_to_sql(expr, user, TableBinding())

--- a/api/tests/unit/policies/test_engine_protocols.py
+++ b/api/tests/unit/policies/test_engine_protocols.py
@@ -147,3 +147,79 @@ def test_compile_with_stub_binding():
     sql = compile_to_sql(expr, user=_UserForEvalTest(), binding=_StubBindingForCompile())
     rendered = str(sql.compile(compile_kwargs={"literal_binds": True}))
     assert "owner_id" in rendered
+
+
+_FORBIDDEN_DOMAIN_PREFIXES = (
+    "src.models.orm",
+    "shared.table_policies",
+    "shared.file_policies",
+)
+
+
+def _scan_for_forbidden_imports(source: str, label: str) -> list[str]:
+    """Return a list of forbidden imports found in `source`.
+
+    Shared between the real-engine assertion and a negative self-check
+    that proves the scanner actually catches what it claims to.
+    """
+    import ast as _ast
+
+    bad: list[str] = []
+    tree = _ast.parse(source)
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.ImportFrom) and node.module:
+            if any(node.module.startswith(p) for p in _FORBIDDEN_DOMAIN_PREFIXES):
+                bad.append(f"{label}: from {node.module}")
+        elif isinstance(node, _ast.Import):
+            for alias in node.names:
+                if any(alias.name.startswith(p) for p in _FORBIDDEN_DOMAIN_PREFIXES):
+                    bad.append(f"{label}: import {alias.name}")
+    return bad
+
+
+def test_engine_does_not_import_domain_code():
+    """The shared engine modules must not import any table-specific code.
+
+    Static analysis: parse each module under `shared/policies/` and assert
+    nothing imports `src.models.orm`, `shared.table_policies`, or
+    `shared.file_policies`. This guards against future regressions that
+    would re-couple the engine to a specific domain.
+    """
+    import pathlib
+
+    here = pathlib.Path(__file__).resolve()
+    # tests/unit/policies/test_engine_protocols.py -> api/shared/policies/
+    engine_root = here.parents[3] / "shared" / "policies"
+    assert engine_root.is_dir(), f"engine root not found at {engine_root}"
+
+    bad: list[str] = []
+    for py in sorted(engine_root.rglob("*.py")):
+        bad.extend(_scan_for_forbidden_imports(py.read_text(), py.name))
+
+    assert not bad, "engine reaches into domain code:\n" + "\n".join(bad)
+
+
+def test_forbidden_import_scanner_catches_violations():
+    """Self-check: prove the scanner actually flags violations.
+
+    Without this, a buggy scanner that always returned [] would make the
+    engine isolation test silently pass forever.
+    """
+    cases = [
+        "from src.models.orm.tables import Document",
+        "from shared.table_policies import RowResolver",
+        "from shared.file_policies import FileResolver",
+        "import src.models.orm.tables",
+    ]
+    for src in cases:
+        assert _scan_for_forbidden_imports(src, "synthetic"), (
+            f"scanner missed forbidden import: {src!r}"
+        )
+
+    # And the inverse — clean imports must NOT be flagged.
+    clean = (
+        "from shared.policies.ast import Expr\n"
+        "from typing import Any\n"
+        "import sqlalchemy\n"
+    )
+    assert _scan_for_forbidden_imports(clean, "synthetic") == []

--- a/api/tests/unit/policies/test_engine_protocols.py
+++ b/api/tests/unit/policies/test_engine_protocols.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from sqlalchemy import column
+from sqlalchemy import Column, Integer, String, column
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import ColumnElement
 
 from shared.policies.ast import (
@@ -16,6 +17,7 @@ from shared.policies.ast import (
     PolicyDocument,
 )
 from shared.policies.binding import Binding
+from shared.policies.compile import compile_to_sql
 from shared.policies.evaluate import evaluate as _engine_evaluate
 from shared.policies.resolver import Resolver
 
@@ -118,3 +120,30 @@ def test_evaluate_with_alternate_namespace():
     expr = Expr.model_validate({"eq": [{"file": "created_by"}, {"user": "user_id"}]})
     resolver = FileResolverStub()
     assert _engine_evaluate(expr, ctx={"created_by": "u-1"}, user=_UserForEvalTest(), resolver=resolver) is True
+
+
+_Base = declarative_base()
+
+
+class _DocFixture(_Base):
+    __tablename__ = "_test_doc_for_compile"
+    id = Column(Integer, primary_key=True)
+    owner_id = Column(String)
+
+
+class _StubBindingForCompile:
+    namespace = "row"
+
+    def resolve_reference(self, path: str):
+        col = getattr(_DocFixture, path, None)
+        if col is None:
+            raise ValueError(f"unknown column: {path}")
+        return col
+
+
+def test_compile_with_stub_binding():
+    """compile_to_sql delegates {row: ...} resolution to the Binding — no Document import in walker."""
+    expr = Expr.model_validate({"eq": [{"row": "owner_id"}, {"user": "user_id"}]})
+    sql = compile_to_sql(expr, user=_UserForEvalTest(), binding=_StubBindingForCompile())
+    rendered = str(sql.compile(compile_kwargs={"literal_binds": True}))
+    assert "owner_id" in rendered

--- a/api/tests/unit/policies/test_engine_protocols.py
+++ b/api/tests/unit/policies/test_engine_protocols.py
@@ -1,0 +1,46 @@
+"""Engine-only tests proving the engine is domain-agnostic.
+
+These tests use a stub Resolver/Binding rather than table-specific ones,
+proving the walker code does not reach into any domain.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from sqlalchemy import column
+from sqlalchemy.sql import ColumnElement
+
+from shared.policies.binding import Binding
+from shared.policies.resolver import Resolver
+
+
+class StubResolver:
+    namespace: ClassVar[str] = "row"
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        return (ctx or {}).get(path)
+
+
+def test_resolver_protocol_runtime_check():
+    """StubResolver structurally satisfies the Resolver protocol."""
+    r: Resolver = StubResolver()
+    assert r.namespace == "row"
+    assert r.resolve("name", {"name": "alice"}) == "alice"
+    assert r.resolve("missing", {}) is None
+    assert r.resolve("name", None) is None
+
+
+class StubBinding:
+    namespace: ClassVar[str] = "row"
+
+    def resolve_reference(self, path: str) -> ColumnElement[Any]:
+        return column(path)
+
+
+def test_binding_protocol_runtime_check():
+    """StubBinding structurally satisfies the Binding protocol."""
+    b: Binding = StubBinding()
+    assert isinstance(b, Binding)
+    assert b.namespace == "row"
+    col = b.resolve_reference("name")
+    assert str(col) == "name"

--- a/api/tests/unit/policies/test_engine_protocols.py
+++ b/api/tests/unit/policies/test_engine_protocols.py
@@ -16,6 +16,7 @@ from shared.policies.ast import (
     PolicyDocument,
 )
 from shared.policies.binding import Binding
+from shared.policies.evaluate import evaluate as _engine_evaluate
 from shared.policies.resolver import Resolver
 
 
@@ -86,3 +87,34 @@ def test_expr_validator_still_works():
 
     with pytest.raises(PydanticValidationError):
         Expr.model_validate({"user": "not_a_real_field"})
+
+
+class _UserForEvalTest:
+    user_id = "u-1"
+    email = "u@x"
+    organization_id = None
+    is_platform_admin = False
+    role_ids: list = []
+    role_names: list = []
+
+
+def test_evaluate_with_stub_resolver():
+    """Engine evaluates `{row: ...}` references via the Resolver — no domain code in walker."""
+    expr = Expr.model_validate({"eq": [{"row": "owner_id"}, {"user": "user_id"}]})
+    resolver = StubResolver()
+    assert _engine_evaluate(expr, ctx={"owner_id": "u-1"}, user=_UserForEvalTest(), resolver=resolver) is True
+    assert _engine_evaluate(expr, ctx={"owner_id": "u-2"}, user=_UserForEvalTest(), resolver=resolver) is False
+
+
+def test_evaluate_with_alternate_namespace():
+    """A different-namespace resolver handles its own references."""
+
+    class FileResolverStub:
+        namespace = "file"
+
+        def resolve(self, path: str, ctx):
+            return (ctx or {}).get(path)
+
+    expr = Expr.model_validate({"eq": [{"file": "created_by"}, {"user": "user_id"}]})
+    resolver = FileResolverStub()
+    assert _engine_evaluate(expr, ctx={"created_by": "u-1"}, user=_UserForEvalTest(), resolver=resolver) is True

--- a/api/tests/unit/policies/test_engine_protocols.py
+++ b/api/tests/unit/policies/test_engine_protocols.py
@@ -10,6 +10,11 @@ from typing import Any, ClassVar
 from sqlalchemy import column
 from sqlalchemy.sql import ColumnElement
 
+from shared.policies.ast import (
+    Expr,
+    Policy as SharedPolicy,
+    PolicyDocument,
+)
 from shared.policies.binding import Binding
 from shared.policies.resolver import Resolver
 
@@ -44,3 +49,40 @@ def test_binding_protocol_runtime_check():
     assert b.namespace == "row"
     col = b.resolve_reference("name")
     assert str(col) == "name"
+
+
+def test_policy_document_round_trip():
+    """PolicyDocument validates with any action vocab as plain strings (domain-agnostic)."""
+    doc = PolicyDocument.model_validate({
+        "policies": [
+            {
+                "name": "admin",
+                "actions": ["read", "write", "list", "delete"],  # file action vocab — accepted at shared layer
+                "when": {"user": "is_platform_admin"},
+            },
+        ],
+    })
+    assert len(doc.policies) == 1
+    assert doc.policies[0].name == "admin"
+    assert doc.policies[0].actions == ["read", "write", "list", "delete"]
+
+
+def test_policy_document_empty():
+    """Empty PolicyDocument is valid (default-deny semantics)."""
+    doc = PolicyDocument()
+    assert doc.policies == []
+
+
+def test_shared_policy_accepts_arbitrary_actions():
+    """Shared Policy is domain-agnostic — accepts any action string list."""
+    p = SharedPolicy(name="x", actions=["custom_action"])
+    assert p.actions == ["custom_action"]
+
+
+def test_expr_validator_still_works():
+    """AST validator still rejects unknown user fields."""
+    import pytest
+    from pydantic import ValidationError as PydanticValidationError
+
+    with pytest.raises(PydanticValidationError):
+        Expr.model_validate({"user": "not_a_real_field"})

--- a/api/tests/unit/policies/test_evaluate.py
+++ b/api/tests/unit/policies/test_evaluate.py
@@ -10,6 +10,23 @@ from shared.policies.evaluate import evaluate
 from src.models.contracts.policies import Expr
 
 
+class _RowResolverForTest:
+    """Local stub for the {row: ...} resolver semantics. Replaced by the
+    real RowResolver from shared.table_policies in Task 6."""
+    namespace = "row"
+
+    def resolve(self, path, ctx):
+        parts = path.split(".")
+        cur = ctx
+        for p in parts:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(p)
+            if cur is None:
+                return None
+        return cur
+
+
 @dataclass
 class FakeUser:
     user_id: UUID = field(default_factory=uuid4)
@@ -28,29 +45,29 @@ def _e(d: dict) -> Expr:
 
 
 def test_eq_literal_literal():
-    assert evaluate(_e({"eq": [1, 1]}), row={}, user=FakeUser()) is True
-    assert evaluate(_e({"eq": [1, 2]}), row={}, user=FakeUser()) is False
+    assert evaluate(_e({"eq": [1, 1]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"eq": [1, 2]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
 
 
 def test_eq_row_reference():
     expr = _e({"eq": [{"row": "x"}, 5]})
-    assert evaluate(expr, row={"x": 5}, user=FakeUser()) is True
-    assert evaluate(expr, row={"x": 6}, user=FakeUser()) is False
-    assert evaluate(expr, row={}, user=FakeUser()) is False  # missing → null → ne
+    assert evaluate(expr, ctx={"x": 5}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"x": 6}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False  # missing → null → ne
 
 
 def test_eq_user_reference():
     uid = uuid4()
     user = FakeUser(user_id=uid)
     expr = _e({"eq": [{"row": "owner"}, {"user": "user_id"}]})
-    assert evaluate(expr, row={"owner": str(uid)}, user=user) is True
-    assert evaluate(expr, row={"owner": str(uuid4())}, user=user) is False
+    assert evaluate(expr, ctx={"owner": str(uid)}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"owner": str(uuid4())}, user=user, resolver=_RowResolverForTest()) is False
 
 
 def test_user_is_platform_admin():
     expr = _e({"user": "is_platform_admin"})
-    assert evaluate(expr, row={}, user=FakeUser(is_platform_admin=True)) is True
-    assert evaluate(expr, row={}, user=FakeUser(is_platform_admin=False)) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(is_platform_admin=True), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(is_platform_admin=False), resolver=_RowResolverForTest()) is False
 
 
 # --- Logic ---
@@ -63,22 +80,22 @@ def test_and_short_circuits_on_false():
             {"eq": [{"row": "missing"}, 1]},  # would be false too
         ]
     })
-    assert evaluate(expr, row={}, user=FakeUser()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
 
 
 def test_and_all_true():
     expr = _e({"and": [{"eq": [1, 1]}, {"eq": [2, 2]}]})
-    assert evaluate(expr, row={}, user=FakeUser()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
 
 
 def test_or_short_circuits_on_true():
     expr = _e({"or": [{"eq": [1, 1]}, {"eq": [{"row": "x"}, 99]}]})
-    assert evaluate(expr, row={}, user=FakeUser()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
 
 
 def test_not():
-    assert evaluate(_e({"not": {"eq": [1, 1]}}), row={}, user=FakeUser()) is False
-    assert evaluate(_e({"not": {"eq": [1, 2]}}), row={}, user=FakeUser()) is True
+    assert evaluate(_e({"not": {"eq": [1, 1]}}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(_e({"not": {"eq": [1, 2]}}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
 
 
 # --- Comparisons ---
@@ -86,16 +103,16 @@ def test_not():
 
 def test_lt_lte_gt_gte_numbers():
     user = FakeUser()
-    assert evaluate(_e({"lt": [1, 2]}), row={}, user=user) is True
-    assert evaluate(_e({"lt": [2, 2]}), row={}, user=user) is False
-    assert evaluate(_e({"lte": [2, 2]}), row={}, user=user) is True
-    assert evaluate(_e({"gt": [3, 2]}), row={}, user=user) is True
-    assert evaluate(_e({"gte": [2, 2]}), row={}, user=user) is True
+    assert evaluate(_e({"lt": [1, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"lt": [2, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(_e({"lte": [2, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"gt": [3, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"gte": [2, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
 
 
 def test_neq():
-    assert evaluate(_e({"neq": [1, 2]}), row={}, user=FakeUser()) is True
-    assert evaluate(_e({"neq": [1, 1]}), row={}, user=FakeUser()) is False
+    assert evaluate(_e({"neq": [1, 2]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"neq": [1, 1]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
 
 
 # --- Membership ---
@@ -104,9 +121,9 @@ def test_neq():
 def test_in_membership():
     user = FakeUser()
     expr = _e({"in": [{"row": "status"}, ["draft", "review"]]})
-    assert evaluate(expr, row={"status": "draft"}, user=user) is True
-    assert evaluate(expr, row={"status": "done"}, user=user) is False
-    assert evaluate(expr, row={}, user=user) is False  # missing
+    assert evaluate(expr, ctx={"status": "draft"}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"status": "done"}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=user, resolver=_RowResolverForTest()) is False  # missing
 
 
 # --- is_null ---
@@ -114,21 +131,21 @@ def test_in_membership():
 
 def test_is_null_missing_field():
     expr = _e({"is_null": {"row": "absent"}})
-    assert evaluate(expr, row={}, user=FakeUser()) is True
-    assert evaluate(expr, row={"absent": "x"}, user=FakeUser()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"absent": "x"}, user=FakeUser(), resolver=_RowResolverForTest()) is False
 
 
 def test_is_null_explicit_null():
     expr = _e({"is_null": {"row": "x"}})
-    assert evaluate(expr, row={"x": None}, user=FakeUser()) is True
+    assert evaluate(expr, ctx={"x": None}, user=FakeUser(), resolver=_RowResolverForTest()) is True
 
 
 def test_not_is_null_pattern():
     """Common idiom: 'is set' check."""
     expr = _e({"not": {"is_null": {"row": "manager_user_id"}}})
     user = FakeUser()
-    assert evaluate(expr, row={"manager_user_id": "abc"}, user=user) is True
-    assert evaluate(expr, row={}, user=user) is False
+    assert evaluate(expr, ctx={"manager_user_id": "abc"}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={}, user=user, resolver=_RowResolverForTest()) is False
 
 
 # --- Calls ---
@@ -136,14 +153,14 @@ def test_not_is_null_pattern():
 
 def test_has_role_match_by_name():
     expr = _e({"call": "has_role", "args": ["admin"]})
-    assert evaluate(expr, row={}, user=FakeUser(role_names=["admin"])) is True
-    assert evaluate(expr, row={}, user=FakeUser(role_names=["viewer"])) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(role_names=["admin"]), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(role_names=["viewer"]), resolver=_RowResolverForTest()) is False
 
 
 def test_has_role_match_by_uuid_string():
     role_id = uuid4()
     expr = _e({"call": "has_role", "args": [str(role_id)]})
-    assert evaluate(expr, row={}, user=FakeUser(role_ids=[role_id])) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(role_ids=[role_id]), resolver=_RowResolverForTest()) is True
 
 
 # --- Realistic policy scenarios ---
@@ -160,11 +177,11 @@ def test_owner_can_edit_open_policy():
         ]
     })
     # Owner, open: allow
-    assert evaluate(policy, row={"created_by": str(uid), "status": "open"}, user=user) is True
+    assert evaluate(policy, ctx={"created_by": str(uid), "status": "open"}, user=user, resolver=_RowResolverForTest()) is True
     # Owner, done: deny
-    assert evaluate(policy, row={"created_by": str(uid), "status": "done"}, user=user) is False
+    assert evaluate(policy, ctx={"created_by": str(uid), "status": "done"}, user=user, resolver=_RowResolverForTest()) is False
     # Other, open: deny
-    assert evaluate(policy, row={"created_by": str(uuid4()), "status": "open"}, user=user) is False
+    assert evaluate(policy, ctx={"created_by": str(uuid4()), "status": "open"}, user=user, resolver=_RowResolverForTest()) is False
 
 
 def test_manager_reads_reports_policy():
@@ -172,15 +189,15 @@ def test_manager_reads_reports_policy():
     mgr_id = uuid4()
     mgr = FakeUser(user_id=mgr_id)
     policy = _e({"eq": [{"row": "manager_user_id"}, {"user": "user_id"}]})
-    assert evaluate(policy, row={"manager_user_id": str(mgr_id)}, user=mgr) is True
-    assert evaluate(policy, row={"manager_user_id": str(uuid4())}, user=mgr) is False
+    assert evaluate(policy, ctx={"manager_user_id": str(mgr_id)}, user=mgr, resolver=_RowResolverForTest()) is True
+    assert evaluate(policy, ctx={"manager_user_id": str(uuid4())}, user=mgr, resolver=_RowResolverForTest()) is False
 
 
 def test_admin_bypass_policy():
     """Platform admin shortcut."""
     policy = _e({"user": "is_platform_admin"})
-    assert evaluate(policy, row={"any": "row"}, user=FakeUser(is_platform_admin=True)) is True
-    assert evaluate(policy, row={"any": "row"}, user=FakeUser(is_platform_admin=False)) is False
+    assert evaluate(policy, ctx={"any": "row"}, user=FakeUser(is_platform_admin=True), resolver=_RowResolverForTest()) is True
+    assert evaluate(policy, ctx={"any": "row"}, user=FakeUser(is_platform_admin=False), resolver=_RowResolverForTest()) is False
 
 
 def test_own_org_policy():
@@ -188,8 +205,8 @@ def test_own_org_policy():
     org_id = uuid4()
     user = FakeUser(organization_id=org_id)
     policy = _e({"eq": [{"row": "organization_id"}, {"user": "organization_id"}]})
-    assert evaluate(policy, row={"organization_id": str(org_id)}, user=user) is True
-    assert evaluate(policy, row={"organization_id": str(uuid4())}, user=user) is False
+    assert evaluate(policy, ctx={"organization_id": str(org_id)}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(policy, ctx={"organization_id": str(uuid4())}, user=user, resolver=_RowResolverForTest()) is False
 
 
 # --- Type semantics ---
@@ -201,21 +218,21 @@ def test_string_eq_with_uuid_value_from_user():
     user = FakeUser(user_id=uid)
     expr = _e({"eq": [{"row": "user_id"}, {"user": "user_id"}]})
     # Row has the UUID as a string (JSONB extraction yields string)
-    assert evaluate(expr, row={"user_id": str(uid)}, user=user) is True
+    assert evaluate(expr, ctx={"user_id": str(uid)}, user=user, resolver=_RowResolverForTest()) is True
 
 
 def test_null_propagates_in_eq():
     """eq([missing, anything]) is false (does not error)."""
     expr = _e({"eq": [{"row": "x"}, "value"]})
-    assert evaluate(expr, row={}, user=FakeUser()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
 
 
 def test_boolean_field_eq():
     """Boolean fields compare correctly."""
     expr = _e({"eq": [{"row": "enabled"}, True]})
     user = FakeUser()
-    assert evaluate(expr, row={"enabled": True}, user=user) is True
-    assert evaluate(expr, row={"enabled": False}, user=user) is False
+    assert evaluate(expr, ctx={"enabled": True}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"enabled": False}, user=user, resolver=_RowResolverForTest()) is False
 
 
 # --- Top-level boolean coercion ---
@@ -224,24 +241,24 @@ def test_boolean_field_eq():
 def test_bare_literal_top_level_coerces_to_bool():
     """A top-level bare literal coerces to bool (truthy → True)."""
     user = FakeUser()
-    assert evaluate(_e({"eq": ["yes", "yes"]}), row={}, user=user) is True
+    assert evaluate(_e({"eq": ["yes", "yes"]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
     # A reference resolving to a non-empty string is truthy
     expr = _e({"eq": [{"row": "x"}, "v"]})
-    assert evaluate(expr, row={"x": "v"}, user=user) is True
+    assert evaluate(expr, ctx={"x": "v"}, user=user, resolver=_RowResolverForTest()) is True
 
 
 # --- row=None contract (DELETE events) ---
 
 
 def test_row_none_resolves_refs_to_none():
-    """row=None makes every {"row": ...} reference resolve to None."""
+    """ctx=None makes every {"row": ...} reference resolve to None."""
     user = FakeUser()
     expr = _e({"eq": [{"row": "x"}, "v"]})
     # Null left side -> NULL-as-false
-    assert evaluate(expr, row=None, user=user) is False
+    assert evaluate(expr, ctx=None, user=user, resolver=_RowResolverForTest()) is False
     # User-only refs still work
     expr_user = _e({"user": "is_platform_admin"})
-    assert evaluate(expr_user, row=None, user=FakeUser(is_platform_admin=True)) is True
+    assert evaluate(expr_user, ctx=None, user=FakeUser(is_platform_admin=True), resolver=_RowResolverForTest()) is True
 
 
 # --- is_null on nested paths ---
@@ -250,10 +267,10 @@ def test_row_none_resolves_refs_to_none():
 def test_is_null_nested_missing_path():
     """is_null on a nested path where an intermediate is missing."""
     expr = _e({"is_null": {"row": "a.b.c"}})
-    assert evaluate(expr, row={}, user=FakeUser()) is True
-    assert evaluate(expr, row={"a": None}, user=FakeUser()) is True
-    assert evaluate(expr, row={"a": "scalar"}, user=FakeUser()) is True
-    assert evaluate(expr, row={"a": {"b": {"c": "v"}}}, user=FakeUser()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"a": None}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"a": "scalar"}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"a": {"b": {"c": "v"}}}, user=FakeUser(), resolver=_RowResolverForTest()) is False
 
 
 # --- in-membership with mixed types ---
@@ -264,10 +281,10 @@ def test_in_membership_mixed_types():
     expr = _e({"in": [{"row": "x"}, [1, "1"]]})
     user = FakeUser()
     # String "1" matches the literal "1" in the list
-    assert evaluate(expr, row={"x": "1"}, user=user) is True
+    assert evaluate(expr, ctx={"x": "1"}, user=user, resolver=_RowResolverForTest()) is True
     # Int 1 matches the literal 1 in the list
-    assert evaluate(expr, row={"x": 1}, user=user) is True
-    assert evaluate(expr, row={"x": 2}, user=user) is False
+    assert evaluate(expr, ctx={"x": 1}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"x": 2}, user=user, resolver=_RowResolverForTest()) is False
 
 
 # --- eq against literal None is rejected at validate time ---
@@ -280,4 +297,4 @@ def test_eq_against_literal_none_rejected():
     with pytest.raises(ValidationError, match="use is_null"):
         _e({"eq": [{"row": "x"}, None]})
     # The correct shape:
-    assert evaluate(_e({"is_null": {"row": "x"}}), row={"x": None}, user=user) is True
+    assert evaluate(_e({"is_null": {"row": "x"}}), ctx={"x": None}, user=user, resolver=_RowResolverForTest()) is True

--- a/api/tests/unit/policies/test_evaluate.py
+++ b/api/tests/unit/policies/test_evaluate.py
@@ -7,24 +7,8 @@ import pytest
 from pydantic import ValidationError
 
 from shared.policies.evaluate import evaluate
+from shared.table_policies import RowResolver
 from src.models.contracts.policies import Expr
-
-
-class _RowResolverForTest:
-    """Local stub for the {row: ...} resolver semantics. Replaced by the
-    real RowResolver from shared.table_policies in Task 6."""
-    namespace = "row"
-
-    def resolve(self, path, ctx):
-        parts = path.split(".")
-        cur = ctx
-        for p in parts:
-            if not isinstance(cur, dict):
-                return None
-            cur = cur.get(p)
-            if cur is None:
-                return None
-        return cur
 
 
 @dataclass
@@ -45,29 +29,29 @@ def _e(d: dict) -> Expr:
 
 
 def test_eq_literal_literal():
-    assert evaluate(_e({"eq": [1, 1]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
-    assert evaluate(_e({"eq": [1, 2]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(_e({"eq": [1, 1]}), ctx={}, user=FakeUser(), resolver=RowResolver()) is True
+    assert evaluate(_e({"eq": [1, 2]}), ctx={}, user=FakeUser(), resolver=RowResolver()) is False
 
 
 def test_eq_row_reference():
     expr = _e({"eq": [{"row": "x"}, 5]})
-    assert evaluate(expr, ctx={"x": 5}, user=FakeUser(), resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"x": 6}, user=FakeUser(), resolver=_RowResolverForTest()) is False
-    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False  # missing → null → ne
+    assert evaluate(expr, ctx={"x": 5}, user=FakeUser(), resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"x": 6}, user=FakeUser(), resolver=RowResolver()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=RowResolver()) is False  # missing → null → ne
 
 
 def test_eq_user_reference():
     uid = uuid4()
     user = FakeUser(user_id=uid)
     expr = _e({"eq": [{"row": "owner"}, {"user": "user_id"}]})
-    assert evaluate(expr, ctx={"owner": str(uid)}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"owner": str(uuid4())}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={"owner": str(uid)}, user=user, resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"owner": str(uuid4())}, user=user, resolver=RowResolver()) is False
 
 
 def test_user_is_platform_admin():
     expr = _e({"user": "is_platform_admin"})
-    assert evaluate(expr, ctx={}, user=FakeUser(is_platform_admin=True), resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={}, user=FakeUser(is_platform_admin=False), resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(is_platform_admin=True), resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(is_platform_admin=False), resolver=RowResolver()) is False
 
 
 # --- Logic ---
@@ -80,22 +64,22 @@ def test_and_short_circuits_on_false():
             {"eq": [{"row": "missing"}, 1]},  # would be false too
         ]
     })
-    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=RowResolver()) is False
 
 
 def test_and_all_true():
     expr = _e({"and": [{"eq": [1, 1]}, {"eq": [2, 2]}]})
-    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=RowResolver()) is True
 
 
 def test_or_short_circuits_on_true():
     expr = _e({"or": [{"eq": [1, 1]}, {"eq": [{"row": "x"}, 99]}]})
-    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=RowResolver()) is True
 
 
 def test_not():
-    assert evaluate(_e({"not": {"eq": [1, 1]}}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
-    assert evaluate(_e({"not": {"eq": [1, 2]}}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"not": {"eq": [1, 1]}}), ctx={}, user=FakeUser(), resolver=RowResolver()) is False
+    assert evaluate(_e({"not": {"eq": [1, 2]}}), ctx={}, user=FakeUser(), resolver=RowResolver()) is True
 
 
 # --- Comparisons ---
@@ -103,16 +87,16 @@ def test_not():
 
 def test_lt_lte_gt_gte_numbers():
     user = FakeUser()
-    assert evaluate(_e({"lt": [1, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(_e({"lt": [2, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is False
-    assert evaluate(_e({"lte": [2, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(_e({"gt": [3, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(_e({"gte": [2, 2]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"lt": [1, 2]}), ctx={}, user=user, resolver=RowResolver()) is True
+    assert evaluate(_e({"lt": [2, 2]}), ctx={}, user=user, resolver=RowResolver()) is False
+    assert evaluate(_e({"lte": [2, 2]}), ctx={}, user=user, resolver=RowResolver()) is True
+    assert evaluate(_e({"gt": [3, 2]}), ctx={}, user=user, resolver=RowResolver()) is True
+    assert evaluate(_e({"gte": [2, 2]}), ctx={}, user=user, resolver=RowResolver()) is True
 
 
 def test_neq():
-    assert evaluate(_e({"neq": [1, 2]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
-    assert evaluate(_e({"neq": [1, 1]}), ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(_e({"neq": [1, 2]}), ctx={}, user=FakeUser(), resolver=RowResolver()) is True
+    assert evaluate(_e({"neq": [1, 1]}), ctx={}, user=FakeUser(), resolver=RowResolver()) is False
 
 
 # --- Membership ---
@@ -121,9 +105,9 @@ def test_neq():
 def test_in_membership():
     user = FakeUser()
     expr = _e({"in": [{"row": "status"}, ["draft", "review"]]})
-    assert evaluate(expr, ctx={"status": "draft"}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"status": "done"}, user=user, resolver=_RowResolverForTest()) is False
-    assert evaluate(expr, ctx={}, user=user, resolver=_RowResolverForTest()) is False  # missing
+    assert evaluate(expr, ctx={"status": "draft"}, user=user, resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"status": "done"}, user=user, resolver=RowResolver()) is False
+    assert evaluate(expr, ctx={}, user=user, resolver=RowResolver()) is False  # missing
 
 
 # --- is_null ---
@@ -131,21 +115,21 @@ def test_in_membership():
 
 def test_is_null_missing_field():
     expr = _e({"is_null": {"row": "absent"}})
-    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"absent": "x"}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"absent": "x"}, user=FakeUser(), resolver=RowResolver()) is False
 
 
 def test_is_null_explicit_null():
     expr = _e({"is_null": {"row": "x"}})
-    assert evaluate(expr, ctx={"x": None}, user=FakeUser(), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"x": None}, user=FakeUser(), resolver=RowResolver()) is True
 
 
 def test_not_is_null_pattern():
     """Common idiom: 'is set' check."""
     expr = _e({"not": {"is_null": {"row": "manager_user_id"}}})
     user = FakeUser()
-    assert evaluate(expr, ctx={"manager_user_id": "abc"}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={"manager_user_id": "abc"}, user=user, resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={}, user=user, resolver=RowResolver()) is False
 
 
 # --- Calls ---
@@ -153,14 +137,14 @@ def test_not_is_null_pattern():
 
 def test_has_role_match_by_name():
     expr = _e({"call": "has_role", "args": ["admin"]})
-    assert evaluate(expr, ctx={}, user=FakeUser(role_names=["admin"]), resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={}, user=FakeUser(role_names=["viewer"]), resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(role_names=["admin"]), resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(role_names=["viewer"]), resolver=RowResolver()) is False
 
 
 def test_has_role_match_by_uuid_string():
     role_id = uuid4()
     expr = _e({"call": "has_role", "args": [str(role_id)]})
-    assert evaluate(expr, ctx={}, user=FakeUser(role_ids=[role_id]), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={}, user=FakeUser(role_ids=[role_id]), resolver=RowResolver()) is True
 
 
 # --- Realistic policy scenarios ---
@@ -177,11 +161,11 @@ def test_owner_can_edit_open_policy():
         ]
     })
     # Owner, open: allow
-    assert evaluate(policy, ctx={"created_by": str(uid), "status": "open"}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(policy, ctx={"created_by": str(uid), "status": "open"}, user=user, resolver=RowResolver()) is True
     # Owner, done: deny
-    assert evaluate(policy, ctx={"created_by": str(uid), "status": "done"}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(policy, ctx={"created_by": str(uid), "status": "done"}, user=user, resolver=RowResolver()) is False
     # Other, open: deny
-    assert evaluate(policy, ctx={"created_by": str(uuid4()), "status": "open"}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(policy, ctx={"created_by": str(uuid4()), "status": "open"}, user=user, resolver=RowResolver()) is False
 
 
 def test_manager_reads_reports_policy():
@@ -189,15 +173,15 @@ def test_manager_reads_reports_policy():
     mgr_id = uuid4()
     mgr = FakeUser(user_id=mgr_id)
     policy = _e({"eq": [{"row": "manager_user_id"}, {"user": "user_id"}]})
-    assert evaluate(policy, ctx={"manager_user_id": str(mgr_id)}, user=mgr, resolver=_RowResolverForTest()) is True
-    assert evaluate(policy, ctx={"manager_user_id": str(uuid4())}, user=mgr, resolver=_RowResolverForTest()) is False
+    assert evaluate(policy, ctx={"manager_user_id": str(mgr_id)}, user=mgr, resolver=RowResolver()) is True
+    assert evaluate(policy, ctx={"manager_user_id": str(uuid4())}, user=mgr, resolver=RowResolver()) is False
 
 
 def test_admin_bypass_policy():
     """Platform admin shortcut."""
     policy = _e({"user": "is_platform_admin"})
-    assert evaluate(policy, ctx={"any": "row"}, user=FakeUser(is_platform_admin=True), resolver=_RowResolverForTest()) is True
-    assert evaluate(policy, ctx={"any": "row"}, user=FakeUser(is_platform_admin=False), resolver=_RowResolverForTest()) is False
+    assert evaluate(policy, ctx={"any": "row"}, user=FakeUser(is_platform_admin=True), resolver=RowResolver()) is True
+    assert evaluate(policy, ctx={"any": "row"}, user=FakeUser(is_platform_admin=False), resolver=RowResolver()) is False
 
 
 def test_own_org_policy():
@@ -205,8 +189,8 @@ def test_own_org_policy():
     org_id = uuid4()
     user = FakeUser(organization_id=org_id)
     policy = _e({"eq": [{"row": "organization_id"}, {"user": "organization_id"}]})
-    assert evaluate(policy, ctx={"organization_id": str(org_id)}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(policy, ctx={"organization_id": str(uuid4())}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(policy, ctx={"organization_id": str(org_id)}, user=user, resolver=RowResolver()) is True
+    assert evaluate(policy, ctx={"organization_id": str(uuid4())}, user=user, resolver=RowResolver()) is False
 
 
 # --- Type semantics ---
@@ -218,21 +202,21 @@ def test_string_eq_with_uuid_value_from_user():
     user = FakeUser(user_id=uid)
     expr = _e({"eq": [{"row": "user_id"}, {"user": "user_id"}]})
     # Row has the UUID as a string (JSONB extraction yields string)
-    assert evaluate(expr, ctx={"user_id": str(uid)}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"user_id": str(uid)}, user=user, resolver=RowResolver()) is True
 
 
 def test_null_propagates_in_eq():
     """eq([missing, anything]) is false (does not error)."""
     expr = _e({"eq": [{"row": "x"}, "value"]})
-    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=RowResolver()) is False
 
 
 def test_boolean_field_eq():
     """Boolean fields compare correctly."""
     expr = _e({"eq": [{"row": "enabled"}, True]})
     user = FakeUser()
-    assert evaluate(expr, ctx={"enabled": True}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"enabled": False}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={"enabled": True}, user=user, resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"enabled": False}, user=user, resolver=RowResolver()) is False
 
 
 # --- Top-level boolean coercion ---
@@ -241,10 +225,10 @@ def test_boolean_field_eq():
 def test_bare_literal_top_level_coerces_to_bool():
     """A top-level bare literal coerces to bool (truthy → True)."""
     user = FakeUser()
-    assert evaluate(_e({"eq": ["yes", "yes"]}), ctx={}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"eq": ["yes", "yes"]}), ctx={}, user=user, resolver=RowResolver()) is True
     # A reference resolving to a non-empty string is truthy
     expr = _e({"eq": [{"row": "x"}, "v"]})
-    assert evaluate(expr, ctx={"x": "v"}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"x": "v"}, user=user, resolver=RowResolver()) is True
 
 
 # --- row=None contract (DELETE events) ---
@@ -255,10 +239,10 @@ def test_row_none_resolves_refs_to_none():
     user = FakeUser()
     expr = _e({"eq": [{"row": "x"}, "v"]})
     # Null left side -> NULL-as-false
-    assert evaluate(expr, ctx=None, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx=None, user=user, resolver=RowResolver()) is False
     # User-only refs still work
     expr_user = _e({"user": "is_platform_admin"})
-    assert evaluate(expr_user, ctx=None, user=FakeUser(is_platform_admin=True), resolver=_RowResolverForTest()) is True
+    assert evaluate(expr_user, ctx=None, user=FakeUser(is_platform_admin=True), resolver=RowResolver()) is True
 
 
 # --- is_null on nested paths ---
@@ -267,10 +251,10 @@ def test_row_none_resolves_refs_to_none():
 def test_is_null_nested_missing_path():
     """is_null on a nested path where an intermediate is missing."""
     expr = _e({"is_null": {"row": "a.b.c"}})
-    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"a": None}, user=FakeUser(), resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"a": "scalar"}, user=FakeUser(), resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"a": {"b": {"c": "v"}}}, user=FakeUser(), resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={}, user=FakeUser(), resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"a": None}, user=FakeUser(), resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"a": "scalar"}, user=FakeUser(), resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"a": {"b": {"c": "v"}}}, user=FakeUser(), resolver=RowResolver()) is False
 
 
 # --- in-membership with mixed types ---
@@ -281,10 +265,10 @@ def test_in_membership_mixed_types():
     expr = _e({"in": [{"row": "x"}, [1, "1"]]})
     user = FakeUser()
     # String "1" matches the literal "1" in the list
-    assert evaluate(expr, ctx={"x": "1"}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(expr, ctx={"x": "1"}, user=user, resolver=RowResolver()) is True
     # Int 1 matches the literal 1 in the list
-    assert evaluate(expr, ctx={"x": 1}, user=user, resolver=_RowResolverForTest()) is True
-    assert evaluate(expr, ctx={"x": 2}, user=user, resolver=_RowResolverForTest()) is False
+    assert evaluate(expr, ctx={"x": 1}, user=user, resolver=RowResolver()) is True
+    assert evaluate(expr, ctx={"x": 2}, user=user, resolver=RowResolver()) is False
 
 
 # --- eq against literal None is rejected at validate time ---
@@ -297,4 +281,4 @@ def test_eq_against_literal_none_rejected():
     with pytest.raises(ValidationError, match="use is_null"):
         _e({"eq": [{"row": "x"}, None]})
     # The correct shape:
-    assert evaluate(_e({"is_null": {"row": "x"}}), ctx={"x": None}, user=user, resolver=_RowResolverForTest()) is True
+    assert evaluate(_e({"is_null": {"row": "x"}}), ctx={"x": None}, user=user, resolver=RowResolver()) is True

--- a/api/tests/unit/policies/test_probe.py
+++ b/api/tests/unit/policies/test_probe.py
@@ -3,9 +3,12 @@
 from uuid import uuid4
 
 from shared.policies.probe import (
-    compile_read_filter,
     evaluate_action,
     is_subscribe_authorized,
+)
+from shared.table_policies import (
+    RowResolver,
+    compile_read_filter,
     make_seed_admin_bypass,
 )
 from src.models.contracts.policies import Policy, TablePolicies
@@ -34,16 +37,16 @@ def _own_row_policy() -> Policy:
 def test_evaluate_action_default_deny():
     """Empty policies → deny."""
     tp = TablePolicies(policies=[])
-    assert evaluate_action("read", tp, row={}, user=FakeUser()) is False
+    assert evaluate_action("read", tp, {}, user=FakeUser(), resolver=RowResolver()) is False
 
 
 def test_evaluate_action_admin_bypass():
     tp = TablePolicies(policies=[_admin_bypass_policy()])
     admin = FakeUser(is_platform_admin=True)
     other = FakeUser(is_platform_admin=False)
-    assert evaluate_action("read", tp, row={}, user=admin) is True
-    assert evaluate_action("update", tp, row={}, user=admin) is True
-    assert evaluate_action("read", tp, row={}, user=other) is False
+    assert evaluate_action("read", tp, {}, user=admin, resolver=RowResolver()) is True
+    assert evaluate_action("update", tp, {}, user=admin, resolver=RowResolver()) is True
+    assert evaluate_action("read", tp, {}, user=other, resolver=RowResolver()) is False
 
 
 def test_evaluate_action_OR_across_rules():
@@ -52,11 +55,11 @@ def test_evaluate_action_OR_across_rules():
     user = FakeUser(user_id=uuid4(), is_platform_admin=False)
     # Not admin, not the creator → deny
     assert evaluate_action(
-        "read", tp, row={"created_by": str(uuid4())}, user=user
+        "read", tp, {"created_by": str(uuid4())}, user=user, resolver=RowResolver()
     ) is False
     # Not admin, is creator → allow via own_row
     assert evaluate_action(
-        "read", tp, row={"created_by": str(user.user_id)}, user=user
+        "read", tp, {"created_by": str(user.user_id)}, user=user, resolver=RowResolver()
     ) is True
 
 
@@ -69,8 +72,8 @@ def test_evaluate_action_skips_rules_for_other_actions():
             "when": None,
         })
     ])
-    assert evaluate_action("read", tp, row={}, user=FakeUser()) is False
-    assert evaluate_action("update", tp, row={}, user=FakeUser()) is True
+    assert evaluate_action("read", tp, {}, user=FakeUser(), resolver=RowResolver()) is False
+    assert evaluate_action("update", tp, {}, user=FakeUser(), resolver=RowResolver()) is True
 
 
 def test_evaluate_action_when_none_means_always():
@@ -78,7 +81,7 @@ def test_evaluate_action_when_none_means_always():
     tp = TablePolicies(policies=[
         Policy.model_validate({"name": "open_read", "actions": ["read"], "when": None})
     ])
-    assert evaluate_action("read", tp, row={}, user=FakeUser()) is True
+    assert evaluate_action("read", tp, {}, user=FakeUser(), resolver=RowResolver()) is True
 
 
 # --- compile_read_filter ---
@@ -128,21 +131,21 @@ def test_subscribe_authorized_when_at_least_one_read_rule_could_match():
     tp = TablePolicies(policies=[_own_row_policy()])
     # Even with empty row, the rule is row-data-dependent; subscribe stays open
     # and the per-message filter gates individual messages.
-    assert is_subscribe_authorized(tp, user=FakeUser()) is True
+    assert is_subscribe_authorized(tp, user=FakeUser(), resolver=RowResolver()) is True
 
 
 def test_subscribe_unauthorized_when_no_read_rules():
     tp = TablePolicies(policies=[
         Policy.model_validate({"name": "create_only", "actions": ["create"], "when": None})
     ])
-    assert is_subscribe_authorized(tp, user=FakeUser()) is False
+    assert is_subscribe_authorized(tp, user=FakeUser(), resolver=RowResolver()) is False
 
 
 def test_subscribe_authorized_for_admin_bypass():
     tp = TablePolicies(policies=[_admin_bypass_policy()])
-    assert is_subscribe_authorized(tp, user=FakeUser(is_platform_admin=True)) is True
+    assert is_subscribe_authorized(tp, user=FakeUser(is_platform_admin=True), resolver=RowResolver()) is True
     # Non-admin, no other read rule → user-level fact resolves to False at probe time
-    assert is_subscribe_authorized(tp, user=FakeUser(is_platform_admin=False)) is False
+    assert is_subscribe_authorized(tp, user=FakeUser(is_platform_admin=False), resolver=RowResolver()) is False
 
 
 # --- seed ---
@@ -160,7 +163,7 @@ def test_subscribe_user_dep_false_followed_by_row_dep_allows():
     tp = TablePolicies(policies=[_admin_bypass_policy(), _own_row_policy()])
     # Non-admin → admin_bypass resolves False at probe time
     # own_row is row-dep → conservatively allow
-    assert is_subscribe_authorized(tp, user=FakeUser(is_platform_admin=False)) is True
+    assert is_subscribe_authorized(tp, user=FakeUser(is_platform_admin=False), resolver=RowResolver()) is True
 
 
 def test_subscribe_all_user_dep_resolving_false_denies():
@@ -174,7 +177,7 @@ def test_subscribe_all_user_dep_resolving_false_denies():
         }),
     ])
     assert is_subscribe_authorized(
-        tp, user=FakeUser(is_platform_admin=False, role_names=["customer"])
+        tp, user=FakeUser(is_platform_admin=False, role_names=["customer"]), resolver=RowResolver()
     ) is False
 
 
@@ -183,7 +186,8 @@ def test_make_seed_admin_bypass_validates():
 
     Catches schema drift at module-test time rather than at first table-create.
     """
-    TablePolicies.model_validate(make_seed_admin_bypass())  # must not raise
+    from shared.table_policies import TablePolicies as TP
+    TP.model_validate(make_seed_admin_bypass())  # must not raise
 
 
 def test_compile_read_filter_single_rule_no_or_wrap():

--- a/api/tests/unit/policies/test_round_trip.py
+++ b/api/tests/unit/policies/test_round_trip.py
@@ -12,6 +12,23 @@ from src.models.contracts.policies import Expr
 from tests.unit.policies.test_evaluate import FakeUser
 
 
+class _RowResolverForTest:
+    """Local stub for the {row: ...} resolver semantics. Replaced by the
+    real RowResolver from shared.table_policies in Task 6."""
+    namespace = "row"
+
+    def resolve(self, path, ctx):
+        parts = path.split(".")
+        cur = ctx
+        for p in parts:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(p)
+            if cur is None:
+                return None
+        return cur
+
+
 # Each case is (expr_dict, row_dict, user_kwargs, expected_bool)
 CASES = [
     # Literals
@@ -62,7 +79,7 @@ def test_round_trip(expr_dict, row, user_kwargs, expected):
     expr = Expr.model_validate(expr_dict)
     user = FakeUser(**user_kwargs)
 
-    eval_result = evaluate(expr, row=row, user=user)
+    eval_result = evaluate(expr, ctx=row, user=user, resolver=_RowResolverForTest())
     assert eval_result is expected, (
         f"evaluator: {eval_result}, expected {expected}, expr={expr_dict}"
     )

--- a/api/tests/unit/policies/test_round_trip.py
+++ b/api/tests/unit/policies/test_round_trip.py
@@ -6,10 +6,38 @@ from pydantic import ValidationError
 from shared.policies.compile import compile_to_sql
 from shared.policies.evaluate import evaluate
 from src.models.contracts.policies import Expr
+from src.models.orm.tables import Document
 
 
 # Reuse the FakeUser shape from test_evaluate
 from tests.unit.policies.test_evaluate import FakeUser
+
+
+class _TableBindingForTest:
+    """Local stub mirroring the pre-Task-5 hardcoded {row: ...} → Document
+    column logic. Replaced by the real TableBinding from
+    shared.table_policies in Task 6."""
+    namespace = "row"
+
+    _COLUMN_MAPPED_ROW_FIELDS = {
+        "id": Document.id,
+        "organization_id": None,
+        "created_by": Document.created_by,
+        "updated_by": Document.updated_by,
+        "created_at": Document.created_at,
+        "updated_at": Document.updated_at,
+        "table_id": Document.table_id,
+    }
+
+    def resolve_reference(self, path):
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in self._COLUMN_MAPPED_ROW_FIELDS:
+            col = self._COLUMN_MAPPED_ROW_FIELDS[parts[0]]
+            if col is not None:
+                return col
+        if len(parts) == 1:
+            return Document.data[parts[0]].astext
+        return Document.data[parts].astext
 
 
 class _RowResolverForTest:
@@ -85,7 +113,7 @@ def test_round_trip(expr_dict, row, user_kwargs, expected):
     )
 
     # Compile the expression to a literal value via a SELECT 1 WHERE <expr>
-    sql_expr = compile_to_sql(expr, user)
+    sql_expr = compile_to_sql(expr, user, _TableBindingForTest())
     # We can't run SQL without the DB; instead, verify the rendered SQL
     # contains expected literals/columns. The actual SQL execution is
     # tested in the e2e test_policies.py via real document rows.

--- a/api/tests/unit/policies/test_round_trip.py
+++ b/api/tests/unit/policies/test_round_trip.py
@@ -5,56 +5,11 @@ from pydantic import ValidationError
 
 from shared.policies.compile import compile_to_sql
 from shared.policies.evaluate import evaluate
+from shared.table_policies import RowResolver, TableBinding
 from src.models.contracts.policies import Expr
-from src.models.orm.tables import Document
-
 
 # Reuse the FakeUser shape from test_evaluate
 from tests.unit.policies.test_evaluate import FakeUser
-
-
-class _TableBindingForTest:
-    """Local stub mirroring the pre-Task-5 hardcoded {row: ...} → Document
-    column logic. Replaced by the real TableBinding from
-    shared.table_policies in Task 6."""
-    namespace = "row"
-
-    _COLUMN_MAPPED_ROW_FIELDS = {
-        "id": Document.id,
-        "organization_id": None,
-        "created_by": Document.created_by,
-        "updated_by": Document.updated_by,
-        "created_at": Document.created_at,
-        "updated_at": Document.updated_at,
-        "table_id": Document.table_id,
-    }
-
-    def resolve_reference(self, path):
-        parts = path.split(".")
-        if len(parts) == 1 and parts[0] in self._COLUMN_MAPPED_ROW_FIELDS:
-            col = self._COLUMN_MAPPED_ROW_FIELDS[parts[0]]
-            if col is not None:
-                return col
-        if len(parts) == 1:
-            return Document.data[parts[0]].astext
-        return Document.data[parts].astext
-
-
-class _RowResolverForTest:
-    """Local stub for the {row: ...} resolver semantics. Replaced by the
-    real RowResolver from shared.table_policies in Task 6."""
-    namespace = "row"
-
-    def resolve(self, path, ctx):
-        parts = path.split(".")
-        cur = ctx
-        for p in parts:
-            if not isinstance(cur, dict):
-                return None
-            cur = cur.get(p)
-            if cur is None:
-                return None
-        return cur
 
 
 # Each case is (expr_dict, row_dict, user_kwargs, expected_bool)
@@ -107,13 +62,13 @@ def test_round_trip(expr_dict, row, user_kwargs, expected):
     expr = Expr.model_validate(expr_dict)
     user = FakeUser(**user_kwargs)
 
-    eval_result = evaluate(expr, ctx=row, user=user, resolver=_RowResolverForTest())
+    eval_result = evaluate(expr, ctx=row, user=user, resolver=RowResolver())
     assert eval_result is expected, (
         f"evaluator: {eval_result}, expected {expected}, expr={expr_dict}"
     )
 
     # Compile the expression to a literal value via a SELECT 1 WHERE <expr>
-    sql_expr = compile_to_sql(expr, user, _TableBindingForTest())
+    sql_expr = compile_to_sql(expr, user, TableBinding())
     # We can't run SQL without the DB; instead, verify the rendered SQL
     # contains expected literals/columns. The actual SQL execution is
     # tested in the e2e test_policies.py via real document rows.

--- a/api/tests/unit/policies/test_subscription_logic.py
+++ b/api/tests/unit/policies/test_subscription_logic.py
@@ -6,6 +6,7 @@ would be emitted to the subscriber.
 """
 
 from shared.policies.subscription import decide_visibility_change
+from shared.table_policies import RowResolver
 from src.models.contracts.policies import Expr, TablePolicies
 from tests.unit.policies.test_evaluate import FakeUser
 
@@ -25,7 +26,7 @@ def test_visibility_stays_in():
     pol = _own_row_policies()
     row_old = {"id": "r1", "created_by": str(user.user_id), "v": 1}
     row_new = {"id": "r1", "created_by": str(user.user_id), "v": 2}
-    decision = decide_visibility_change(row_old, row_new, pol, user)
+    decision = decide_visibility_change(row_old, row_new, pol, user, resolver=RowResolver())
     assert decision is not None
     assert decision[0] == "update"
     assert decision[1] == row_new
@@ -37,7 +38,7 @@ def test_visibility_stays_out():
     other = "00000000-0000-0000-0000-000000000999"
     row_old = {"id": "r1", "created_by": other, "v": 1}
     row_new = {"id": "r1", "created_by": other, "v": 2}
-    assert decide_visibility_change(row_old, row_new, pol, user) is None
+    assert decide_visibility_change(row_old, row_new, pol, user, resolver=RowResolver()) is None
 
 
 def test_visibility_gain():
@@ -47,7 +48,7 @@ def test_visibility_gain():
     other = "00000000-0000-0000-0000-000000000999"
     row_old = {"id": "r1", "created_by": other}
     row_new = {"id": "r1", "created_by": str(user.user_id)}
-    decision = decide_visibility_change(row_old, row_new, pol, user)
+    decision = decide_visibility_change(row_old, row_new, pol, user, resolver=RowResolver())
     assert decision is not None
     assert decision[0] == "insert"
     assert decision[1] == row_new
@@ -59,7 +60,7 @@ def test_visibility_loss():
     other = "00000000-0000-0000-0000-000000000999"
     row_old = {"id": "r1", "created_by": str(user.user_id)}
     row_new = {"id": "r1", "created_by": other}
-    decision = decide_visibility_change(row_old, row_new, pol, user)
+    decision = decide_visibility_change(row_old, row_new, pol, user, resolver=RowResolver())
     assert decision == ("delete", "r1")
 
 
@@ -71,5 +72,5 @@ def test_user_filter_narrows_visibility():
     row_old = {"id": "r1", "created_by": str(user.user_id), "status": "open"}
     row_new = {"id": "r1", "created_by": str(user.user_id), "status": "done"}
     # Status flipped from open to done → user filter says no longer visible
-    decision = decide_visibility_change(row_old, row_new, pol, user, user_filter=user_filter)
+    decision = decide_visibility_change(row_old, row_new, pol, user, resolver=RowResolver(), user_filter=user_filter)
     assert decision == ("delete", "r1")

--- a/api/tests/unit/policies/test_table_policies_binding.py
+++ b/api/tests/unit/policies/test_table_policies_binding.py
@@ -1,0 +1,75 @@
+"""Tests for the table-domain bindings to the shared engine."""
+from __future__ import annotations
+
+from sqlalchemy.sql import ColumnElement
+
+from shared.policies.ast import PolicyDocument
+from shared.table_policies import (
+    RowResolver,
+    TableBinding,
+    TablePolicies,
+    compile_read_filter,
+    make_seed_admin_bypass,
+)
+from src.models.orm.tables import Document
+
+
+class _User:
+    user_id = "u-1"
+    email = "u@x"
+    organization_id = None
+    is_platform_admin = True
+    role_ids: list = []
+    role_names: list = []
+
+
+def test_row_resolver_namespace():
+    assert RowResolver().namespace == "row"
+
+
+def test_row_resolver_dot_path():
+    r = RowResolver()
+    assert r.resolve("a", {"a": 1}) == 1
+    assert r.resolve("a.b", {"a": {"b": 2}}) == 2
+    assert r.resolve("missing", {}) is None
+    assert r.resolve("a.b", None) is None
+
+
+def test_table_binding_column_mapped():
+    b = TableBinding()
+    col = b.resolve_reference("created_by")
+    assert col is Document.created_by
+
+
+def test_table_binding_jsonb_fallback():
+    b = TableBinding()
+    col = b.resolve_reference("some_data_field")
+    s = str(col)
+    assert "data" in s.lower()
+
+
+def test_make_seed_admin_bypass_uses_table_actions():
+    seed = make_seed_admin_bypass()
+    assert seed["policies"][0]["actions"] == ["read", "create", "update", "delete"]
+
+
+def test_compile_read_filter_returns_none_for_empty():
+    doc = PolicyDocument()
+    assert compile_read_filter(doc, user=_User()) is None
+
+
+def test_compile_read_filter_or_across_rules():
+    doc = PolicyDocument.model_validate({
+        "policies": [
+            {"name": "a", "actions": ["read"], "when": {"user": "is_platform_admin"}},
+            {"name": "b", "actions": ["read"], "when": {"eq": [{"row": "owner_id"}, {"user": "user_id"}]}},
+        ],
+    })
+    sql = compile_read_filter(doc, user=_User())
+    assert sql is not None
+    assert isinstance(sql, ColumnElement)
+
+
+def test_table_policies_re_exports_policy_document():
+    """TablePolicies is an alias of PolicyDocument."""
+    assert TablePolicies is PolicyDocument

--- a/api/tests/unit/test_admin_bypass_seed_migration.py
+++ b/api/tests/unit/test_admin_bypass_seed_migration.py
@@ -10,8 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from shared.policies.probe import make_seed_admin_bypass
-from src.models.contracts.policies import TablePolicies
+from shared.table_policies import TablePolicies, make_seed_admin_bypass
 
 
 MIGRATION_PATH = (
@@ -61,6 +60,7 @@ def test_migration_seed_validates_as_table_policies():
 def test_migration_seed_admin_only_evaluation(user_attrs, expected):
     """Behaviorally: the seed grants every action to admins, denies all others."""
     from shared.policies.probe import evaluate_action
+    from shared.table_policies import RowResolver
 
     class StubUser:
         def __init__(self, **kw):
@@ -76,6 +76,6 @@ def test_migration_seed_admin_only_evaluation(user_attrs, expected):
     policies = TablePolicies.model_validate(_extract_seed_from_migration())
     user = StubUser(**user_attrs)
     for action in ("read", "create", "update", "delete"):
-        assert evaluate_action(action, policies, row={}, user=user) is expected, (
+        assert evaluate_action(action, policies, ctx={}, user=user, resolver=RowResolver()) is expected, (
             f"action={action!r} user={user_attrs} expected={expected}"
         )

--- a/docs/superpowers/plans/2026-05-19-file-policies.md
+++ b/docs/superpowers/plans/2026-05-19-file-policies.md
@@ -1,0 +1,3290 @@
+# File Policies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship file policies (#170) — RLS-style rules that let apps read and write files directly from the browser without proxying through workflows. Backed by a new `FilePolicy` ORM table, a `file_index` sidecar extension carrying `created_by`/`created_at`, a `FileResolver` plugged into the shared policy engine, REST-relax of `/api/files/*` from `CurrentSuperuser` to `Context`, a Web SDK (`client/src/lib/app-sdk/files.ts`), CLI/MCP/manifest plumbing, admin UI (file browser + rule editor + effective-access tester), and websocket subscriptions for prefix-based live listings.
+
+**Architecture:** This plan plugs into the refactored engine from `2026-05-19-policy-engine-extraction.md` (PR A). A new `api/shared/file_policies.py` provides a `FileResolver` (namespace=`file`, no `Binding` since files have no SQL pushdown), a file-specific `make_seed_admin_bypass` with the `[read,write,delete,list]` action vocab, and a `compile_action_filter(action, policies, user) -> Callable[[FileMetadata], bool]` helper that produces a Python predicate the list endpoint uses to filter S3 results in-memory. Policy resolution is longest-prefix-wins on `(location, path)` — different from tables' additive-across-rules. A new sidecar in `file_index` carries `created_by`/`created_at` populated by every write path; pre-sidecar files are admin-only by intentional design.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy 2.x, Pydantic v2, Alembic, pytest. React + TypeScript with shadcn/ui + Monaco editor for the admin UI. Playwright for E2E client tests.
+
+**Hard precondition:** PR A (`2026-05-19-policy-engine-extraction.md`) must be merged before starting Task 2 of this plan. Task 1 verifies that.
+
+---
+
+## Scope and sub-project decomposition
+
+This plan is one cohesive build. The work breaks into seven sub-projects:
+
+| Sub-project | Tasks | Owner role | Can parallelize with |
+|---|---|---|---|
+| **A. Engine wiring** | 2–4 | Backend | — (foundational) |
+| **B. Storage + migration** | 5–7 | Backend | A (after Task 2) |
+| **C. REST relax + batch signed-URL** | 8–11 | Backend | D (after Task 7) |
+| **D. CLI / MCP / Manifest** | 12–14 | Backend | C |
+| **E. Web SDK + useFiles hook** | 15–17 | Frontend | C (after Task 8) |
+| **F. Admin UI (browser, editor, tester)** | 18–21 | Frontend | E (after Task 15) |
+| **G. Subscriptions** | 22–24 | Backend + Frontend | F |
+
+For agent-team execution: spin up 3 agents after Task 7 lands — one on C, one on D, one on E. After Task 15, F can start. G is last.
+
+---
+
+## Public API contracts (cross-task)
+
+These signatures are referenced by multiple tasks. They are the contract; do not deviate.
+
+### `api/shared/file_policies.py`
+
+```python
+class FileMetadata(BaseModel):
+    """Domain context shape for `{file: ...}` references."""
+    location: str
+    path: str  # user-meaningful, no scope segment
+    created_by: UUID | None
+    created_at: datetime | None
+
+class FileResolver:
+    namespace: ClassVar[str] = "file"
+    def resolve(self, path: str, ctx: FileMetadata | dict | None) -> Any: ...
+
+class FileAction(str, Enum):
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    LIST = "list"
+
+def make_seed_admin_bypass() -> dict: ...  # action vocab = read/write/delete/list
+
+def find_governing_policy(
+    location: str,
+    path: str,
+    db: AsyncSession,
+    organization_id: UUID | None,
+) -> "FilePolicy | None":
+    """Longest-prefix match against file_policies for (location, path)."""
+
+async def evaluate_file_action(
+    action: FileAction,
+    location: str,
+    path: str,
+    file_meta: FileMetadata | None,
+    user: UserPrincipal,
+    db: AsyncSession,
+    organization_id: UUID | None,
+) -> bool:
+    """End-to-end: lookup governing policy → load metadata if needed → evaluator."""
+
+async def filter_listing(
+    location: str,
+    prefix: str,
+    items: list[FileMetadata],
+    user: UserPrincipal,
+    db: AsyncSession,
+    organization_id: UUID | None,
+) -> list[FileMetadata]:
+    """Per-row read check for a listing. Uses governing policy for each item."""
+```
+
+### `api/shared/models.py` additions
+
+```python
+class FilePolicyDocument(BaseModel):
+    """List of rules. Action vocab is file-specific."""
+    policies: list["FilePolicyRule"]
+
+class FilePolicyRule(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    description: str | None = None
+    actions: list[Literal["read", "write", "delete", "list"]] = Field(min_length=1)
+    when: Expr | None = None
+
+class FilePolicyCreate(BaseModel):
+    location: str
+    path: str
+    policies: FilePolicyDocument
+    organization_id: UUID | None = None  # null = global
+
+class FilePolicyUpdate(BaseModel):
+    policies: FilePolicyDocument
+
+class FilePolicyResponse(BaseModel):
+    id: UUID
+    organization_id: UUID | None
+    location: str
+    path: str
+    policies: FilePolicyDocument
+    created_by: UUID
+    created_at: datetime
+    updated_at: datetime
+
+class FileSignedUrlsRequest(BaseModel):
+    paths: list[str] = Field(min_length=1, max_length=500)
+    method: Literal["GET", "PUT"] = "GET"
+    expires_in: int = Field(default=300, ge=30, le=3600)
+
+class FileSignedUrlsResponse(BaseModel):
+    allowed: list["FileSignedUrlItem"]
+    denied: list["FileSignedUrlDenial"]
+
+class FileSignedUrlItem(BaseModel):
+    path: str
+    url: str
+    expires_in: int
+
+class FileSignedUrlDenial(BaseModel):
+    path: str
+    error: Literal["not_found", "denied"]
+```
+
+### `api/src/models/orm/file_policy.py`
+
+```python
+class FilePolicy(Base):
+    __tablename__ = "file_policies"
+    id: Mapped[UUID] = mapped_column(PG_UUID, primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[UUID | None] = mapped_column(PG_UUID, ForeignKey("organizations.id"), nullable=True)
+    location: Mapped[str] = mapped_column(String(64), nullable=False)
+    path: Mapped[str] = mapped_column(String(1000), nullable=False)
+    policies: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    created_by: Mapped[UUID] = mapped_column(PG_UUID, ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint("organization_id", "location", "path", name="uq_file_policies_org_loc_path"),
+        Index("ix_file_policies_lookup", "organization_id", "location", "path"),
+    )
+```
+
+### `api/src/models/orm/file_index.py` (extended)
+
+```python
+class FileIndex(Base):
+    __tablename__ = "file_index"
+
+    path: Mapped[str] = mapped_column(String(1000), primary_key=True)  # existing
+    content: Mapped[str | None]  # existing
+    content_hash: Mapped[str | None]  # existing
+    updated_at: Mapped[datetime]  # existing
+    updated_by: Mapped[str | None]  # existing
+
+    # NEW columns (Task 5 migration):
+    location: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    scope: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    user_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)  # user-meaningful path (no scope)
+    created_by: Mapped[UUID | None] = mapped_column(PG_UUID, nullable=True)
+    created_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+```
+
+### `client/src/lib/app-sdk/files.ts`
+
+```typescript
+export interface FilesSdk {
+  read(path: string): Promise<string>;
+  write(path: string, content: string | ArrayBuffer): Promise<void>;
+  delete(path: string): Promise<void>;
+  list(prefix: string): Promise<FileMetadata[]>;
+  exists(path: string): Promise<boolean>;
+  signedUrl(path: string, method?: "GET" | "PUT"): Promise<SignedUrl>;
+  signedUrls(paths: string[], method?: "GET" | "PUT"): Promise<SignedUrlsResult>;
+  upload(path: string, blob: Blob): Promise<void>;
+  download(path: string): Promise<Blob>;
+}
+
+export interface FileMetadata { path: string; size: number; updated_at: string; created_by: string | null; }
+export interface SignedUrl { url: string; expires_in: number; }
+export interface SignedUrlsResult { allowed: { path: string; url: string; expires_in: number }[]; denied: { path: string; error: "not_found" | "denied" }[]; }
+```
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Confirm PR A merged**
+
+Run: `git log main --oneline | grep -i "domain-agnostic engine"`
+Expected: One match (the merge commit). If absent, PR A is not merged — block and resolve.
+
+- [ ] **Step 2: Confirm engine modules in place**
+
+Run: `test -f api/shared/policies/ast.py && test -f api/shared/policies/resolver.py && test -f api/shared/table_policies.py && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Boot test stack**
+
+Run: `./test.sh stack up`
+Expected: Stack boots.
+
+- [ ] **Step 4: Boot dev stack**
+
+Run: `./debug.sh status | grep -q "Status:   UP" || ./debug.sh`
+Expected: Dev stack running (needed for type regen in later tasks).
+
+---
+
+## Sub-project A: Engine wiring
+
+### Task 2: Create `FileResolver` and `FilePolicyDocument` Pydantic models
+
+**Files:**
+- Create: `api/shared/file_policies.py`
+- Modify: `api/shared/models.py`
+- Test: `api/tests/unit/test_file_resolver.py`
+
+- [ ] **Step 1: Write the failing test for FileResolver**
+
+Create: `api/tests/unit/test_file_resolver.py`
+
+```python
+"""FileResolver: resolves `{file: ...}` references against FileMetadata."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from shared.file_policies import FileMetadata, FileResolver
+
+
+def test_file_resolver_namespace():
+    assert FileResolver().namespace == "file"
+
+
+def test_file_resolver_resolves_known_fields():
+    uid = uuid4()
+    ts = datetime.now(timezone.utc)
+    meta = FileMetadata(
+        location="shared",
+        path="finance/q1.pdf",
+        created_by=uid,
+        created_at=ts,
+    )
+    r = FileResolver()
+    assert r.resolve("created_by", meta) == str(uid)
+    assert r.resolve("created_at", meta) == ts.isoformat()
+    assert r.resolve("path", meta) == "finance/q1.pdf"
+    assert r.resolve("location", meta) == "shared"
+
+
+def test_file_resolver_handles_none_ctx():
+    r = FileResolver()
+    assert r.resolve("created_by", None) is None
+
+
+def test_file_resolver_rejects_unknown_field():
+    meta = FileMetadata(location="shared", path="x", created_by=None, created_at=None)
+    r = FileResolver()
+    # Unknown fields return None (consistent with RowResolver — Resolver is
+    # responsible for validation at the field-name level, but a missing field
+    # on a known shape returns None to match the SQL NULL-as-false semantics).
+    assert r.resolve("nonexistent", meta) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/test_file_resolver.py -v`
+Expected: FAIL — `ModuleNotFoundError: shared.file_policies`.
+
+- [ ] **Step 3: Implement `shared.file_policies` (initial cut)**
+
+Create: `api/shared/file_policies.py`
+
+```python
+"""File-domain binding to the shared policy engine.
+
+Mirrors `shared.table_policies` for the file domain. Action vocab is
+file-specific (read/write/delete/list). No Binding — files have no SQL
+pushdown (lists are S3-prefix-bound, filtered per-row in Python).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, ClassVar
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from shared.policies.ast import PolicyDocument
+
+# Known fields on `{file: ...}` references. Resolver returns None for anything else.
+_KNOWN_FILE_FIELDS: frozenset[str] = frozenset({
+    "location",
+    "path",
+    "created_by",
+    "created_at",
+})
+
+
+class FileMetadata(BaseModel):
+    """Context shape for file policy evaluation."""
+
+    location: str
+    path: str  # user-meaningful (no scope segment)
+    created_by: UUID | None = None
+    created_at: datetime | None = None
+
+
+class FileAction(str, Enum):
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    LIST = "list"
+
+
+class FileResolver:
+    """Resolves `{file: path}` references against FileMetadata."""
+
+    namespace: ClassVar[str] = "file"
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        if ctx is None:
+            return None
+        if path not in _KNOWN_FILE_FIELDS:
+            return None
+        if isinstance(ctx, FileMetadata):
+            val = getattr(ctx, path, None)
+        elif isinstance(ctx, dict):
+            val = ctx.get(path)
+        else:
+            return None
+        if isinstance(val, UUID):
+            return str(val)
+        if isinstance(val, datetime):
+            return val.isoformat()
+        return val
+
+
+def make_seed_admin_bypass() -> dict:
+    """Seeded policy for a freshly-created file_policies row. File action vocab."""
+    return {
+        "policies": [
+            {
+                "name": "admin_bypass",
+                "description": "Platform admins bypass all checks.",
+                "actions": ["read", "write", "delete", "list"],
+                "when": {"user": "is_platform_admin"},
+            },
+        ],
+    }
+
+
+__all__ = [
+    "FileMetadata",
+    "FileAction",
+    "FileResolver",
+    "PolicyDocument",  # re-export for handler ergonomics
+    "make_seed_admin_bypass",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/unit/test_file_resolver.py -v`
+Expected: PASS — all four tests green.
+
+- [ ] **Step 5: Add `FilePolicyDocument` / `FilePolicyRule` to shared models**
+
+Modify: `api/shared/models.py`
+
+Add at an appropriate location (near other policy-related models):
+
+```python
+from typing import Literal as _Literal
+from shared.policies.ast import Expr as _PolicyExpr
+
+
+class FilePolicyRule(BaseModel):
+    """One rule in a file policy. File-specific action vocab."""
+
+    name: str = Field(min_length=1, max_length=100)
+    description: str | None = None
+    actions: list[_Literal["read", "write", "delete", "list"]] = Field(min_length=1)
+    when: _PolicyExpr | None = None
+
+    @field_validator("actions")
+    @classmethod
+    def _no_dup_actions(cls, v: list[str]) -> list[str]:
+        if len(set(v)) != len(v):
+            raise ValueError("actions must not contain duplicates")
+        return v
+
+
+class FilePolicyDocument(BaseModel):
+    """List of rules for a single (location, path) policy."""
+
+    policies: list[FilePolicyRule] = Field(default_factory=list)
+```
+
+If `BaseModel` / `Field` / `field_validator` are not already imported in `models.py`, add them.
+
+- [ ] **Step 6: Run unit tests to confirm nothing broke**
+
+Run: `./test.sh unit -v 2>&1 | tail -10`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/shared/file_policies.py api/shared/models.py api/tests/unit/test_file_resolver.py
+git commit -m "feat(file-policies): add FileResolver + FilePolicyDocument
+
+FileResolver plugs into the shared engine for {file: ...} references.
+Known fields: location, path, created_by, created_at. Action vocab
+is read/write/delete/list. Mirrors shared.table_policies shape."
+```
+
+---
+
+### Task 3: Add `evaluate_file_action` and `find_governing_policy` (longest-prefix lookup)
+
+**Files:**
+- Modify: `api/shared/file_policies.py`
+- Test: `api/tests/unit/test_file_policy_lookup.py`
+
+The longest-prefix-wins resolution is the key behavioral difference from tables. This task implements + tests it without DB access yet (synthetic FilePolicy rows passed in as a list).
+
+- [ ] **Step 1: Write the failing test for longest-prefix matching**
+
+Create: `api/tests/unit/test_file_policy_lookup.py`
+
+```python
+"""Longest-prefix lookup for governing FilePolicy."""
+from __future__ import annotations
+
+import pytest
+
+from shared.file_policies import _select_longest_prefix
+
+
+@pytest.fixture
+def policies():
+    return [
+        {"id": "p-root", "location": "shared", "path": ""},
+        {"id": "p-finance", "location": "shared", "path": "finance"},
+        {"id": "p-finance-q1", "location": "shared", "path": "finance/q1"},
+        {"id": "p-other-loc", "location": "private", "path": ""},
+    ]
+
+
+def test_exact_match(policies):
+    assert _select_longest_prefix(policies, "shared", "finance")["id"] == "p-finance"
+
+
+def test_subpath_uses_longest_match(policies):
+    assert _select_longest_prefix(policies, "shared", "finance/q1/jan.pdf")["id"] == "p-finance-q1"
+    assert _select_longest_prefix(policies, "shared", "finance/q2/feb.pdf")["id"] == "p-finance"
+    assert _select_longest_prefix(policies, "shared", "hr/handbook.pdf")["id"] == "p-root"
+
+
+def test_location_isolated(policies):
+    assert _select_longest_prefix(policies, "private", "anything")["id"] == "p-other-loc"
+    assert _select_longest_prefix(policies, "shared", "finance")["id"] == "p-finance"
+
+
+def test_no_match_returns_none(policies):
+    assert _select_longest_prefix(policies, "nonexistent", "x") is None
+
+
+def test_prefix_boundary_must_be_path_separator():
+    """`finance` should NOT match `financialreports/...` — path boundaries matter."""
+    pol = [{"id": "p-finance", "location": "shared", "path": "finance"}]
+    assert _select_longest_prefix(pol, "shared", "financialreports/x") is None
+    assert _select_longest_prefix(pol, "shared", "finance/x")["id"] == "p-finance"
+    assert _select_longest_prefix(pol, "shared", "finance")["id"] == "p-finance"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/test_file_policy_lookup.py -v`
+Expected: FAIL — `_select_longest_prefix` not exported.
+
+- [ ] **Step 3: Implement `_select_longest_prefix` in `file_policies.py`**
+
+Append to: `api/shared/file_policies.py`
+
+```python
+from typing import TypeVar
+
+_Policy = TypeVar("_Policy", bound=dict)
+
+
+def _select_longest_prefix(
+    policies: list[_Policy],
+    location: str,
+    path: str,
+) -> _Policy | None:
+    """Find the policy with the longest `(location, path)` prefix matching the request.
+
+    Prefix boundaries must align to path separators: a policy at `path="finance"`
+    matches `"finance"` and `"finance/anything"` but NOT `"financialreports"`.
+    """
+    best: _Policy | None = None
+    best_len = -1
+    for p in policies:
+        if p["location"] != location:
+            continue
+        pp = p["path"]
+        if pp == "":
+            if best_len < 0:
+                best, best_len = p, 0
+            continue
+        if path == pp or path.startswith(pp + "/"):
+            if len(pp) > best_len:
+                best, best_len = p, len(pp)
+    return best
+
+
+__all__.append("_select_longest_prefix")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/unit/test_file_policy_lookup.py -v`
+Expected: PASS — all five tests green.
+
+- [ ] **Step 5: Add an integration test for `evaluate_file_action` semantics with default-deny**
+
+Append to: `api/tests/unit/test_file_policy_lookup.py`
+
+```python
+from shared.file_policies import FileMetadata
+from shared.policies.ast import PolicyDocument
+from shared.policies.evaluate import evaluate
+from shared.policies.probe import evaluate_action
+from shared.file_policies import FileResolver
+
+
+class _User:
+    user_id = "u-1"
+    email = "u@x"
+    organization_id = None
+    is_platform_admin = False
+    role_ids = []
+    role_names = ["finance"]
+
+
+def test_default_deny_no_policy():
+    """No policy at any prefix → denied for everyone but admin (and admin path is via admin_bypass rule)."""
+    doc = PolicyDocument()
+    assert evaluate_action(
+        "read", doc, ctx=None, user=_User(), resolver=FileResolver(),
+    ) is False
+
+
+def test_creator_rule_allows_owner_read():
+    doc = PolicyDocument.model_validate({
+        "policies": [{
+            "name": "own_uploads",
+            "actions": ["read", "write", "delete"],
+            "when": {"eq": [{"file": "created_by"}, {"user": "user_id"}]},
+        }],
+    })
+    from uuid import UUID
+    owner = FileMetadata(location="shared", path="x.pdf", created_by=UUID("00000000-0000-0000-0000-000000000001"), created_at=None)
+    # User u-1 is not UUID-1
+    assert evaluate_action(
+        "read", doc, ctx=owner, user=_User(), resolver=FileResolver(),
+    ) is False
+
+
+def test_has_role_rule():
+    doc = PolicyDocument.model_validate({
+        "policies": [{
+            "name": "finance_team",
+            "actions": ["read", "write", "list"],
+            "when": {"call": "has_role", "args": ["finance"]},
+        }],
+    })
+    assert evaluate_action(
+        "read", doc, ctx=None, user=_User(), resolver=FileResolver(),
+    ) is True
+    assert evaluate_action(
+        "delete", doc, ctx=None, user=_User(), resolver=FileResolver(),
+    ) is False
+```
+
+- [ ] **Step 6: Run the suite**
+
+Run: `./test.sh tests/unit/test_file_policy_lookup.py tests/unit/test_file_resolver.py -v`
+Expected: PASS — all tests green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/shared/file_policies.py api/tests/unit/test_file_policy_lookup.py
+git commit -m "feat(file-policies): longest-prefix policy selector + integration tests
+
+_select_longest_prefix implements path-separator-aware prefix matching
+(finance does not match financialreports). evaluate_file_action wired
+via shared.policies.probe.evaluate_action with FileResolver."
+```
+
+---
+
+### Task 4: Wire `find_governing_policy` and `evaluate_file_action` to the DB
+
+**Files:**
+- Modify: `api/shared/file_policies.py`
+- Test: `api/tests/e2e/platform/test_file_policy_evaluator.py`
+
+- [ ] **Step 1: Write the failing E2E test against a real DB**
+
+Create: `api/tests/e2e/platform/test_file_policy_evaluator.py`
+
+```python
+"""E2E: governing policy lookup against the file_policies table."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.file_policies import (
+    FileAction,
+    FileMetadata,
+    evaluate_file_action,
+    find_governing_policy,
+)
+from src.models.orm.file_policy import FilePolicy
+
+
+async def _insert_policy(db, *, location, path, policies, org_id=None, user_id=None):
+    row = FilePolicy(
+        organization_id=org_id,
+        location=location,
+        path=path,
+        policies=policies,
+        created_by=user_id or uuid4(),
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_find_governing_policy_longest_prefix(db: AsyncSession):
+    org_id = uuid4()
+    user_id = uuid4()
+    await _insert_policy(db, location="shared", path="", policies={"policies": []}, org_id=org_id, user_id=user_id)
+    await _insert_policy(db, location="shared", path="finance", policies={"policies": []}, org_id=org_id, user_id=user_id)
+    await _insert_policy(db, location="shared", path="finance/q1", policies={"policies": []}, org_id=org_id, user_id=user_id)
+
+    p = await find_governing_policy("shared", "finance/q1/jan.pdf", db, org_id)
+    assert p is not None and p.path == "finance/q1"
+
+    p = await find_governing_policy("shared", "finance/q2/feb.pdf", db, org_id)
+    assert p is not None and p.path == "finance"
+
+    p = await find_governing_policy("shared", "hr/handbook.pdf", db, org_id)
+    assert p is not None and p.path == ""
+
+    p = await find_governing_policy("nonexistent", "x", db, org_id)
+    assert p is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_file_action_admin_bypass(db: AsyncSession, platform_admin_user):
+    org_id = uuid4()
+    user_id = uuid4()
+    await _insert_policy(db, location="shared", path="", policies={
+        "policies": [{
+            "name": "admin_bypass",
+            "actions": ["read", "write", "delete", "list"],
+            "when": {"user": "is_platform_admin"},
+        }],
+    }, org_id=org_id, user_id=user_id)
+
+    allowed = await evaluate_file_action(
+        FileAction.READ,
+        location="shared",
+        path="anything.pdf",
+        file_meta=None,
+        user=platform_admin_user,
+        db=db,
+        organization_id=org_id,
+    )
+    assert allowed is True
+
+
+@pytest.mark.asyncio
+async def test_evaluate_file_action_default_deny(db: AsyncSession, regular_user):
+    # No policies at all → default deny
+    allowed = await evaluate_file_action(
+        FileAction.READ,
+        location="shared",
+        path="anything.pdf",
+        file_meta=None,
+        user=regular_user,
+        db=db,
+        organization_id=uuid4(),
+    )
+    assert allowed is False
+```
+
+Note on fixtures `platform_admin_user` and `regular_user`: these likely already exist in `api/tests/conftest.py` for table policy tests. If they don't, add them next to the existing user fixtures.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/e2e/platform/test_file_policy_evaluator.py -v`
+Expected: FAIL — `find_governing_policy` and `evaluate_file_action` not yet exported; also `FilePolicy` ORM doesn't yet exist (Task 5 creates it).
+
+- [ ] **Step 3: Defer step 4-Z until Task 5 lands**
+
+Stop here. Task 5 creates the `FilePolicy` ORM and the migration. Task 6 returns to finish the function implementations.
+
+- [ ] **Step 4: Commit the failing test (skipped)**
+
+Pytest skip the new tests until ORM lands:
+
+Wrap the file content with `pytestmark = pytest.mark.skip(reason="awaits Task 5 FilePolicy ORM")` at the top.
+
+```bash
+git add api/tests/e2e/platform/test_file_policy_evaluator.py
+git commit -m "test(file-policies): WIP evaluator E2E (skipped — awaits FilePolicy ORM)"
+```
+
+---
+
+## Sub-project B: Storage + migration
+
+### Task 5: Create `FilePolicy` ORM + Alembic migration + sidecar columns on `file_index`
+
+**Files:**
+- Create: `api/src/models/orm/file_policy.py`
+- Modify: `api/src/models/orm/__init__.py`
+- Modify: `api/src/models/orm/file_index.py`
+- Create: `api/alembic/versions/<YYYYMMDDHHMM>_file_policies_and_file_index_sidecar.py` (Alembic generates the filename)
+- Test: `api/tests/unit/test_file_policy_orm.py`
+
+- [ ] **Step 1: Create the FilePolicy ORM**
+
+Create: `api/src/models/orm/file_policy.py`
+
+```python
+"""FilePolicy ORM model.
+
+Stores RLS-style rules keyed by (organization_id, location, path) for direct
+file reads/writes from apps. Resolution is longest-prefix-wins on
+(location, path); within a policy, rules are additive OR per action.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.orm.base import Base
+
+
+class FilePolicy(Base):
+    """RLS-style policy for a (location, path) prefix."""
+
+    __tablename__ = "file_policies"
+
+    id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    organization_id: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=True,  # null = global
+    )
+    location: Mapped[str] = mapped_column(String(64), nullable=False)
+    path: Mapped[str] = mapped_column(String(1000), nullable=False)
+    policies: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    created_by: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id", "location", "path",
+            name="uq_file_policies_org_loc_path",
+        ),
+        Index("ix_file_policies_lookup", "organization_id", "location", "path"),
+    )
+```
+
+- [ ] **Step 2: Register the ORM in `__init__.py`**
+
+Modify: `api/src/models/orm/__init__.py`
+
+Add the import and __all__ entry:
+
+```python
+from src.models.orm.file_policy import FilePolicy
+
+__all__ = [
+    # ... existing entries ...
+    "FilePolicy",
+]
+```
+
+- [ ] **Step 3: Extend `FileIndex` with sidecar columns**
+
+Modify: `api/src/models/orm/file_index.py`
+
+Replace the class with:
+
+```python
+"""FileIndex ORM model.
+
+Search index for text content in _repo/ AND sidecar metadata for file
+policies (created_by, created_at, location/scope/user_path decomposition).
+Populated via dual-write whenever files are written to S3.
+"""
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import DateTime, String, Text, text
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.orm.base import Base
+
+
+class FileIndex(Base):
+    """Search index + policy sidecar for workspace files in _repo/."""
+
+    __tablename__ = "file_index"
+
+    path: Mapped[str] = mapped_column(String(1000), primary_key=True)
+    content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("NOW()"),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Sidecar fields for file policies (#170). Populated by every write path.
+    # NULL on pre-existing rows means the file is admin-only until rewritten.
+    location: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    scope: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    user_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    created_by: Mapped[UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True,
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+```
+
+- [ ] **Step 4: Generate the Alembic migration**
+
+Run: `cd api && alembic revision -m "file_policies and file_index sidecar"`
+Expected: A new file under `api/alembic/versions/`.
+
+- [ ] **Step 5: Edit the migration**
+
+Open the new file and replace `upgrade()`/`downgrade()`:
+
+```python
+"""file_policies and file_index sidecar.
+
+Adds the file_policies table for RLS-style file access rules and extends
+file_index with sidecar columns (location, scope, user_path, created_by,
+created_at) so policies can filter listings by `{file: created_by}`.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "<auto>"
+down_revision = "<auto>"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "file_policies",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("location", sa.String(length=64), nullable=False),
+        sa.Column("path", sa.String(length=1000), nullable=False),
+        sa.Column("policies", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization_id", "location", "path", name="uq_file_policies_org_loc_path"),
+    )
+    op.create_index(
+        "ix_file_policies_lookup", "file_policies",
+        ["organization_id", "location", "path"],
+    )
+
+    op.add_column("file_index", sa.Column("location", sa.String(length=64), nullable=True))
+    op.add_column("file_index", sa.Column("scope", sa.String(length=64), nullable=True))
+    op.add_column("file_index", sa.Column("user_path", sa.String(length=1000), nullable=True))
+    op.add_column("file_index", sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True))
+    op.add_column("file_index", sa.Column("created_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("file_index", "created_at")
+    op.drop_column("file_index", "created_by")
+    op.drop_column("file_index", "user_path")
+    op.drop_column("file_index", "scope")
+    op.drop_column("file_index", "location")
+    op.drop_index("ix_file_policies_lookup", table_name="file_policies")
+    op.drop_table("file_policies")
+```
+
+Update `revision` and `down_revision` with the values Alembic generated.
+
+- [ ] **Step 6: Apply the migration in the test stack**
+
+Run: `./test.sh stack reset && ./test.sh stack up`
+Expected: Both tables present.
+
+- [ ] **Step 7: Smoke-test the ORM**
+
+Create: `api/tests/unit/test_file_policy_orm.py`
+
+```python
+"""FilePolicy ORM smoke test — confirm the table exists and round-trips."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.orm.file_policy import FilePolicy
+
+
+@pytest.mark.asyncio
+async def test_file_policy_round_trip(db: AsyncSession, regular_user):
+    fp = FilePolicy(
+        organization_id=None,
+        location="shared",
+        path="finance",
+        policies={"policies": []},
+        created_by=regular_user.user_id,
+    )
+    db.add(fp)
+    await db.commit()
+    await db.refresh(fp)
+
+    result = await db.execute(
+        select(FilePolicy).where(FilePolicy.id == fp.id)
+    )
+    loaded = result.scalar_one()
+    assert loaded.location == "shared"
+    assert loaded.path == "finance"
+    assert loaded.policies == {"policies": []}
+```
+
+Run: `./test.sh tests/unit/test_file_policy_orm.py -v`
+Expected: PASS.
+
+- [ ] **Step 8: Apply migration in the dev stack**
+
+Run: `docker compose restart bifrost-init && docker compose restart api`
+(Or equivalent for the worktree's debug stack — check container names with `./debug.sh status`.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add api/src/models/orm/file_policy.py api/src/models/orm/__init__.py api/src/models/orm/file_index.py api/alembic/versions/*file_policies*.py api/tests/unit/test_file_policy_orm.py
+git commit -m "feat(file-policies): FilePolicy ORM + file_index sidecar columns
+
+New file_policies table keyed by (org_id, location, path). file_index
+gains location/scope/user_path/created_by/created_at sidecar columns
+populated by every write path. Existing rows leave them NULL —
+pre-sidecar files are admin-only until rewritten (per design spec)."
+```
+
+---
+
+### Task 6: Finish `evaluate_file_action` and `find_governing_policy` against the DB
+
+**Files:**
+- Modify: `api/shared/file_policies.py`
+- Modify: `api/tests/e2e/platform/test_file_policy_evaluator.py` (un-skip)
+
+- [ ] **Step 1: Un-skip the E2E test**
+
+Modify: `api/tests/e2e/platform/test_file_policy_evaluator.py`
+
+Remove the `pytestmark = pytest.mark.skip(...)` line.
+
+- [ ] **Step 2: Run test to verify it fails on missing functions**
+
+Run: `./test.sh tests/e2e/platform/test_file_policy_evaluator.py -v`
+Expected: FAIL — `find_governing_policy`/`evaluate_file_action` not yet defined.
+
+- [ ] **Step 3: Implement the DB-backed helpers**
+
+Append to: `api/shared/file_policies.py`
+
+```python
+from typing import TYPE_CHECKING
+from uuid import UUID as _UUID
+
+from sqlalchemy import select as _select
+from sqlalchemy.ext.asyncio import AsyncSession as _AsyncSession
+
+from shared.policies.ast import PolicyDocument as _PolicyDocument
+from shared.policies.probe import evaluate_action as _evaluate_action
+
+if TYPE_CHECKING:
+    from src.models.orm.file_policy import FilePolicy as _FilePolicy
+
+
+async def find_governing_policy(
+    location: str,
+    path: str,
+    db: "_AsyncSession",
+    organization_id: "_UUID | None",
+):
+    """Longest-prefix lookup against file_policies for (org, location, path)."""
+    from src.models.orm.file_policy import FilePolicy as _FP
+
+    stmt = _select(_FP).where(
+        _FP.location == location,
+        (_FP.organization_id == organization_id) | (_FP.organization_id.is_(None)),
+    )
+    result = await db.execute(stmt)
+    candidates = result.scalars().all()
+
+    rows = [{"id": p.id, "location": p.location, "path": p.path, "row": p} for p in candidates]
+    best = _select_longest_prefix(rows, location, path)
+    return best["row"] if best else None
+
+
+async def evaluate_file_action(
+    action: "FileAction",
+    location: str,
+    path: str,
+    file_meta: "FileMetadata | None",
+    user,
+    db: "_AsyncSession",
+    organization_id: "_UUID | None",
+) -> bool:
+    """Resolve the governing policy and evaluate `action` against it."""
+    governing = await find_governing_policy(location, path, db, organization_id)
+    if governing is None:
+        return False
+    doc = _PolicyDocument.model_validate(governing.policies)
+    return _evaluate_action(
+        action.value,
+        doc,
+        ctx=file_meta,
+        user=user,
+        resolver=FileResolver(),
+    )
+
+
+__all__.extend(["find_governing_policy", "evaluate_file_action"])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/e2e/platform/test_file_policy_evaluator.py -v`
+Expected: PASS — all three E2E tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/shared/file_policies.py api/tests/e2e/platform/test_file_policy_evaluator.py
+git commit -m "feat(file-policies): DB-backed find_governing_policy + evaluate_file_action
+
+Longest-prefix lookup against file_policies table; runs the shared
+engine evaluator with FileResolver. Default deny when no governing
+policy. Org-scoped lookup (org policies + global policies)."
+```
+
+---
+
+### Task 7: Sidecar dual-write on every file write path
+
+**Files:**
+- Modify: `api/src/services/file_backend.py` (or wherever the actual S3-write logic lives)
+- Modify: `api/src/routers/files.py` (write endpoint sidecar update)
+- Modify: `api/src/routers/forms.py` (form upload path)
+- Modify: any other write path identified via grep
+- Test: `api/tests/e2e/platform/test_file_index_sidecar.py`
+
+The sidecar is the source of truth for `{file: created_by}` and `{file: created_at}`. Every write must populate it or Creator-scope policies misbehave.
+
+- [ ] **Step 1: Inventory every write path**
+
+Run: `grep -rn "file_index\|FileIndex" api/src/ api/shared/ --include="*.py" | grep -iE "insert|update|add\b|merge" | head -20`
+Record the file paths into a comment block in this task — every one needs to set the five new fields.
+
+- [ ] **Step 2: Write the failing E2E test**
+
+Create: `api/tests/e2e/platform/test_file_index_sidecar.py`
+
+```python
+"""Every file write path must populate the file_index sidecar columns."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.orm.file_index import FileIndex
+
+
+@pytest.mark.asyncio
+async def test_files_write_populates_sidecar(
+    db: AsyncSession,
+    api_client_admin,  # existing fixture, authenticated as platform admin
+    platform_admin_user,
+):
+    resp = await api_client_admin.post("/api/files/write", json={
+        "location": "shared",
+        "scope": "org-x",
+        "path": "test/sidecar.txt",
+        "content": "hello",
+    })
+    assert resp.status_code == 204
+
+    result = await db.execute(
+        select(FileIndex).where(FileIndex.user_path == "test/sidecar.txt")
+    )
+    row = result.scalar_one()
+    assert row.location == "shared"
+    assert row.scope == "org-x"
+    assert row.user_path == "test/sidecar.txt"
+    assert row.created_by == platform_admin_user.user_id
+    assert row.created_at is not None
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `./test.sh tests/e2e/platform/test_file_index_sidecar.py -v`
+Expected: FAIL — sidecar columns are NULL.
+
+- [ ] **Step 4: Add a sidecar-write helper**
+
+Append to: `api/shared/file_policies.py`
+
+```python
+async def upsert_sidecar(
+    db: "_AsyncSession",
+    *,
+    s3_key: str,
+    location: str,
+    scope: "str | None",
+    user_path: str,
+    user_id: "_UUID",
+) -> None:
+    """Upsert the file_index sidecar fields for a freshly-written file.
+
+    Idempotent on (s3_key) since file_index has path as its primary key.
+    On insert: populates created_by/created_at to (user_id, now()).
+    On update: leaves created_by/created_at untouched (preserves original creator).
+    """
+    from datetime import datetime, timezone
+    from src.models.orm.file_index import FileIndex
+
+    stmt = _select(FileIndex).where(FileIndex.path == s3_key)
+    existing = (await db.execute(stmt)).scalar_one_or_none()
+
+    now = datetime.now(timezone.utc)
+    if existing is None:
+        db.add(FileIndex(
+            path=s3_key,
+            location=location,
+            scope=scope,
+            user_path=user_path,
+            created_by=user_id,
+            created_at=now,
+            updated_at=now,
+            updated_by=str(user_id),
+        ))
+    else:
+        existing.location = location
+        existing.scope = scope
+        existing.user_path = user_path
+        existing.updated_at = now
+        existing.updated_by = str(user_id)
+        # created_by/created_at intentionally preserved
+
+
+__all__.append("upsert_sidecar")
+```
+
+- [ ] **Step 5: Call `upsert_sidecar` from every write path**
+
+For each write path identified in Step 1, add a call to `upsert_sidecar` immediately after the S3 write succeeds and before the request returns. Each call site has a different way to resolve `(location, scope, user_path)`:
+
+- `POST /api/files/write` (`routers/files.py`): values are in the request body.
+- Form uploads (`routers/forms.py`): scope = `<form-id>`, location = `"uploads"`, user_path = the user-supplied filename.
+- Workflow SDK writes (`sdk/files.py` if any direct-write helpers): pass through to the existing S3-write internal — add `upsert_sidecar` next to the dual-write that maintains FileIndex content/hash.
+
+**Important:** make these changes in the same commit; partial coverage means some files are missing sidecar and policy evaluator denies them unexpectedly.
+
+- [ ] **Step 6: Run the sidecar E2E**
+
+Run: `./test.sh tests/e2e/platform/test_file_index_sidecar.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full file-related test suite**
+
+Run: `./test.sh tests/e2e/platform/ -k "file or upload" -v`
+Expected: PASS — existing file tests unchanged.
+
+- [ ] **Step 8: Add a sidecar-required check to verify nothing was missed**
+
+Append to: `api/tests/e2e/platform/test_file_index_sidecar.py`
+
+```python
+@pytest.mark.asyncio
+async def test_form_upload_populates_sidecar(
+    db: AsyncSession,
+    api_client_admin,
+    test_form_id: str,
+):
+    """Form uploads write a file_index row with location='uploads', scope=form_id."""
+    files = {"file": ("test.txt", b"hi", "text/plain")}
+    resp = await api_client_admin.post(
+        f"/api/forms/{test_form_id}/upload",
+        files=files,
+    )
+    assert resp.status_code in (200, 201)
+
+    result = await db.execute(
+        select(FileIndex)
+        .where(FileIndex.location == "uploads")
+        .where(FileIndex.scope == test_form_id)
+    )
+    rows = result.scalars().all()
+    assert len(rows) >= 1
+    row = rows[0]
+    assert row.created_by is not None
+    assert row.created_at is not None
+```
+
+Run: `./test.sh tests/e2e/platform/test_file_index_sidecar.py -v`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add api/shared/file_policies.py api/src/routers/files.py api/src/routers/forms.py api/tests/e2e/platform/test_file_index_sidecar.py
+# add any other write-path files you modified
+git commit -m "feat(file-policies): dual-write file_index sidecar on every write path
+
+Every file write now populates file_index.location/scope/user_path/
+created_by/created_at. upsert_sidecar() is the shared helper; called
+from POST /api/files/write, form uploads, and any SDK direct-write
+paths. created_by/created_at are preserved on update (only the
+original writer is credited as creator)."
+```
+
+---
+
+## Sub-project C: REST relax + batch signed-URL
+
+### Task 8: Relax `/api/files/*` from `CurrentSuperuser` to `Context` with policy enforcement
+
+**Files:**
+- Modify: `api/src/routers/files.py`
+- Test: `api/tests/e2e/platform/test_file_policies_rest.py`
+
+- [ ] **Step 1: Write the failing REST matrix test**
+
+Create: `api/tests/e2e/platform/test_file_policies_rest.py`
+
+```python
+"""REST matrix: admin vs role-holder vs plain user × read/write/delete/list."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.orm.file_policy import FilePolicy
+
+
+@pytest.fixture
+async def finance_policy(db: AsyncSession, admin_user):
+    fp = FilePolicy(
+        organization_id=None,  # global for test simplicity
+        location="shared",
+        path="finance",
+        policies={
+            "policies": [
+                {
+                    "name": "admin_bypass",
+                    "actions": ["read", "write", "delete", "list"],
+                    "when": {"user": "is_platform_admin"},
+                },
+                {
+                    "name": "finance_team",
+                    "actions": ["read", "write", "delete", "list"],
+                    "when": {"call": "has_role", "args": ["finance"]},
+                },
+            ],
+        },
+        created_by=admin_user.user_id,
+    )
+    db.add(fp)
+    await db.commit()
+    return fp
+
+
+@pytest.mark.asyncio
+async def test_admin_can_read(api_client_admin, finance_policy):
+    resp = await api_client_admin.post("/api/files/read", json={
+        "location": "shared",
+        "scope": "org-1",
+        "path": "finance/q1.pdf",
+    })
+    # 200 if file exists, 404 if not — but NEVER 403 for admin
+    assert resp.status_code != 403
+
+
+@pytest.mark.asyncio
+async def test_finance_role_can_read(api_client_finance, finance_policy):
+    resp = await api_client_finance.post("/api/files/read", json={
+        "location": "shared",
+        "scope": "org-1",
+        "path": "finance/q1.pdf",
+    })
+    assert resp.status_code != 403
+
+
+@pytest.mark.asyncio
+async def test_plain_user_denied(api_client_plain, finance_policy):
+    resp = await api_client_plain.post("/api/files/read", json={
+        "location": "shared",
+        "scope": "org-1",
+        "path": "finance/q1.pdf",
+    })
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_default_deny_no_policy(api_client_plain):
+    """A request for a path with no governing policy → 403 (non-admin)."""
+    resp = await api_client_plain.post("/api/files/read", json={
+        "location": "shared",
+        "scope": "org-1",
+        "path": "ungoverned/x.pdf",
+    })
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_exists_does_not_leak(api_client_plain, finance_policy):
+    """Deny and not-found both return 403 (existence-non-leak)."""
+    resp = await api_client_plain.post("/api/files/exists", json={
+        "location": "shared",
+        "scope": "org-1",
+        "path": "finance/q1.pdf",
+    })
+    assert resp.status_code == 403
+```
+
+Fixtures needed: `api_client_finance` (auth as user with role `finance`) and `api_client_plain` (no relevant roles). Add to `api/tests/conftest.py` next to existing API-client fixtures.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/e2e/platform/test_file_policies_rest.py -v`
+Expected: FAIL — endpoints still require `CurrentSuperuser` (401 instead of 403).
+
+- [ ] **Step 3: Relax `read` endpoint**
+
+Modify: `api/src/routers/files.py`
+
+Replace the `read` endpoint:
+
+```python
+from shared.file_policies import (
+    FileAction,
+    FileMetadata,
+    evaluate_file_action,
+    find_governing_policy,
+)
+from src.core.auth import Context, UserPrincipal
+# remove CurrentSuperuser import if no longer used
+
+
+@router.post("/read", response_model=FileReadResponse)
+async def read_file(
+    request: FileReadRequest,
+    ctx: Context,
+    user: UserPrincipal,  # was CurrentSuperuser
+) -> FileReadResponse:
+    # Load sidecar metadata (if any) for FileMetadata
+    s3_key = resolve_s3_key(request.location, request.scope, request.path)
+    fi = await _load_file_index(ctx.db, s3_key)
+    file_meta = FileMetadata(
+        location=request.location,
+        path=request.path,
+        created_by=fi.created_by if fi else None,
+        created_at=fi.created_at if fi else None,
+    )
+
+    allowed = await evaluate_file_action(
+        FileAction.READ,
+        location=request.location,
+        path=request.path,
+        file_meta=file_meta,
+        user=user,
+        db=ctx.db,
+        organization_id=ctx.organization_id,
+    )
+    if not allowed:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    # ... existing read logic ...
+```
+
+Add helper:
+
+```python
+async def _load_file_index(db: AsyncSession, s3_key: str):
+    from src.models.orm.file_index import FileIndex
+    result = await db.execute(select(FileIndex).where(FileIndex.path == s3_key))
+    return result.scalar_one_or_none()
+```
+
+- [ ] **Step 4: Relax write, delete, list, exists, signed-url**
+
+Apply the same pattern to each endpoint. The action mapping:
+
+- `POST /api/files/read` → `FileAction.READ`
+- `POST /api/files/write` → `FileAction.WRITE`
+- `POST /api/files/delete` → `FileAction.DELETE`
+- `POST /api/files/list` → `FileAction.LIST` (and use `filter_listing` from Task 9 to filter results)
+- `POST /api/files/exists` → `FileAction.READ` BUT respond 403 for both deny AND not-found (existence-non-leak)
+- `POST /api/files/signed-url` → `FileAction.READ` (GET) / `FileAction.WRITE` (PUT)
+
+The other endpoints (`/pull`, `/manifest`, `/watch`, `/watchers`, the admin-mode browse endpoints starting around line 586) remain `CurrentSuperuser`-gated.
+
+- [ ] **Step 5: Run the matrix test**
+
+Run: `./test.sh tests/e2e/platform/test_file_policies_rest.py -v`
+Expected: PASS — all five tests green.
+
+- [ ] **Step 6: Regression check — admin must still work**
+
+Run: `./test.sh tests/e2e/platform/test_files.py -v`
+Expected: PASS — existing tests still pass (admin can read/write everything via the seeded admin_bypass).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/src/routers/files.py api/tests/e2e/platform/test_file_policies_rest.py api/tests/conftest.py
+git commit -m "feat(file-policies): relax /api/files/* to Context + policy enforcement
+
+read/write/delete/list/exists/signed-url now check file policies via
+evaluate_file_action. Admin keeps full access via the seeded
+admin_bypass rule (which lands automatically on first policy create).
+exists uses existence-non-leak (403 for both deny and not-found)."
+```
+
+---
+
+### Task 9: List endpoint — per-row filtering
+
+**Files:**
+- Modify: `api/src/routers/files.py`
+- Modify: `api/shared/file_policies.py`
+- Test: `api/tests/e2e/platform/test_file_policies_rest.py` (extend)
+
+- [ ] **Step 1: Write the failing test for Creator-only listing**
+
+Append to: `api/tests/e2e/platform/test_file_policies_rest.py`
+
+```python
+@pytest.fixture
+async def own_uploads_policy(db: AsyncSession, admin_user):
+    fp = FilePolicy(
+        organization_id=None,
+        location="shared",
+        path="user-uploads",
+        policies={
+            "policies": [
+                {
+                    "name": "admin_bypass",
+                    "actions": ["read", "write", "delete", "list"],
+                    "when": {"user": "is_platform_admin"},
+                },
+                {
+                    "name": "own_uploads",
+                    "actions": ["read", "write", "delete", "list"],
+                    "when": {"eq": [{"file": "created_by"}, {"user": "user_id"}]},
+                },
+            ],
+        },
+        created_by=admin_user.user_id,
+    )
+    db.add(fp)
+    await db.commit()
+    return fp
+
+
+@pytest.mark.asyncio
+async def test_list_filters_to_own_files(
+    db: AsyncSession,
+    api_client_plain,
+    api_client_other_plain,  # different non-admin user
+    own_uploads_policy,
+):
+    """User A's list returns only User A's files."""
+    # Two users upload one file each
+    await api_client_plain.post("/api/files/write", json={
+        "location": "shared", "scope": "x", "path": "user-uploads/a.txt", "content": "a",
+    })
+    await api_client_other_plain.post("/api/files/write", json={
+        "location": "shared", "scope": "x", "path": "user-uploads/b.txt", "content": "b",
+    })
+
+    resp = await api_client_plain.post("/api/files/list", json={
+        "location": "shared",
+        "scope": "x",
+        "prefix": "user-uploads/",
+    })
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    paths = [it["path"] for it in items]
+    assert "user-uploads/a.txt" in paths
+    assert "user-uploads/b.txt" not in paths
+```
+
+Add `api_client_other_plain` to conftest fixtures (a second non-admin user — already needed for table-policies tests, likely exists).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/e2e/platform/test_file_policies_rest.py::test_list_filters_to_own_files -v`
+Expected: FAIL — list returns both files (no filter applied yet).
+
+- [ ] **Step 3: Add `filter_listing` to `file_policies.py`**
+
+Append to: `api/shared/file_policies.py`
+
+```python
+async def filter_listing(
+    location: str,
+    items: list[FileMetadata],
+    user,
+    db: "_AsyncSession",
+    organization_id: "_UUID | None",
+) -> list[FileMetadata]:
+    """Filter a listing by per-item read permission.
+
+    For each item, looks up the governing policy and runs the read evaluator.
+    Items the user cannot read are silently omitted (no count leak).
+    """
+    out: list[FileMetadata] = []
+    # Cache governing-policy lookups by (location, path-prefix) to avoid
+    # N queries for a flat folder.
+    cache: dict[tuple[str, str], object] = {}
+    for item in items:
+        cache_key = (location, item.path)
+        if cache_key in cache:
+            governing = cache[cache_key]
+        else:
+            governing = await find_governing_policy(location, item.path, db, organization_id)
+            cache[cache_key] = governing
+
+        if governing is None:
+            continue
+        doc = _PolicyDocument.model_validate(governing.policies)
+        if _evaluate_action(
+            FileAction.READ.value,
+            doc,
+            ctx=item,
+            user=user,
+            resolver=FileResolver(),
+        ):
+            out.append(item)
+    return out
+
+
+__all__.append("filter_listing")
+```
+
+- [ ] **Step 4: Update the list endpoint**
+
+Modify: `api/src/routers/files.py`
+
+In the `list` endpoint, after the S3-prefix list returns items, build `FileMetadata` for each (looking up file_index for `created_by`/`created_at` per item — single query, `IN (...)` on `path`), then pass through `filter_listing`.
+
+```python
+@router.post("/list", response_model=FileListResponse)
+async def list_files(
+    request: FileListRequest,
+    ctx: Context,
+    user: UserPrincipal,
+) -> FileListResponse:
+    # First check action=list against the listing prefix (cheap fail-fast).
+    list_allowed = await evaluate_file_action(
+        FileAction.LIST,
+        location=request.location,
+        path=request.prefix,
+        file_meta=None,
+        user=user,
+        db=ctx.db,
+        organization_id=ctx.organization_id,
+    )
+    if not list_allowed:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    # Existing S3 list logic returns paths + sizes.
+    raw_items = await _s3_list(request.location, request.scope, request.prefix)
+
+    # Bulk-load sidecar rows for these paths in one query.
+    s3_keys = [resolve_s3_key(request.location, request.scope, it.path) for it in raw_items]
+    from src.models.orm.file_index import FileIndex
+    fi_rows = (await ctx.db.execute(
+        select(FileIndex).where(FileIndex.path.in_(s3_keys))
+    )).scalars().all()
+    by_path = {fi.user_path: fi for fi in fi_rows}
+
+    metas = [
+        FileMetadata(
+            location=request.location,
+            path=it.path,
+            created_by=(by_path.get(it.path) and by_path[it.path].created_by),
+            created_at=(by_path.get(it.path) and by_path[it.path].created_at),
+        )
+        for it in raw_items
+    ]
+
+    visible = await filter_listing(request.location, metas, user, ctx.db, ctx.organization_id)
+
+    return FileListResponse(items=[
+        FileListMetadataItem(
+            path=m.path,
+            size=next(it.size for it in raw_items if it.path == m.path),
+            created_by=str(m.created_by) if m.created_by else None,
+            updated_at=...,
+        )
+        for m in visible
+    ])
+```
+
+Adjust the response model `FileListMetadataItem` to include `created_by: str | None`.
+
+- [ ] **Step 5: Run the test**
+
+Run: `./test.sh tests/e2e/platform/test_file_policies_rest.py::test_list_filters_to_own_files -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/shared/file_policies.py api/src/routers/files.py api/tests/e2e/platform/test_file_policies_rest.py
+git commit -m "feat(file-policies): per-item read filter on list endpoint
+
+list now bulk-loads sidecar metadata for the listing, then runs the
+per-item read evaluator. Items the user can't read are silently omitted
+(no count leak)."
+```
+
+---
+
+### Task 10: Batch signed-URL endpoint
+
+**Files:**
+- Modify: `api/src/routers/files.py`
+- Modify: `api/shared/models.py` (signed-urls request/response)
+- Test: `api/tests/e2e/platform/test_file_signed_urls_batch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create: `api/tests/e2e/platform/test_file_signed_urls_batch.py`
+
+```python
+"""POST /api/files/signed-urls — batch signing with mixed allow/deny."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_batch_signed_urls_mixed(
+    api_client_finance,
+    finance_policy,  # from test_file_policies_rest
+):
+    resp = await api_client_finance.post("/api/files/signed-urls", json={
+        "location": "shared",
+        "scope": "x",
+        "paths": [
+            "finance/q1.pdf",
+            "finance/q2.pdf",
+            "hr/handbook.pdf",  # no policy → deny
+        ],
+        "method": "GET",
+        "expires_in": 300,
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    allowed_paths = [item["path"] for item in body["allowed"]]
+    denied_paths = [item["path"] for item in body["denied"]]
+    assert set(allowed_paths) == {"finance/q1.pdf", "finance/q2.pdf"}
+    assert "hr/handbook.pdf" in denied_paths
+    for item in body["allowed"]:
+        assert item["url"].startswith("http")
+        assert item["expires_in"] == 300
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/e2e/platform/test_file_signed_urls_batch.py -v`
+Expected: FAIL — endpoint doesn't exist.
+
+- [ ] **Step 3: Add the request/response models to `shared/models.py`**
+
+Use the contract shapes from the "Public API contracts" section at the top of this plan.
+
+- [ ] **Step 4: Add the endpoint to `routers/files.py`**
+
+```python
+class FileSignedUrlsRequest(BaseModel):
+    location: str
+    scope: str | None = None
+    paths: list[str] = Field(min_length=1, max_length=500)
+    method: Literal["GET", "PUT"] = "GET"
+    expires_in: int = Field(default=300, ge=30, le=3600)
+
+
+@router.post("/signed-urls")
+async def signed_urls_batch(
+    request: FileSignedUrlsRequest,
+    ctx: Context,
+    user: UserPrincipal,
+) -> FileSignedUrlsResponse:
+    action = FileAction.READ if request.method == "GET" else FileAction.WRITE
+
+    allowed: list[FileSignedUrlItem] = []
+    denied: list[FileSignedUrlDenial] = []
+    for path in request.paths:
+        s3_key = resolve_s3_key(request.location, request.scope, path)
+        fi = await _load_file_index(ctx.db, s3_key)
+        file_meta = FileMetadata(
+            location=request.location, path=path,
+            created_by=fi.created_by if fi else None,
+            created_at=fi.created_at if fi else None,
+        )
+        if await evaluate_file_action(
+            action,
+            location=request.location, path=path, file_meta=file_meta,
+            user=user, db=ctx.db, organization_id=ctx.organization_id,
+        ):
+            url = await _sign_url(s3_key, request.method, request.expires_in)
+            allowed.append(FileSignedUrlItem(path=path, url=url, expires_in=request.expires_in))
+        else:
+            denied.append(FileSignedUrlDenial(path=path, error="denied"))
+
+    return FileSignedUrlsResponse(allowed=allowed, denied=denied)
+```
+
+- [ ] **Step 5: Run test**
+
+Run: `./test.sh tests/e2e/platform/test_file_signed_urls_batch.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/routers/files.py api/shared/models.py api/tests/e2e/platform/test_file_signed_urls_batch.py
+git commit -m "feat(file-policies): batch signed-URL endpoint
+
+POST /api/files/signed-urls accepts a list of paths and a method;
+returns split allowed/denied lists. One auth check, N HMACs.
+Unblocks gallery use cases (per design spec §10.3 fallback —
+useful standalone even if other surfaces slip)."
+```
+
+---
+
+### Task 11: Validate endpoint for file policies
+
+**Files:**
+- Modify: `api/src/routers/files.py`
+- Test: `api/tests/e2e/platform/test_file_policy_validate.py`
+
+A `POST /api/files/policies/validate` mirrors `/api/tables/policies/validate`. Same `PolicyValidationResponse` shape; structured errors via the AST validator's `ValueError`s.
+
+- [ ] **Step 1: Test + endpoint**
+
+Create: `api/tests/e2e/platform/test_file_policy_validate.py`
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_validate_clean(api_client_admin):
+    resp = await api_client_admin.post("/api/files/policies/validate", json={
+        "policies": [{"name": "admin", "actions": ["read"], "when": {"user": "is_platform_admin"}}],
+    })
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_validate_unknown_user_field(api_client_admin):
+    resp = await api_client_admin.post("/api/files/policies/validate", json={
+        "policies": [{"name": "x", "actions": ["read"], "when": {"user": "nonexistent"}}],
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert any("unknown user field" in e["message"] for e in body["errors"])
+```
+
+Add the endpoint:
+
+```python
+@router.post("/policies/validate")
+async def validate_file_policy(
+    document: dict,
+    user: UserPrincipal,
+) -> PolicyValidationResponse:
+    from shared.models import FilePolicyDocument
+    errors: list[PolicyValidationError] = []
+    try:
+        FilePolicyDocument.model_validate(document)
+    except ValidationError as e:
+        for err in e.errors():
+            errors.append(PolicyValidationError(
+                path=".".join(str(p) for p in err["loc"]),
+                message=err["msg"],
+            ))
+    return PolicyValidationResponse(ok=not errors, errors=errors)
+```
+
+Run: `./test.sh tests/e2e/platform/test_file_policy_validate.py -v`
+Expected: PASS.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add api/src/routers/files.py api/tests/e2e/platform/test_file_policy_validate.py
+git commit -m "feat(file-policies): policy validate endpoint
+
+POST /api/files/policies/validate returns structured per-field errors,
+mirroring /api/tables/policies/validate."
+```
+
+---
+
+## Sub-project D: CLI / MCP / Manifest
+
+### Task 12: CRUD endpoints for FilePolicy
+
+**Files:**
+- Modify: `api/src/routers/files.py`
+- Test: `api/tests/e2e/platform/test_file_policy_crud.py`
+
+- [ ] **Step 1: Test + endpoints**
+
+Create: `api/tests/e2e/platform/test_file_policy_crud.py`
+
+```python
+"""CRUD for FilePolicy via /api/files/policies."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_get_update_delete(api_client_admin):
+    create = await api_client_admin.post("/api/files/policies", json={
+        "location": "shared",
+        "path": "test/x",
+        "policies": {"policies": [{
+            "name": "admin", "actions": ["read"], "when": {"user": "is_platform_admin"},
+        }]},
+    })
+    assert create.status_code == 201
+    pid = create.json()["id"]
+
+    get = await api_client_admin.get(f"/api/files/policies/{pid}")
+    assert get.status_code == 200
+    assert get.json()["path"] == "test/x"
+
+    update = await api_client_admin.put(f"/api/files/policies/{pid}", json={
+        "policies": {"policies": [
+            {"name": "admin", "actions": ["read", "write"], "when": {"user": "is_platform_admin"}},
+        ]},
+    })
+    assert update.status_code == 200
+
+    listr = await api_client_admin.get("/api/files/policies?location=shared")
+    assert listr.status_code == 200
+    assert any(p["id"] == pid for p in listr.json())
+
+    delete = await api_client_admin.delete(f"/api/files/policies/{pid}")
+    assert delete.status_code == 204
+```
+
+Add the endpoints (CREATE, GET, UPDATE, LIST, DELETE). These are admin-only (`CurrentSuperuser`) — only the data-plane endpoints relaxed in Task 8.
+
+```python
+@router.post("/policies", response_model=FilePolicyResponse, status_code=201)
+async def create_file_policy(req: FilePolicyCreate, ctx: Context, user: CurrentSuperuser):
+    from src.models.orm.file_policy import FilePolicy as FPOrm
+    # Validate policy document
+    from shared.models import FilePolicyDocument
+    FilePolicyDocument.model_validate(req.policies.model_dump() if hasattr(req.policies, "model_dump") else req.policies)
+
+    row = FPOrm(
+        organization_id=req.organization_id,
+        location=req.location,
+        path=req.path,
+        policies=req.policies.model_dump() if hasattr(req.policies, "model_dump") else req.policies,
+        created_by=user.user_id,
+    )
+    ctx.db.add(row)
+    await ctx.db.commit()
+    await ctx.db.refresh(row)
+    return FilePolicyResponse.model_validate(row, from_attributes=True)
+
+
+@router.get("/policies/{policy_id}", response_model=FilePolicyResponse)
+async def get_file_policy(policy_id: UUID, ctx: Context, user: CurrentSuperuser):
+    from src.models.orm.file_policy import FilePolicy as FPOrm
+    row = (await ctx.db.execute(select(FPOrm).where(FPOrm.id == policy_id))).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(404)
+    return FilePolicyResponse.model_validate(row, from_attributes=True)
+
+
+@router.put("/policies/{policy_id}", response_model=FilePolicyResponse)
+async def update_file_policy(policy_id: UUID, req: FilePolicyUpdate, ctx: Context, user: CurrentSuperuser):
+    from src.models.orm.file_policy import FilePolicy as FPOrm
+    row = (await ctx.db.execute(select(FPOrm).where(FPOrm.id == policy_id))).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(404)
+    row.policies = req.policies.model_dump() if hasattr(req.policies, "model_dump") else req.policies
+    await ctx.db.commit()
+    await ctx.db.refresh(row)
+    return FilePolicyResponse.model_validate(row, from_attributes=True)
+
+
+@router.get("/policies", response_model=list[FilePolicyResponse])
+async def list_file_policies(
+    ctx: Context, user: CurrentSuperuser,
+    location: str | None = None,
+    organization_id: UUID | None = None,
+):
+    from src.models.orm.file_policy import FilePolicy as FPOrm
+    stmt = select(FPOrm)
+    if location is not None:
+        stmt = stmt.where(FPOrm.location == location)
+    if organization_id is not None:
+        stmt = stmt.where(FPOrm.organization_id == organization_id)
+    rows = (await ctx.db.execute(stmt)).scalars().all()
+    return [FilePolicyResponse.model_validate(r, from_attributes=True) for r in rows]
+
+
+@router.delete("/policies/{policy_id}", status_code=204)
+async def delete_file_policy(policy_id: UUID, ctx: Context, user: CurrentSuperuser):
+    from src.models.orm.file_policy import FilePolicy as FPOrm
+    await ctx.db.execute(FPOrm.__table__.delete().where(FPOrm.id == policy_id))
+    await ctx.db.commit()
+```
+
+Run: `./test.sh tests/e2e/platform/test_file_policy_crud.py -v`
+Expected: PASS.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add api/src/routers/files.py api/tests/e2e/platform/test_file_policy_crud.py
+git commit -m "feat(file-policies): CRUD endpoints under /api/files/policies"
+```
+
+---
+
+### Task 13: CLI `bifrost files policies <verb>`
+
+**Files:**
+- Modify: `api/bifrost/files_policies_cli.py` (new submodule)
+- Modify: `api/bifrost/__main__.py` or wherever the CLI command tree is wired
+- Modify: `api/bifrost/dto_flags.py` — register `FilePolicyCreate` / `FilePolicyUpdate`
+- Test: `api/tests/unit/test_dto_flags.py` (will fail until DTOs registered)
+
+- [ ] **Step 1: Confirm baseline DTO parity**
+
+Run: `./test.sh tests/unit/test_dto_flags.py -v`
+Expected: PASS (baseline).
+
+- [ ] **Step 2: Add CLI commands**
+
+Look at `api/bifrost/tables_policies_cli.py` (table policies CLI from PR #178) for the canonical shape. Mirror it.
+
+Create: `api/bifrost/files_policies_cli.py`
+
+```python
+"""bifrost files policies <verb>"""
+import json
+from pathlib import Path
+
+import click
+
+from bifrost._client import client
+
+
+@click.group(name="policies")
+def policies_group():
+    """Manage file policies."""
+
+
+@policies_group.command(name="set")
+@click.option("--location", required=True)
+@click.option("--path", required=True)
+@click.option("--policies-file", type=click.Path(exists=True))
+@click.option("--policies", "policies_inline")
+@click.option("--organization-id", default=None)
+def set_policy(location, path, policies_file, policies_inline, organization_id):
+    """Create or update a file policy at (location, path)."""
+    if policies_file:
+        doc = json.loads(Path(policies_file).read_text())
+    elif policies_inline:
+        doc = json.loads(policies_inline)
+    else:
+        raise click.UsageError("provide --policies-file or --policies")
+
+    # Find-or-create
+    existing = client.get("/api/files/policies", params={"location": location}).json()
+    match = next((p for p in existing if p["path"] == path), None)
+    if match:
+        client.put(f"/api/files/policies/{match['id']}", json={"policies": doc})
+    else:
+        client.post("/api/files/policies", json={
+            "location": location, "path": path, "policies": doc,
+            "organization_id": organization_id,
+        })
+
+
+@policies_group.command(name="get")
+@click.option("--location", required=True)
+@click.option("--path", required=True)
+def get_policy(location, path):
+    rows = client.get("/api/files/policies", params={"location": location}).json()
+    match = next((p for p in rows if p["path"] == path), None)
+    if not match:
+        raise click.ClickException(f"no policy at ({location}, {path})")
+    click.echo(json.dumps(match, indent=2))
+
+
+@policies_group.command(name="list")
+@click.option("--location", default=None)
+def list_policies(location):
+    params = {"location": location} if location else {}
+    rows = client.get("/api/files/policies", params=params).json()
+    click.echo(json.dumps(rows, indent=2))
+
+
+@policies_group.command(name="delete")
+@click.option("--location", required=True)
+@click.option("--path", required=True)
+def delete_policy(location, path):
+    rows = client.get("/api/files/policies", params={"location": location}).json()
+    match = next((p for p in rows if p["path"] == path), None)
+    if not match:
+        return
+    client.delete(f"/api/files/policies/{match['id']}")
+```
+
+Wire it into the `files` group in `__main__.py`:
+
+```python
+from bifrost.files_policies_cli import policies_group as _files_policies_group
+files_group.add_command(_files_policies_group)
+```
+
+- [ ] **Step 3: Register DTOs**
+
+Modify: `api/bifrost/dto_flags.py`
+
+Find the `DTO_REGISTRY` (or equivalent) and add:
+
+```python
+"FilePolicyCreate": FilePolicyCreate,
+"FilePolicyUpdate": FilePolicyUpdate,
+```
+
+Confirm:
+
+Run: `./test.sh tests/unit/test_dto_flags.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: CLI smoke test**
+
+Add: `api/tests/unit/test_files_policies_cli.py` — invokes Click via `CliRunner` and asserts the help text + a roundtrip against a mocked client.
+
+Run: `./test.sh tests/unit/test_files_policies_cli.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/bifrost/files_policies_cli.py api/bifrost/__main__.py api/bifrost/dto_flags.py api/tests/unit/test_files_policies_cli.py
+git commit -m "feat(file-policies): bifrost files policies set/get/list/delete"
+```
+
+---
+
+### Task 14: Manifest serialization
+
+**Files:**
+- Modify: `api/bifrost/manifest.py`
+- Modify: `api/src/services/manifest_generator.py`
+- Modify: `api/src/services/github_sync.py`
+- Modify: `api/bifrost/portable.py`
+- Test: `api/tests/unit/test_manifest.py` (extend)
+- Test: `api/tests/e2e/platform/test_git_sync_local.py` (extend)
+
+- [ ] **Step 1: Add `ManifestFilePolicy` to `manifest.py`**
+
+Modify: `api/bifrost/manifest.py`
+
+```python
+class ManifestFilePolicy(BaseModel):
+    """Portable serialization of a FilePolicy row."""
+    id: UUID | None = None  # absent for portable export; assigned on import
+    organization_id: UUID | None = None  # null for global policies
+    location: str
+    path: str
+    policies: dict  # JSON document, validated as FilePolicyDocument
+```
+
+If there's a top-level Manifest container that lists `tables`, `agents`, `forms`, etc., add `file_policies: dict[str, ManifestFilePolicy] = Field(default_factory=dict)`.
+
+- [ ] **Step 2: Generator (DB → manifest)**
+
+Modify: `api/src/services/manifest_generator.py`
+
+Find the existing table-policy generator (likely a function that iterates `Table` rows and emits a section). Add an analogous loop over `FilePolicy` rows:
+
+```python
+async def _generate_file_policies(db: AsyncSession, organization_id: UUID | None) -> dict[str, dict]:
+    from src.models.orm.file_policy import FilePolicy
+    stmt = select(FilePolicy)
+    if organization_id is not None:
+        stmt = stmt.where(FilePolicy.organization_id == organization_id)
+    rows = (await db.execute(stmt)).scalars().all()
+    return {
+        str(r.id): {
+            "id": str(r.id),
+            "organization_id": str(r.organization_id) if r.organization_id else None,
+            "location": r.location,
+            "path": r.path,
+            "policies": r.policies,
+        }
+        for r in rows
+    }
+```
+
+Hook it into the top-level generator that produces the manifest file.
+
+- [ ] **Step 3: Importer (manifest → DB)**
+
+Modify: `api/src/services/github_sync.py`
+
+Add `_resolve_file_policy` following the non-destructive upsert pattern documented in CLAUDE.md ("Critical: non-destructive upsert pattern"):
+
+```python
+async def _resolve_file_policy(
+    db: AsyncSession,
+    entry: ManifestFilePolicy,
+    organization_id: UUID | None,
+    user_id: UUID,
+) -> None:
+    from src.models.orm.file_policy import FilePolicy
+    existing = (await db.execute(
+        select(FilePolicy)
+        .where(FilePolicy.organization_id == organization_id)
+        .where(FilePolicy.location == entry.location)
+        .where(FilePolicy.path == entry.path)
+    )).scalar_one_or_none()
+    if existing:
+        existing.policies = entry.policies
+    else:
+        db.add(FilePolicy(
+            organization_id=organization_id,
+            location=entry.location,
+            path=entry.path,
+            policies=entry.policies,
+            created_by=user_id,
+        ))
+```
+
+Add stale-entity cleanup at the section level: delete any `FilePolicy` rows not in the manifest.
+
+- [ ] **Step 4: Portable scrub**
+
+Modify: `api/bifrost/portable.py`
+
+On portable export, scrub `organization_id` (set to None — only global policies round-trip). On import, re-stamp with the target org id.
+
+- [ ] **Step 5: Round-trip unit test**
+
+Append to: `api/tests/unit/test_manifest.py`
+
+```python
+def test_file_policy_round_trip():
+    """Manifest FilePolicy serializes and re-parses identically."""
+    src = ManifestFilePolicy(
+        organization_id=None,
+        location="shared",
+        path="finance",
+        policies={"policies": [{
+            "name": "admin", "actions": ["read"], "when": {"user": "is_platform_admin"},
+        }]},
+    )
+    blob = src.model_dump_json()
+    reparsed = ManifestFilePolicy.model_validate_json(blob)
+    assert reparsed.location == "shared"
+    assert reparsed.path == "finance"
+    assert reparsed.policies == src.policies
+```
+
+Run: `./test.sh tests/unit/test_manifest.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: E2E git sync test**
+
+Append to: `api/tests/e2e/platform/test_git_sync_local.py`
+
+Add a test that creates a `FilePolicy`, exports to a local manifest dir, imports back into an empty target DB, and asserts the row matches.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/bifrost/manifest.py api/src/services/manifest_generator.py api/src/services/github_sync.py api/bifrost/portable.py api/tests/unit/test_manifest.py api/tests/e2e/platform/test_git_sync_local.py
+git commit -m "feat(file-policies): manifest round-trip for FilePolicy
+
+ManifestFilePolicy serializes (location, path, policies). Generator
+emits, github_sync upserts non-destructively, portable export scrubs
+organization_id. Round-trip unit + e2e tests cover the lifecycle."
+```
+
+---
+
+## Sub-project E: Web SDK
+
+### Task 15: `client/src/lib/app-sdk/files.ts` — TypeScript SDK
+
+**Files:**
+- Create: `client/src/lib/app-sdk/files.ts`
+- Test: `client/src/lib/app-sdk/files.test.ts`
+
+- [ ] **Step 1: Regenerate types**
+
+Run: `cd client && npm run generate:types`
+Expected: `client/src/lib/v1.d.ts` updated with new file-policy endpoints.
+
+- [ ] **Step 2: Write the failing vitest**
+
+Create: `client/src/lib/app-sdk/files.test.ts`
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createFilesSdk } from "./files";
+
+const mockFetch = vi.fn();
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch;
+});
+
+describe("files SDK", () => {
+  it("read calls POST /api/files/read with the path", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ content: "hello" }),
+    });
+    const sdk = createFilesSdk({ location: "shared", scope: "x" });
+    const content = await sdk.read("a.txt");
+    expect(content).toBe("hello");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/files/read",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("signedUrls returns allowed and denied lists", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        allowed: [{ path: "a.txt", url: "https://x", expires_in: 300 }],
+        denied: [{ path: "b.txt", error: "denied" }],
+      }),
+    });
+    const sdk = createFilesSdk({ location: "shared", scope: "x" });
+    const result = await sdk.signedUrls(["a.txt", "b.txt"]);
+    expect(result.allowed).toHaveLength(1);
+    expect(result.denied).toHaveLength(1);
+    expect(result.denied[0].error).toBe("denied");
+  });
+
+  it("upload uses a signed PUT URL", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ url: "https://put-here", expires_in: 300 }),
+      })
+      .mockResolvedValueOnce({ ok: true });
+    const sdk = createFilesSdk({ location: "shared", scope: "x" });
+    const blob = new Blob(["hi"], { type: "text/plain" });
+    await sdk.upload("a.txt", blob);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://put-here",
+      expect.objectContaining({ method: "PUT", body: blob }),
+    );
+  });
+
+  it("read raises on 403", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "forbidden" }),
+    });
+    const sdk = createFilesSdk({ location: "shared", scope: "x" });
+    await expect(sdk.read("a.txt")).rejects.toThrow(/403|forbidden/i);
+  });
+});
+```
+
+Run: `cd client && npm run test files`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement the SDK**
+
+Create: `client/src/lib/app-sdk/files.ts`
+
+```typescript
+import type { components } from "@/lib/v1";
+
+export type FileMetadata = {
+  path: string;
+  size: number;
+  updated_at: string;
+  created_by: string | null;
+};
+export type SignedUrl = { url: string; expires_in: number };
+export type SignedUrlsResult = {
+  allowed: { path: string; url: string; expires_in: number }[];
+  denied: { path: string; error: "not_found" | "denied" }[];
+};
+
+export interface FilesSdk {
+  read(path: string): Promise<string>;
+  write(path: string, content: string | ArrayBuffer): Promise<void>;
+  delete(path: string): Promise<void>;
+  list(prefix: string): Promise<FileMetadata[]>;
+  exists(path: string): Promise<boolean>;
+  signedUrl(path: string, method?: "GET" | "PUT"): Promise<SignedUrl>;
+  signedUrls(paths: string[], method?: "GET" | "PUT"): Promise<SignedUrlsResult>;
+  upload(path: string, blob: Blob): Promise<void>;
+  download(path: string): Promise<Blob>;
+}
+
+export type FilesSdkConfig = {
+  location: string;
+  scope?: string;
+  baseUrl?: string;
+};
+
+async function call(url: string, init: RequestInit): Promise<Response> {
+  const resp = await fetch(url, init);
+  if (!resp.ok) {
+    let detail = `${resp.status}`;
+    try {
+      const body = await resp.json();
+      if (body.detail) detail += `: ${body.detail}`;
+    } catch {}
+    throw new Error(detail);
+  }
+  return resp;
+}
+
+export function createFilesSdk(config: FilesSdkConfig): FilesSdk {
+  const { location, scope, baseUrl = "" } = config;
+
+  return {
+    async read(path) {
+      const resp = await call(`${baseUrl}/api/files/read`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location, scope, path }),
+      });
+      return (await resp.json()).content;
+    },
+
+    async write(path, content) {
+      await call(`${baseUrl}/api/files/write`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location, scope, path, content }),
+      });
+    },
+
+    async delete(path) {
+      await call(`${baseUrl}/api/files/delete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location, scope, path }),
+      });
+    },
+
+    async list(prefix) {
+      const resp = await call(`${baseUrl}/api/files/list`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location, scope, prefix }),
+      });
+      return (await resp.json()).items;
+    },
+
+    async exists(path) {
+      const resp = await fetch(`${baseUrl}/api/files/exists`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location, scope, path }),
+      });
+      if (resp.status === 403) return false; // existence-non-leak: deny == not-found
+      return (await resp.json()).exists;
+    },
+
+    async signedUrl(path, method = "GET") {
+      const resp = await call(`${baseUrl}/api/files/signed-url`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location, scope, path, method }),
+      });
+      return resp.json();
+    },
+
+    async signedUrls(paths, method = "GET") {
+      const resp = await call(`${baseUrl}/api/files/signed-urls`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ location, scope, paths, method }),
+      });
+      return resp.json();
+    },
+
+    async upload(path, blob) {
+      const { url } = await this.signedUrl(path, "PUT");
+      await call(url, { method: "PUT", body: blob });
+    },
+
+    async download(path) {
+      const { url } = await this.signedUrl(path, "GET");
+      const resp = await call(url, { method: "GET" });
+      return resp.blob();
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run vitest**
+
+Run: `cd client && npm run test files`
+Expected: PASS — all four tests green.
+
+- [ ] **Step 5: Type-check + lint**
+
+Run: `cd client && npm run tsc && npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/lib/app-sdk/files.ts client/src/lib/app-sdk/files.test.ts client/src/lib/v1.d.ts
+git commit -m "feat(app-sdk): Files SDK for browser apps
+
+createFilesSdk({location, scope}) exposes read/write/delete/list/
+exists/signedUrl/signedUrls/upload/download. All calls go through
+/api/files/* and are subject to file-policies enforcement.
+exists silently maps 403 to false (existence-non-leak)."
+```
+
+---
+
+### Task 16: `useFiles(prefix)` React hook
+
+**Files:**
+- Create: `client/src/lib/app-sdk/use-files.tsx`
+- Test: `client/src/lib/app-sdk/use-files.test.tsx`
+
+The hook returns a live listing — REST list seed + websocket invalidation. For this task, ship the REST-seed half only; the websocket half lands in Task 22.
+
+- [ ] **Step 1: Write the failing test**
+
+Create: `client/src/lib/app-sdk/use-files.test.tsx`
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useFiles } from "./use-files";
+
+const mockFetch = vi.fn();
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch;
+});
+
+describe("useFiles", () => {
+  it("returns items from /api/files/list", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [{ path: "a.txt", size: 1, updated_at: "", created_by: null }] }),
+    });
+    const { result } = renderHook(() =>
+      useFiles({ location: "shared", scope: "x", prefix: "" }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces 403 as an access-denied error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "forbidden" }),
+    });
+    const { result } = renderHook(() =>
+      useFiles({ location: "shared", scope: "x", prefix: "" }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("access_denied");
+    expect(result.current.items).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Implement the hook**
+
+Create: `client/src/lib/app-sdk/use-files.tsx`
+
+```typescript
+import { useEffect, useState } from "react";
+import { createFilesSdk, type FileMetadata } from "./files";
+
+export type UseFilesOptions = {
+  location: string;
+  scope?: string;
+  prefix: string;
+};
+
+export type UseFilesResult = {
+  items: FileMetadata[];
+  loading: boolean;
+  error: "access_denied" | "other" | null;
+  refresh: () => Promise<void>;
+};
+
+export function useFiles({ location, scope, prefix }: UseFilesOptions): UseFilesResult {
+  const [items, setItems] = useState<FileMetadata[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<"access_denied" | "other" | null>(null);
+
+  const refresh = async () => {
+    const sdk = createFilesSdk({ location, scope });
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await sdk.list(prefix);
+      setItems(result);
+    } catch (e: any) {
+      if (String(e.message).startsWith("403")) setError("access_denied");
+      else setError("other");
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // Live-listing via websocket lands in Task 22 (subscriptions).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location, scope, prefix]);
+
+  return { items, loading, error, refresh };
+}
+```
+
+- [ ] **Step 3: Run tests + type-check**
+
+Run: `cd client && npm run test use-files && npm run tsc`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/lib/app-sdk/use-files.tsx client/src/lib/app-sdk/use-files.test.tsx
+git commit -m "feat(app-sdk): useFiles hook (REST-seed half)
+
+Returns {items, loading, error, refresh}. Maps 403 to error='access_denied'.
+Websocket invalidation lands in the subscriptions task."
+```
+
+---
+
+### Task 17: Playwright e2e — embedded app uses Files SDK
+
+**Files:**
+- Create: `client/e2e/files-app-direct.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create: `client/e2e/files-app-direct.spec.ts`
+
+```typescript
+import { test, expect } from "@playwright/test";
+
+test("embedded app reads + writes files via SDK without executing a workflow", async ({ page, request }) => {
+  // Pre-seed an admin-bypass policy at the test location
+  // (use the admin API; assumes a fixture login as superuser)
+  await request.post("/api/files/policies", {
+    data: {
+      location: "shared",
+      path: "test/sdk-direct",
+      policies: { policies: [
+        { name: "everyone_for_test", actions: ["read", "write", "list"], when: null },
+      ]},
+    },
+  });
+
+  // Navigate to a built-in test app that exercises the Files SDK
+  // (the app needs to exist — see step 2)
+  await page.goto("/apps/files-sdk-smoke");
+
+  // Trigger a write
+  await page.getByRole("button", { name: "Write file" }).click();
+  await expect(page.getByText("Wrote successfully")).toBeVisible();
+
+  // Trigger a read
+  await page.getByRole("button", { name: "Read file" }).click();
+  await expect(page.getByText("hello world")).toBeVisible();
+
+  // Assert no workflow execution was created
+  const execResp = await request.get("/api/agent-runs?limit=10");
+  const recent = (await execResp.json()).items;
+  expect(recent.find((r: any) => r.app_slug === "files-sdk-smoke")).toBeFalsy();
+});
+```
+
+- [ ] **Step 2: Build the smoke app**
+
+Create `apps/files-sdk-smoke/index.tsx` (built-in app for E2E) that uses `createFilesSdk` to write then read a file when buttons are clicked. Mirror the smallest existing test app for setup boilerplate.
+
+- [ ] **Step 3: Run**
+
+Run: `./test.sh client e2e e2e/files-app-direct.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/e2e/files-app-direct.spec.ts apps/files-sdk-smoke/
+git commit -m "test(file-policies): e2e — app uses Files SDK direct, no workflow"
+```
+
+---
+
+## Sub-project F: Admin UI
+
+### Task 18: Shared tree-view component
+
+**Files:**
+- Create: `client/src/components/files/FileTree.tsx`
+- Test: `client/src/components/files/FileTree.test.tsx`
+
+The file browser, the rule editor's path picker, and the renamer all use the same tree component. Build it once, parameterize the right-click menu via props.
+
+- [ ] **Step 1: Test**
+
+Create: `client/src/components/files/FileTree.test.tsx`
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FileTree } from "./FileTree";
+
+describe("FileTree", () => {
+  it("renders nested paths", () => {
+    render(
+      <FileTree
+        items={[
+          { path: "a/b.txt", isFile: true },
+          { path: "a/c/d.txt", isFile: true },
+          { path: "e.txt", isFile: true },
+        ]}
+      />,
+    );
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b.txt")).toBeInTheDocument();
+    expect(screen.getByText("e.txt")).toBeInTheDocument();
+  });
+
+  it("hides scope segment by default", () => {
+    render(
+      <FileTree
+        items={[{ path: "a/b.txt", isFile: true, scope: "org-x" }]}
+      />,
+    );
+    expect(screen.queryByText("org-x")).not.toBeInTheDocument();
+  });
+
+  it("shows scope when admin-mode is on", () => {
+    render(
+      <FileTree
+        items={[{ path: "a/b.txt", isFile: true, scope: "org-x" }]}
+        showRawScopes
+      />,
+    );
+    expect(screen.getByText("org-x")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+Create: `client/src/components/files/FileTree.tsx`
+
+A standard recursive tree built on shadcn's `Collapsible` + `ContextMenu`. Props:
+- `items: { path: string; isFile: boolean; scope?: string; created_by?: string }[]`
+- `showRawScopes?: boolean`
+- `onFileContextMenu?: (path) => MenuItem[]`
+- `onFolderContextMenu?: (path) => MenuItem[]`
+
+Group items by their first path segment; recurse on subpaths. The implementation is ~150 LoC of normal tree rendering — follow `apps/file-browser-demo/...` if such a precedent exists; otherwise build fresh on Radix Collapsible.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd client && npm run test FileTree`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/files/FileTree.tsx client/src/components/files/FileTree.test.tsx
+git commit -m "feat(file-policies): shared FileTree component with scope-hiding"
+```
+
+---
+
+### Task 19: File browser page
+
+**Files:**
+- Create: `client/src/pages/files/FileBrowser.tsx`
+- Test: `client/src/pages/files/FileBrowser.test.tsx`
+- Modify: `client/src/router.tsx` (add route `/files`)
+
+- [ ] **Step 1: Test**
+
+Create: `client/src/pages/files/FileBrowser.test.tsx`
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FileBrowser } from "./FileBrowser";
+
+vi.mock("@/lib/app-sdk/use-files", () => ({
+  useFiles: () => ({
+    items: [{ path: "shared/finance/q1.pdf", size: 1, updated_at: "", created_by: null }],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+describe("FileBrowser", () => {
+  it("renders the tree under the current location", () => {
+    render(<FileBrowser />);
+    expect(screen.getByText("q1.pdf")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Implement the page**
+
+Create: `client/src/pages/files/FileBrowser.tsx`
+
+Compose:
+- Location picker (top-left): dropdown of known locations
+- OrgSelect: filters server-side
+- "Show raw scopes" admin toggle
+- `<FileTree>` with right-click menus that route to the rule editor + the tester
+- Action buttons: "Upload file", "Add policy at…"
+
+- [ ] **Step 3: Register the route**
+
+Modify: `client/src/router.tsx`
+
+```typescript
+{ path: "/files", element: <FileBrowser />, requiresAuth: true }
+```
+
+- [ ] **Step 4: Run + smoke-test in browser**
+
+Run: `cd client && npm run test FileBrowser`
+Expected: PASS.
+
+Then navigate to the dev URL and open `/files`. Verify the tree renders and right-click works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/pages/files/FileBrowser.tsx client/src/pages/files/FileBrowser.test.tsx client/src/router.tsx
+git commit -m "feat(file-policies): file browser page"
+```
+
+---
+
+### Task 20: Rule editor (Monaco + templates + reference panel)
+
+**Files:**
+- Create: `client/src/components/files/FilePolicyEditor.tsx`
+- Test: `client/src/components/files/FilePolicyEditor.test.tsx`
+
+The shape is **identical to** `TablePolicyEditor` (built in PR #178). The differences:
+- Action vocab: `read/write/delete/list` (vs tables: `read/create/update/delete`)
+- Reference panel: `{file: created_by | created_at | path | location}` (vs `{row: ...}`)
+- Templates: "Everyone reads, role X writes" / "Only the file's creator" / "Admin bypass" — adapted action vocab
+
+- [ ] **Step 1: Test**
+
+Mirror the structure of `client/src/components/tables/TablePolicyEditor.test.tsx` — at minimum:
+- Renders without crashing
+- Loads a template into the editor
+- Calls the validate endpoint on change with debounce
+- Surfaces structured errors from the validator
+- Shows the `{file: ...}` reference panel
+
+- [ ] **Step 2: Implement**
+
+Mirror `client/src/components/tables/TablePolicyEditor.tsx`. Where it imports `compile_read_filter`-shaped helpers or the table validator, swap for the file-policies analogues. The Monaco JSON schema validation can reuse the same `Expr` JSON schema since the AST is shared.
+
+- [ ] **Step 3: Run + smoke-test**
+
+Run: `cd client && npm run test FilePolicyEditor`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/files/FilePolicyEditor.tsx client/src/components/files/FilePolicyEditor.test.tsx
+git commit -m "feat(file-policies): FilePolicyEditor with Monaco JSON + templates"
+```
+
+---
+
+### Task 21: Effective-access tester
+
+**Files:**
+- Create: `client/src/components/files/EffectiveAccessTester.tsx`
+- Create: `api/src/routers/files.py` — add `/api/files/policies/test` endpoint
+- Test (client): `client/src/components/files/EffectiveAccessTester.test.tsx`
+- Test (backend): `api/tests/e2e/platform/test_file_policy_test_endpoint.py`
+
+This is the safety-net surface from the spec §"Effective access tester". Backend endpoint runs the real evaluator with a (possibly synthesized) user and returns the resolution trail.
+
+- [ ] **Step 1: Backend endpoint test**
+
+Create: `api/tests/e2e/platform/test_file_policy_test_endpoint.py`
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_resolution_trail(api_client_admin, finance_policy):
+    resp = await api_client_admin.post("/api/files/policies/test", json={
+        "user_id": "<some-user-uuid>",
+        "extra_roles": ["finance"],  # hypothetical
+        "location": "shared",
+        "path": "finance/q1.pdf",
+        "action": "read",
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["allowed"] is True
+    assert body["matched_policy"]["path"] == "finance"
+    assert body["matched_rule"] == "finance_team"
+    assert "trace" in body
+```
+
+- [ ] **Step 2: Implement the endpoint**
+
+```python
+@router.post("/policies/test")
+async def test_file_policy_access(
+    request: "FilePolicyTestRequest",
+    ctx: Context,
+    user: CurrentSuperuser,  # tester is admin-only
+) -> "FilePolicyTestResponse":
+    # Synthesize a hypothetical user
+    real = await _load_user(ctx.db, request.user_id)
+    hypo = real.with_extra_roles(request.extra_roles)
+
+    governing = await find_governing_policy(
+        request.location, request.path, ctx.db, ctx.organization_id,
+    )
+    if not governing:
+        return FilePolicyTestResponse(allowed=False, matched_policy=None, matched_rule=None, trace=[])
+
+    # Walk rules manually to emit a trail
+    doc = FilePolicyDocument.model_validate(governing.policies)
+    trace = []
+    for rule in doc.policies:
+        if request.action not in rule.actions:
+            continue
+        rule_result = (
+            rule.when is None
+            or evaluate(rule.when, ctx=None, user=hypo, resolver=FileResolver())
+        )
+        trace.append({"rule": rule.name, "result": rule_result})
+        if rule_result:
+            return FilePolicyTestResponse(
+                allowed=True,
+                matched_policy={"id": str(governing.id), "path": governing.path},
+                matched_rule=rule.name,
+                trace=trace,
+            )
+    return FilePolicyTestResponse(allowed=False, matched_policy={"id": str(governing.id), "path": governing.path}, matched_rule=None, trace=trace)
+```
+
+Define `FilePolicyTestRequest`/`FilePolicyTestResponse` in `shared/models.py`.
+
+- [ ] **Step 3: Client component**
+
+Create: `client/src/components/files/EffectiveAccessTester.tsx`
+
+Form: user-picker, optional "extra roles" multi-select, path input, action select. Submit calls `/api/files/policies/test`. Render the trail as a numbered list with green/red dots.
+
+- [ ] **Step 4: Add to FileBrowser as "Test access here…" right-click**
+
+Modify: `FileBrowser.tsx`
+
+Right-click on file or folder → "Test access here…" → opens the tester in a Drawer with `path` pre-filled.
+
+Standalone page: `/files/access-tester` for support cases.
+
+- [ ] **Step 5: Run tests**
+
+Run: `./test.sh tests/e2e/platform/test_file_policy_test_endpoint.py -v`
+Then: `cd client && npm run test EffectiveAccessTester`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/routers/files.py api/shared/models.py api/tests/e2e/platform/test_file_policy_test_endpoint.py client/src/components/files/EffectiveAccessTester.tsx client/src/components/files/EffectiveAccessTester.test.tsx client/src/pages/files/FileBrowser.tsx
+git commit -m "feat(file-policies): effective-access tester + /api/files/policies/test
+
+Renders the resolution trail (which policy matched, which rule fired,
+per-rule pass/fail). Supports hypothetical-user testing: 'as Alice +
+Role Y, even though Alice doesn't have Role Y'. Available from the
+file browser right-click ('Test access here…') and a standalone page."
+```
+
+---
+
+## Sub-project G: Subscriptions
+
+### Task 22: Backend — files websocket channel
+
+**Files:**
+- Modify: `api/src/routers/websocket.py`
+- Modify: `api/src/core/pubsub.py` (new `publish_file_change` / `publish_file_policy_changed`)
+- Modify: `api/shared/file_policies.py` (call publish on write/delete from Tasks 7-8 — wire-up now)
+- Test: `api/tests/e2e/platform/test_file_subscriptions.py`
+
+- [ ] **Step 1: Test the websocket flow**
+
+Create: `api/tests/e2e/platform/test_file_subscriptions.py`
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_subscribe_accepts_when_user_can_list(ws_client_finance, finance_policy):
+    async with ws_client_finance.subscribe("files:shared:finance") as ws:
+        # subscribe handshake succeeded — connection stays open
+        assert await ws.recv() is None  # no immediate message
+
+
+@pytest.mark.asyncio
+async def test_subscribe_rejects_when_user_cannot_list(ws_client_plain, finance_policy):
+    with pytest.raises(Exception, match="subscription_denied"):
+        async with ws_client_plain.subscribe("files:shared:finance"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_creator_only_filtering(ws_client_plain, ws_client_other_plain, own_uploads_policy, api_client_plain):
+    """When two users subscribe to the same prefix, each only sees their own writes."""
+    async with ws_client_plain.subscribe("files:shared:user-uploads") as ws_a:
+        async with ws_client_other_plain.subscribe("files:shared:user-uploads") as ws_b:
+            await api_client_plain.post("/api/files/write", json={
+                "location": "shared", "scope": "x",
+                "path": "user-uploads/a.txt", "content": "a",
+            })
+            msg_a = await ws_a.recv(timeout=2)
+            assert msg_a["action"] == "insert"
+            msg_b = await ws_b.recv_or_none(timeout=2)
+            assert msg_b is None  # filtered out
+```
+
+- [ ] **Step 2: Implement the channel handler**
+
+In `routers/websocket.py`, add the `files:` channel kind. Handshake: parse `(location, prefix)`, call `evaluate_file_action(FileAction.LIST, ...)` — if false, reply `subscription_denied` and close.
+
+- [ ] **Step 3: Implement `publish_file_change` / `publish_file_policy_changed`**
+
+In `core/pubsub.py`:
+
+```python
+async def publish_file_change(location: str, path: str, action: str, file_meta: dict) -> None:
+    # Pub to all "files:{location}:{prefix}" channels where prefix is a prefix of `path`.
+    # Server-side per-recipient filter: if subscriber's effective read is Creator-only,
+    # drop events whose created_by != subscriber.user_id.
+    ...
+
+async def publish_file_policy_changed(location: str, path: str) -> None:
+    # All subscriptions under (location, path) re-probe authorization;
+    # those whose probe is now False receive `subscription_revoked` and close.
+    ...
+```
+
+- [ ] **Step 4: Wire publish calls into write/delete paths**
+
+In `routers/files.py`, after each successful write/delete (post-sidecar-update), call `publish_file_change(...)`.
+
+In the CRUD endpoints for FilePolicy, after each create/update/delete, call `publish_file_policy_changed(...)`.
+
+- [ ] **Step 5: Run**
+
+Run: `./test.sh tests/e2e/platform/test_file_subscriptions.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/routers/websocket.py api/src/core/pubsub.py api/src/routers/files.py api/tests/e2e/platform/test_file_subscriptions.py
+git commit -m "feat(file-policies): websocket subscriptions for prefix change events
+
+files:{location}:{prefix} channel. Subscribe handshake runs the list
+evaluator. publish_file_change broadcasts on write/delete with
+per-recipient Creator filter. publish_file_policy_changed forces
+re-probe on subscribed clients (subscription_revoked if denied)."
+```
+
+---
+
+### Task 23: Frontend — wire websocket into `useFiles`
+
+**Files:**
+- Modify: `client/src/lib/app-sdk/use-files.tsx`
+- Test: `client/src/lib/app-sdk/use-files.test.tsx`
+
+- [ ] **Step 1: Extend `useFiles` to open a websocket**
+
+Subscribe to `files:{location}:{prefix}`. On `insert`/`update`/`delete`, mutate the `items` array locally without a refetch. On `subscription_revoked`, set `error="access_denied"` and clear `items`.
+
+- [ ] **Step 2: Extend tests**
+
+Cover: insert event appends, delete removes, update mutates, `subscription_revoked` resets state.
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cd client && npm run test use-files`
+Expected: PASS.
+
+```bash
+git add client/src/lib/app-sdk/use-files.tsx client/src/lib/app-sdk/use-files.test.tsx
+git commit -m "feat(app-sdk): useFiles subscribes to file change events
+
+Live listing via websocket. Handles insert/update/delete events and
+subscription_revoked. No refetch on each event — mutates local state."
+```
+
+---
+
+### Task 24: Folder rename as a UI primitive
+
+**Files:**
+- Modify: `api/src/routers/files.py` (rename endpoint)
+- Modify: `client/src/pages/files/FileBrowser.tsx` (rename dialog)
+- Test: `client/e2e/files-rename.spec.ts`
+
+S3 doesn't rename — the UI does S3 copy + delete + sidecar update + FilePolicy path update in one user action.
+
+- [ ] **Step 1: Backend rename endpoint test + impl**
+
+Endpoint `POST /api/files/rename` accepts `(location, scope, old_prefix, new_prefix)` and:
+1. Updates every `FilePolicy` row whose `(location, path)` falls under the old prefix (one transaction).
+2. Lists S3 keys under the old prefix.
+3. For each key: copy to new prefix; update `file_index` sidecar (`user_path`, plus the S3 key in the path PK — which means a delete-old + insert-new in the sidecar table); delete old S3 key.
+4. Return `{moved_files: N, updated_policies: M}`.
+
+Test: end-to-end rename with both files and a policy under the old prefix, assert all three side effects.
+
+- [ ] **Step 2: UI dialog**
+
+In `FileBrowser.tsx`, "Rename folder" right-click → dialog. Pre-flight: call `POST /api/files/rename/preview` (counts only) to surface "this will move X files and update Y policies".
+
+- [ ] **Step 3: Playwright spec**
+
+```typescript
+test("rename folder updates files, sidecar, and policies", async ({ page, request }) => {
+  // Seed: a policy + two files under "test/old/"
+  // ... seed setup ...
+  await page.goto("/files");
+  await page.getByText("old").click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Rename" }).click();
+  await page.getByPlaceholder("New name").fill("new");
+  await expect(page.getByText("This will move 2 files and update 1 policy")).toBeVisible();
+  await page.getByRole("button", { name: "Rename" }).click();
+  await expect(page.getByText("new")).toBeVisible();
+  await expect(page.getByText("old")).not.toBeVisible();
+});
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `./test.sh client e2e e2e/files-rename.spec.ts`
+Expected: PASS.
+
+```bash
+git add api/src/routers/files.py client/src/pages/files/FileBrowser.tsx client/e2e/files-rename.spec.ts
+git commit -m "feat(file-policies): folder rename as a UI primitive
+
+UI dialog surfaces the secondary effects ('this will move 47 files and
+update 3 policies') before the rename. Backend updates policies first
+(one tx) then S3-copies + sidecar-updates + deletes — worst-case
+interleaving is 'new prefix briefly empty', never 'access mismatched'."
+```
+
+---
+
+## Final verification
+
+### Task 25: Pre-completion sweep
+
+- [ ] **Step 1: Pyright + ruff (backend)**
+
+Run: `cd api && pyright && ruff check .`
+Expected: 0 errors.
+
+- [ ] **Step 2: Frontend type-check + lint + types regen**
+
+Run: `cd client && npm run generate:types && npm run tsc && npm run lint`
+Expected: 0 errors. No type drift.
+
+- [ ] **Step 3: Backend full test suite**
+
+Run: `./test.sh all`
+Expected: PASS.
+
+- [ ] **Step 4: Frontend unit suite**
+
+Run: `./test.sh client unit`
+Expected: PASS.
+
+- [ ] **Step 5: Frontend e2e suite**
+
+Run: `./test.sh client e2e`
+Expected: PASS.
+
+- [ ] **Step 6: DTO parity test**
+
+Run: `./test.sh tests/unit/test_dto_flags.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Manifest round-trip e2e**
+
+Run: `./test.sh tests/e2e/platform/test_git_sync_local.py -v`
+Expected: PASS.
+
+- [ ] **Step 8: Open PR**
+
+```bash
+git push -u origin 170-file-policies
+gh pr create --title "feat(files): file policies (#170)" --body "$(cat <<'EOF'
+## Summary
+
+- `FilePolicy` ORM keyed by (org_id, location, path) with longest-prefix-wins resolution
+- `file_index` sidecar extension (created_by, created_at, scope decomposition) populated by every write path
+- `/api/files/*` data-plane endpoints relaxed from CurrentSuperuser to Context with policy enforcement
+- Batch signed-URL endpoint (`/api/files/signed-urls`) — gallery unblocker
+- Web SDK at `client/src/lib/app-sdk/files.ts` with `useFiles` hook
+- Admin UI: file browser, rule editor (Monaco), effective-access tester, folder rename primitive
+- CLI: `bifrost files policies set/get/list/delete`
+- Manifest round-trip via `ManifestFilePolicy`
+- Websocket subscriptions on `files:{location}:{prefix}` with per-recipient Creator filtering
+
+Plugs into the domain-agnostic engine from #<PR-A-number>. Action vocab is `read/write/delete/list`. Pre-sidecar files are admin-only by design (no retroactive backfill of created_by).
+
+Spec: `docs/superpowers/specs/2026-05-01-file-policies-design.md`
+Plan: `docs/superpowers/plans/2026-05-19-file-policies.md`
+
+Closes #170.
+
+## Test plan
+
+- [ ] `./test.sh all` green
+- [ ] `./test.sh client unit` green
+- [ ] `./test.sh client e2e` green
+- [ ] DTO parity + manifest round-trip green
+- [ ] Manual: file browser loads, tree renders, scope-hide toggle works
+- [ ] Manual: rule editor renders, templates load, validate endpoint surfaces errors
+- [ ] Manual: effective-access tester shows resolution trail
+- [ ] Manual: subscribe in two tabs as different users, write a file, assert per-recipient Creator filter
+- [ ] Manual: rename a folder with files + a policy, assert pre-flight count + post-rename consistency
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Parallelism playbook for agent teams
+
+| Phase | Tasks | Concurrency |
+|---|---|---|
+| 1 — Foundation | 1, 2, 3 | Serial. One agent. |
+| 2 — Storage | 4, 5, 6 | Serial. One agent. |
+| 3 — Sidecar | 7 | Serial. One agent (touches many write paths). |
+| 4 — REST + CLI + SDK | 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 | **3 agents in parallel** after Task 7: backend agent on 8→11; backend agent on 12→14; frontend agent on 15→17. |
+| 5 — Admin UI | 18, 19, 20, 21 | Serial within the frontend lane. One agent. |
+| 6 — Subscriptions | 22, 23, 24 | 22 first (backend), then 23 and 24 in parallel. |
+| 7 — Verification | 25 | One agent, serial. |
+
+**Coordination notes:**
+- Task 8 and Task 12 both edit `api/src/routers/files.py`. They touch different sections (8 = data-plane endpoints; 12 = CRUD endpoints) but agents must rebase carefully or run sequentially.
+- Task 15 (SDK) does not need backend Task 11 or 12 to be complete — it only needs Task 8 (the relaxed data-plane endpoints) and the generated types.
+- The Files SDK e2e (Task 17) needs Task 15 + Task 8 (no admin UI required).

--- a/docs/superpowers/plans/2026-05-19-files-sdk-handoff.md
+++ b/docs/superpowers/plans/2026-05-19-files-sdk-handoff.md
@@ -1,0 +1,87 @@
+# Files SDK — handoff for a fresh session
+
+> **What this is:** a single-screen pickup point for the file-policies work (#170).
+> Read this first; it tells you where you are, what's left, and which docs to load.
+
+## TL;DR
+
+- **PR A (engine extraction) is open and CI-green**: <https://github.com/jackmusick/bifrost/pull/264>. Branch: `170-file-policies`.
+- **PR B (file-policies impl) is unwritten code, fully planned** in `2026-05-19-file-policies.md`.
+- **Hard gate:** PR A must merge before Task 2 of Plan B can start. Plan B Task 1 is just the "is PR A merged?" check.
+
+## What's done
+
+| Item | State | Where |
+|---|---|---|
+| Spec for file policies | ✅ committed | `docs/superpowers/specs/2026-05-01-file-policies-design.md` |
+| Plan A — engine extraction | ✅ executed | `docs/superpowers/plans/2026-05-19-policy-engine-extraction.md` |
+| Plan B — file-policies build | ✅ written, **not started** | `docs/superpowers/plans/2026-05-19-file-policies.md` |
+| PR A: domain-agnostic engine | ✅ open, all CI green | [PR #264](https://github.com/jackmusick/bifrost/pull/264) |
+| PR B (file policies) | ⏳ not started | — |
+
+## What PR A actually shipped
+
+Refactored `api/shared/policies/` so the engine is domain-agnostic, with table-specific code in a new module:
+
+- `api/shared/policies/{ast,resolver,binding,evaluate,compile,probe,subscription,functions}.py` — domain-agnostic
+- `api/shared/table_policies.py` — `RowResolver`, `TableBinding`, `compile_read_filter`, `make_seed_admin_bypass`, `TablePolicies = PolicyDocument`
+- AST validator now accepts `{row: ...}` and `{file: ...}` references via a `_KNOWN_NAMESPACES` allowlist; unknown single-key dicts (e.g. `{has_role: "x"}`) raise with a clear error
+- Engine isolation test (`test_engine_does_not_import_domain_code`) statically forbids the engine from importing `src.models.orm`, `shared.table_policies`, or `shared.file_policies`
+- All consumers (`routers/tables.py`, `routers/websocket.py`, `routers/cli.py`, `services/manifest_import.py`, `services/mcp_server/tools/tables.py`, `routers/export_import.py`, `test_admin_bypass_seed_migration.py`) migrated to the new imports/signatures
+
+**Verification at completion:** 5107 tests passed, 50 skipped, 0 failed in full `./test.sh all`. Pyright + ruff clean.
+
+## What PR B will ship (the full file-policies build)
+
+From the spec / Plan B, the seven sub-projects:
+
+| # | Sub-project | Tasks | Notes |
+|---|---|---|---|
+| A | Engine wiring | 2–4 | `FileResolver` + longest-prefix lookup + DB-backed `evaluate_file_action` |
+| B | Storage + migration | 5–7 | `FilePolicy` ORM + `file_index` sidecar columns + dual-write on every write path |
+| C | REST relax + batch signed-URL | 8–11 | `/api/files/*` from `CurrentSuperuser` → `Context` with policy enforcement; new `POST /api/files/signed-urls`; CRUD + validate endpoints |
+| D | CLI / MCP / Manifest | 12–14 | `bifrost files policies …`; DTO parity; ManifestFilePolicy round-trip |
+| E | Web SDK + `useFiles` hook | 15–17 | `client/src/lib/app-sdk/files.ts`; Playwright E2E |
+| F | Admin UI | 18–21 | Tree-view file browser; Monaco rule editor; effective-access tester |
+| G | Subscriptions | 22–24 | `files:{location}:{prefix}` websocket channel; per-recipient Creator filter; folder-rename as a UI primitive |
+
+**Parallelism in Plan B:** Tasks 1–7 serial. After Task 7 lands, sub-projects C/D/E can run in parallel (three agents). After Task 15, F starts. G is last. Plan §"Parallelism playbook for agent teams" has the exact split.
+
+## How to resume in a fresh session
+
+1. **Read this file first** (you're here).
+2. **Check PR A status:**
+   ```bash
+   gh pr view 264 --json state,mergeable,statusCheckRollup -q '.state, .mergeable'
+   ```
+   - If `MERGED`: proceed to step 3.
+   - If `OPEN` and CI green: ask the user whether to merge. Do not self-merge without explicit consent (see project memory `feedback_explicit_merge_consent`).
+   - If anything red: investigate.
+3. **Read the spec** to refresh context: `docs/superpowers/specs/2026-05-01-file-policies-design.md` (553 lines, fully self-contained).
+4. **Open Plan B** and start at Task 1 (a 4-step "is PR A merged?" preflight):
+   `docs/superpowers/plans/2026-05-19-file-policies.md`
+5. **Use the `superpowers:subagent-driven-development` skill** to execute Plan B task-by-task with two-stage review (spec compliance + code quality). The plan is written for that workflow.
+
+## Worktree state
+
+- Branch: `170-file-policies` at `/home/jack/GitHub/bifrost/.worktrees/170-file-policies`
+- Rebased on `main` as of 2026-05-19; 9 commits ahead (8 engine refactor + 1 plan docs)
+- Test stack: was up via `./test.sh stack up` (compose project `bifrost-test-9e2076d6`). May have timed out by now — `./test.sh stack status` to check.
+- Dev stack: down (not needed for Plan B Tasks 1–6 since those are backend-only)
+
+## Known quirks the next session should be aware of
+
+- **Pyright "could not be resolved" diagnostics from the harness are false alarms.** They appear when pyright is invoked with the wrong cwd. Always verify with `cd api && pyright <path>` before treating one as real. (See conversation history — happened ~10 times during PR A execution.)
+- **`./test.sh` can fail to boot the api container if a recent commit broke imports.** When you see "service `api` is not running", restart with `docker compose -p <project> -f docker-compose.test.yml restart api`. The Plan B implementer hit this during Task 6 when consumers were temporarily broken; same pattern will recur during Plan B's transitional commits.
+- **`make_seed_admin_bypass` for files needs the file action vocab `[read, write, delete, list]`**, NOT tables' `[read, create, update, delete]`. The spec is clear about this; Plan B Task 2 codifies it.
+- **Pre-sidecar files are admin-only by design.** No retroactive backfill of `created_by`. Plan B Task 7 enumerates every write path that must populate the sidecar — if you find a path the plan misses, add it and update the plan.
+
+## If a PR A change request comes back
+
+If PR #264 picks up review comments before merge, address them on the same branch (`170-file-policies`). The plan files and spec live on the same branch, so amending PR A is straightforward.
+
+## Decision log (things I'd ask about if I were a fresh session)
+
+- **Why a tables-narrowed `Policy` in `contracts/policies.py` vs. just using the wide one?** The existing test `test_policy_actions_limited_to_known_set` (predating this work) asserts `Policy(actions=["query"])` raises — i.e., handlers using `Policy` from contracts expect strict action vocab enforcement. Keeping the narrow class preserved behavior while letting the shared engine accept any string. The shim is explicitly temporary; the comment in `contracts/policies.py` points new code at `shared.table_policies`.
+- **Why a `_KNOWN_NAMESPACES` allowlist in the AST validator instead of a fully open one?** The original validator (pre-refactor) rejected `{has_role: "support"}` because `has_role` wasn't a known operator. The refactor's "single-key dict ⇒ domain reference" branch silently accepted it. Adding `{"row", "file"}` as the allowlist re-tightens to the original behavior while staying domain-agnostic at the engine layer. Adding a new domain (e.g. `runs`) is a one-line change here.
+- **Why pass `RowResolver()` explicitly everywhere instead of defaulting in `evaluate_action`?** The plan deliberately requires the resolver kwarg so the engine has no implicit domain. The cost (a few extra `resolver=RowResolver()` at handler call sites) is small; the payoff (domain-agnostic engine, file policies can plug in trivially) is large.

--- a/docs/superpowers/plans/2026-05-19-policy-engine-extraction.md
+++ b/docs/superpowers/plans/2026-05-19-policy-engine-extraction.md
@@ -1,0 +1,1899 @@
+# Policy Engine Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `api/shared/policies/` into a domain-agnostic engine consumed via `Resolver` + `Binding` protocols, with table-specific code moved into `api/shared/table_policies.py`. Tables behavior must remain bit-for-bit unchanged. This is the precondition for the file-policies plan (#170) and is independently valuable per design doc §10.2.
+
+**Architecture:** Today `api/shared/policies/` reaches into table-specific ORM models (`Document`, `_COLUMN_MAPPED_ROW_FIELDS`, hardcoded `{row}` reference namespace, `TablePolicies` class name, table action vocab). We introduce two Protocol-based seams: a `Resolver` (resolves `{<namespace>: path}` references against a domain context at evaluate time) and a `Binding` (resolves the same references against a SQL backend at compile time). The walker code is otherwise unchanged. Table-specific code (RowResolver, TableBinding, `compile_read_filter`, `make_seed_admin_bypass` with table action vocab) moves to `api/shared/table_policies.py`. After this refactor, file-policies can land by adding `api/shared/file_policies.py` (FileResolver, no Binding — files have no SQL surface) without touching the engine.
+
+**Tech Stack:** Python 3.11, SQLAlchemy 2.x, Pydantic v2, pytest. No new runtime deps.
+
+---
+
+## Pre-flight
+
+This plan modifies `api/shared/policies/` and 8 consumer modules. The test suite for the engine (`api/tests/unit/policies/`) is the safety net — every refactor task ends with that suite still green.
+
+The refactor is **mechanical**: protocol indirection + file moves. There is no behavior change. The tasks are structured so that each one ends with a green test suite; do not batch.
+
+### Files to be created
+
+| Path | Responsibility |
+|------|---------------|
+| `api/shared/policies/ast.py` | `Expr`, `Policy`, `PolicyDocument`, AST validator. Domain-agnostic. Imports `FUNCTIONS` from `shared.policies.functions`. |
+| `api/shared/policies/resolver.py` | `Resolver` protocol. Reference resolution at evaluate time. |
+| `api/shared/policies/binding.py` | `Binding` protocol. Reference resolution at compile time (for domains with SQL pushdown). |
+| `api/shared/table_policies.py` | `RowResolver`, `TableBinding`, `compile_read_filter`, `make_seed_admin_bypass` (table action vocab), `TablePolicies` re-export. |
+| `api/tests/unit/policies/test_engine_protocols.py` | Engine-only tests using a stub Resolver/Binding. Proves the engine is domain-agnostic. |
+
+### Files to be modified
+
+| Path | Change |
+|------|--------|
+| `api/shared/policies/evaluate.py` | Accept `Resolver`; remove `{row}`-specific code. `row: dict \| None` becomes `ctx: Any`. |
+| `api/shared/policies/compile.py` | Accept `Binding`; remove `Document`/`_COLUMN_MAPPED_ROW_FIELDS`. |
+| `api/shared/policies/probe.py` | Drop `compile_read_filter` (moves to `table_policies.py`); drop `make_seed_admin_bypass` (moves to `table_policies.py`). Keep `evaluate_action`, `is_subscribe_authorized`, `_is_purely_user_dependent`. |
+| `api/shared/policies/subscription.py` | Replace `TablePolicies` → `PolicyDocument`. Accept `Resolver`. |
+| `api/shared/policies/functions.py` | No code change. Confirm domain-agnostic. |
+| `api/src/models/contracts/policies.py` | Becomes a thin re-export shim for backward-compat: `from shared.policies.ast import Expr, Policy, PolicyDocument as TablePolicies`. Keep `PolicyValidationError`/`PolicyValidationResponse` (response models — not engine code). |
+| `api/src/routers/tables.py` | Import `compile_read_filter`, `evaluate_action` from `shared.table_policies` (action-OR over rules) and pass `RowResolver()` / `TableBinding()` into engine helpers. |
+| `api/src/routers/websocket.py` | Pass `RowResolver()` into `decide_visibility_change` and `is_subscribe_authorized`. |
+| `api/src/routers/cli.py`, `api/src/services/manifest_import.py`, `api/src/services/mcp_server/tools/tables.py`, `api/src/routers/export_import.py` | `make_seed_admin_bypass` import moves to `shared.table_policies`. |
+| `api/tests/unit/policies/test_evaluate.py` | Adapt to new `Resolver`-based signature. |
+| `api/tests/unit/policies/test_compile.py` | Adapt to new `Binding`-based signature; pass `TableBinding()`. |
+| `api/tests/unit/policies/test_probe.py` | `make_seed_admin_bypass` import moves; `compile_read_filter` import moves. |
+| `api/tests/unit/policies/test_subscription_logic.py` | Pass `RowResolver()`. |
+| `api/tests/unit/policies/test_round_trip.py` | Pass `RowResolver()` + `TableBinding()`. |
+| `api/tests/unit/test_admin_bypass_seed_migration.py` | `make_seed_admin_bypass` import moves. |
+
+### Public API contract (after refactor)
+
+```python
+# api/shared/policies/ast.py
+class Expr(RootModel[dict]): ...
+class Policy(BaseModel):
+    name: str
+    description: str | None
+    actions: list[str]  # generic; domains re-type via Literal
+    when: Expr | None
+class PolicyDocument(BaseModel):
+    policies: list[Policy]
+
+# api/shared/policies/resolver.py
+class Resolver(Protocol):
+    namespace: ClassVar[str]  # "row" | "file" | ...
+    def resolve(self, path: str, ctx: Any) -> Any: ...
+
+# api/shared/policies/binding.py
+class Binding(Protocol):
+    namespace: ClassVar[str]
+    def resolve_reference(self, path: str) -> ColumnElement[Any]: ...
+
+# api/shared/policies/evaluate.py
+def evaluate(expr: Expr, ctx: Any, user: Any, resolver: Resolver) -> bool: ...
+
+# api/shared/policies/compile.py
+def compile_to_sql(expr: Expr, user: Any, binding: Binding) -> ColumnElement[Any]: ...
+
+# api/shared/policies/probe.py
+def evaluate_action(action: str, policies: PolicyDocument, ctx: Any, user: Any, resolver: Resolver) -> bool: ...
+def is_subscribe_authorized(policies: PolicyDocument, user: Any, resolver: Resolver) -> bool: ...
+
+# api/shared/policies/subscription.py
+def decide_visibility_change(
+    old_ctx: dict | None,
+    new_ctx: dict | None,
+    policies: PolicyDocument,
+    user: Any,
+    resolver: Resolver,
+    user_filter: Expr | None = None,
+) -> tuple[Action, dict | str | None] | None: ...
+
+# api/shared/table_policies.py
+class RowResolver:
+    namespace = "row"
+    def resolve(self, path: str, ctx: dict | None) -> Any: ...
+class TableBinding:
+    namespace = "row"
+    def resolve_reference(self, path: str) -> ColumnElement[Any]: ...
+def compile_read_filter(policies: PolicyDocument, user: Any) -> ColumnElement[Any] | None: ...
+def make_seed_admin_bypass() -> dict: ...
+TablePolicies = PolicyDocument  # re-export
+```
+
+---
+
+## Task 1: Boot test stack and confirm baseline
+
+**Files:** None (verification step)
+
+- [ ] **Step 1: Boot test stack**
+
+Run: `./test.sh stack up`
+Expected: Stack boots; no errors.
+
+- [ ] **Step 2: Run existing policies tests; confirm baseline green**
+
+Run: `./test.sh tests/unit/policies/ -v`
+Expected: All tests pass. If any fail, stop and investigate before refactoring.
+
+- [ ] **Step 3: Capture baseline test count**
+
+Run: `./test.sh tests/unit/policies/ --collect-only -q | tail -5`
+Expected: A number like "47 tests collected". Record this number — every refactor task must end with the same count (or more) passing.
+
+---
+
+## Task 2: Create `Resolver` and `Binding` protocols
+
+**Files:**
+- Create: `api/shared/policies/resolver.py`
+- Create: `api/shared/policies/binding.py`
+
+- [ ] **Step 1: Write the failing test for protocol shape**
+
+Create: `api/tests/unit/policies/test_engine_protocols.py`
+
+```python
+"""Engine-only tests proving the engine is domain-agnostic.
+
+These tests use a stub Resolver/Binding rather than table-specific ones,
+proving the walker code does not reach into any domain.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from shared.policies.binding import Binding
+from shared.policies.resolver import Resolver
+
+
+class StubResolver:
+    namespace: ClassVar[str] = "row"
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        return (ctx or {}).get(path)
+
+
+def test_resolver_protocol_runtime_check():
+    """StubResolver structurally satisfies the Resolver protocol."""
+    r: Resolver = StubResolver()
+    assert r.namespace == "row"
+    assert r.resolve("name", {"name": "alice"}) == "alice"
+    assert r.resolve("missing", {}) is None
+    assert r.resolve("name", None) is None
+
+
+def test_binding_protocol_exists():
+    """Binding protocol importable and has required attributes."""
+    assert hasattr(Binding, "namespace")
+    assert hasattr(Binding, "resolve_reference")
+```
+
+- [ ] **Step 2: Run test to verify it fails (import error)**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py -v`
+Expected: FAIL — `ModuleNotFoundError: shared.policies.resolver` (or `.binding`).
+
+- [ ] **Step 3: Write the protocol modules**
+
+Create: `api/shared/policies/resolver.py`
+
+```python
+"""Resolver protocol — domain-agnostic reference resolution at evaluate time.
+
+Each domain (tables, files, ...) implements a Resolver that knows how to look
+up `{<namespace>: path}` references against its context shape. The evaluator
+walker treats Resolver opaquely; the namespace string is the only piece of
+domain knowledge the walker carries.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Resolver(Protocol):
+    """Resolves `{<namespace>: path}` references against a domain context."""
+
+    namespace: ClassVar[str]
+    """The reference namespace key this resolver handles. E.g. "row" for tables,
+    "file" for files. The walker compares against `set(node.keys()) == {namespace}`.
+    """
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        """Resolve a dot-path against the domain ctx. Missing returns None."""
+        ...
+```
+
+Create: `api/shared/policies/binding.py`
+
+```python
+"""Binding protocol — domain-agnostic reference resolution at compile time.
+
+Domains with a SQL surface (tables) implement a Binding that maps
+`{<namespace>: path}` references to SQLAlchemy column expressions. Domains
+without a SQL surface (files — list operations are S3 prefix-bound; the
+evaluator filters in Python) do not implement Binding.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol, runtime_checkable
+
+from sqlalchemy.sql import ColumnElement
+
+
+@runtime_checkable
+class Binding(Protocol):
+    """Resolves `{<namespace>: path}` references to SQLAlchemy columns."""
+
+    namespace: ClassVar[str]
+    """Must match the matching Resolver's namespace for the same domain."""
+
+    def resolve_reference(self, path: str) -> ColumnElement[Any]:
+        """Map a dot-path into a SQLAlchemy column expression."""
+        ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py -v`
+Expected: PASS — both tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/shared/policies/resolver.py api/shared/policies/binding.py api/tests/unit/policies/test_engine_protocols.py
+git commit -m "feat(policies): introduce Resolver and Binding protocols
+
+Domain-agnostic seams for the policy engine. Resolver handles
+reference lookup at evaluate time; Binding handles it at compile time.
+Subsequent commits move table-specific code behind these protocols."
+```
+
+---
+
+## Task 3: Extract AST types into `shared/policies/ast.py`
+
+**Files:**
+- Create: `api/shared/policies/ast.py`
+- Modify: `api/src/models/contracts/policies.py` (convert to re-export shim)
+
+The current `api/src/models/contracts/policies.py` holds `Expr`, `Policy`, `TablePolicies`, and the AST validator. We move the engine-relevant types to `shared/policies/ast.py`. The contracts file becomes a backward-compat re-export so call sites don't break in this commit; later tasks migrate imports.
+
+- [ ] **Step 1: Write the failing test for `PolicyDocument`**
+
+Append to: `api/tests/unit/policies/test_engine_protocols.py`
+
+```python
+from shared.policies.ast import (
+    Expr,
+    Policy,
+    PolicyDocument,
+)
+
+
+def test_policy_document_round_trip():
+    """PolicyDocument validates with the action vocab as plain strings."""
+    doc = PolicyDocument.model_validate({
+        "policies": [
+            {
+                "name": "admin",
+                "actions": ["read", "write", "list", "delete"],
+                "when": {"user": "is_platform_admin"},
+            },
+        ],
+    })
+    assert len(doc.policies) == 1
+    assert doc.policies[0].name == "admin"
+    assert doc.policies[0].actions == ["read", "write", "list", "delete"]
+
+
+def test_policy_document_empty():
+    """Empty PolicyDocument is valid (default-deny semantics)."""
+    doc = PolicyDocument()
+    assert doc.policies == []
+
+
+def test_expr_validator_still_works():
+    """AST validator still rejects unknown user fields."""
+    import pytest
+
+    with pytest.raises(ValueError, match="unknown user field"):
+        Expr.model_validate({"user": "not_a_real_field"})
+```
+
+- [ ] **Step 2: Run test to verify it fails (import error)**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py -v`
+Expected: FAIL — `ImportError: shared.policies.ast`.
+
+- [ ] **Step 3: Create `api/shared/policies/ast.py`**
+
+Move the validator and types out of `api/src/models/contracts/policies.py`. The `Action` Literal is widened to `str` here (each domain re-types it).
+
+Create: `api/shared/policies/ast.py`
+
+```python
+"""Pydantic AST types for policy expressions. Domain-agnostic.
+
+The AST validator enforces structural correctness. Reference namespaces
+(`{row: ...}`, `{file: ...}`) are validated by name against
+KNOWN_USER_FIELDS for the user namespace; the entity namespace is
+accepted opaquely — domain-specific allowlists live in the domain's
+Resolver/Binding.
+"""
+from __future__ import annotations
+
+from typing import Any, Final
+
+from pydantic import (
+    BaseModel,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
+
+from shared.policies.functions import FUNCTIONS
+
+KNOWN_USER_FIELDS: Final[frozenset[str]] = frozenset({
+    "user_id",
+    "email",
+    "organization_id",
+    "is_platform_admin",
+    "role_ids",
+    "role_names",
+})
+
+_LOGIC_OPS: Final[frozenset[str]] = frozenset({"and", "or", "not"})
+_COMPARE_OPS: Final[frozenset[str]] = frozenset({"eq", "neq", "lt", "lte", "gt", "gte"})
+_OTHER_OPS: Final[frozenset[str]] = frozenset({"in", "is_null", "call"})
+_ALL_OPS: Final[frozenset[str]] = _LOGIC_OPS | _COMPARE_OPS | _OTHER_OPS
+
+_DEPTH_LIMIT: Final[int] = 64
+
+# Reserved namespaces that are well-known to the AST validator.
+# Domain-specific ones (e.g. "row", "file") are accepted opaquely if they
+# are the only key in a node — the domain's Resolver enforces field validity.
+_RESERVED_TOP_KEYS: Final[frozenset[str]] = frozenset({"user", "call", "args"}) | _ALL_OPS
+
+
+def _validate_operand(node: Any, depth: int = 0, path: str = "$") -> None:
+    if depth >= _DEPTH_LIMIT:
+        raise ValueError(
+            f"{path}: expression nested too deeply (>{_DEPTH_LIMIT} levels)"
+        )
+    if isinstance(node, (str, int, float, bool)) or node is None:
+        return
+    if isinstance(node, list):
+        for i, item in enumerate(node):
+            _validate_operand(item, depth + 1, f"{path}[{i}]")
+        return
+    if not isinstance(node, dict):
+        raise ValueError(f"{path}: unexpected operand type: {type(node).__name__}")
+
+    keys = set(node.keys())
+    if keys == {"user"}:
+        ref = node["user"]
+        if ref not in KNOWN_USER_FIELDS:
+            raise ValueError(
+                f"{path}: unknown user field {ref!r}; "
+                f"available: {sorted(KNOWN_USER_FIELDS)}"
+            )
+        return
+    if keys == {"call", "args"} or keys == {"call"}:
+        _validate_call(node, depth=depth, path=path)
+        return
+    if len(keys) == 1:
+        op = next(iter(keys))
+        if op in _ALL_OPS:
+            _validate_op_node(op, node[op], depth=depth, path=path)
+            return
+        # Treat as a domain reference: `{ <namespace>: "path.path" }`.
+        # We validate the *shape* here; the Resolver validates the field name.
+        ref = node[op]
+        if not isinstance(ref, str) or not ref:
+            raise ValueError(
+                f"{path}: {op!r} reference must be a non-empty string, got {ref!r}"
+            )
+        return
+    raise ValueError(
+        f"{path}: operator node must have exactly one key, got {sorted(keys)}"
+    )
+
+
+def _validate_op_node(op: str, value: Any, depth: int, path: str) -> None:
+    if op in _LOGIC_OPS - {"not"}:
+        if not isinstance(value, list) or len(value) < 2:
+            raise ValueError(f"{path}.{op}: {op} requires at least two operands")
+        for i, item in enumerate(value):
+            _validate_operand(item, depth + 1, f"{path}.{op}[{i}]")
+        return
+    if op == "not":
+        if isinstance(value, list):
+            raise ValueError(
+                f"{path}.{op}: not requires exactly one operand (not a list)"
+            )
+        _validate_operand(value, depth + 1, f"{path}.{op}")
+        return
+    if op in _COMPARE_OPS:
+        if not isinstance(value, list) or len(value) != 2:
+            raise ValueError(f"{path}.{op}: {op} requires exactly two operands")
+        if op in {"eq", "neq"}:
+            for operand in value:
+                if operand is None:
+                    raise ValueError(
+                        f"{path}.{op}: {op} does not accept null literals "
+                        "(NULL semantics differ between evaluator and SQL "
+                        "pushdown); use is_null instead"
+                    )
+        for i, item in enumerate(value):
+            _validate_operand(item, depth + 1, f"{path}.{op}[{i}]")
+        return
+    if op == "in":
+        if not isinstance(value, list) or len(value) != 2:
+            raise ValueError(f"{path}.{op}: in requires [operand, [literal, ...]]")
+        left, right = value
+        _validate_operand(left, depth + 1, f"{path}.{op}[0]")
+        if not isinstance(right, list) or not right:
+            raise ValueError(
+                f"{path}.{op}: in requires a non-empty literal list as second arg"
+            )
+        for i, item in enumerate(right):
+            if not isinstance(item, (str, int, float, bool)) and item is not None:
+                raise ValueError(
+                    f"{path}.{op}[1][{i}]: in literal list items must be scalars or null"
+                )
+        return
+    if op == "is_null":
+        if isinstance(value, list):
+            raise ValueError(
+                f"{path}.{op}: is_null requires exactly one operand (not a list)"
+            )
+        _validate_operand(value, depth + 1, f"{path}.{op}")
+        return
+
+
+def _validate_call(node: dict, depth: int, path: str) -> None:
+    target = node.get("call")
+    args = node.get("args", [])
+    if not isinstance(target, str):
+        raise ValueError(f"{path}: call target must be a string")
+    if target not in FUNCTIONS:
+        raise ValueError(
+            f"{path}: unknown function {target!r}; available: {sorted(FUNCTIONS)}"
+        )
+    fn = FUNCTIONS[target]
+    if len(args) != len(fn.arg_types):
+        raise ValueError(
+            f"{path}: function {target!r} expects {len(fn.arg_types)} args, "
+            f"got {len(args)}"
+        )
+    for i, (arg, t) in enumerate(zip(args, fn.arg_types)):
+        if isinstance(arg, dict):
+            _validate_operand(arg, depth + 1, f"{path}.args[{i}]")
+            continue
+        if not isinstance(arg, t):
+            raise ValueError(
+                f"{path}.args[{i}]: function {target!r} arg {i} expected "
+                f"{t.__name__}, got {type(arg).__name__}"
+            )
+
+
+class Expr(RootModel[dict]):
+    """Policy expression AST. Validated at construction."""
+
+    @model_validator(mode="after")
+    def _validate(self):
+        _validate_operand(self.root, depth=0, path="$")
+        return self
+
+
+class Policy(BaseModel):
+    """One rule in a policy document. `actions` is a list of strings;
+    each domain re-types via Literal for stricter validation at its
+    routers (e.g. `TablePolicy.actions: list[Literal["read","create",...]]`).
+    """
+
+    name: str = Field(min_length=1, max_length=100)
+    description: str | None = None
+    actions: list[str] = Field(min_length=1)
+    when: Expr | None = None
+
+    @field_validator("actions")
+    @classmethod
+    def _no_dup_actions(cls, v: list[str]) -> list[str]:
+        if len(set(v)) != len(v):
+            raise ValueError("actions must not contain duplicates")
+        return v
+
+
+class PolicyDocument(BaseModel):
+    """Container for a list of rules. Resolution is additive OR per action."""
+
+    policies: list[Policy] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Convert `contracts/policies.py` to a re-export shim**
+
+Modify: `api/src/models/contracts/policies.py`
+
+Replace entire content with:
+
+```python
+"""Backward-compat shim. Use `shared.policies.ast` for engine types.
+
+Tables-specific imports re-exported here. New code should import from
+`shared.table_policies` (TablePolicies alias) or `shared.policies.ast`
+(PolicyDocument).
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from shared.policies.ast import (
+    KNOWN_USER_FIELDS,
+    Expr,
+    Policy,
+    PolicyDocument,
+)
+
+# Table-specific action vocab. File-policies has its own.
+Action = Literal["read", "create", "update", "delete"]
+
+
+# TablePolicies is a tables-typed alias of PolicyDocument. Kept here for the
+# few callers (tests, validate endpoint) that import it from this path.
+TablePolicies = PolicyDocument
+
+
+class PolicyValidationError(BaseModel):
+    """Single structured validation error for a policy document."""
+
+    path: str
+    message: str
+
+
+class PolicyValidationResponse(BaseModel):
+    """Outcome of a POST /api/tables/policies/validate call."""
+
+    ok: bool
+    errors: list[PolicyValidationError] = Field(default_factory=list)
+
+
+__all__ = [
+    "KNOWN_USER_FIELDS",
+    "Action",
+    "Expr",
+    "Policy",
+    "PolicyDocument",
+    "TablePolicies",
+    "PolicyValidationError",
+    "PolicyValidationResponse",
+]
+```
+
+- [ ] **Step 5: Run the engine-protocols tests**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py -v`
+Expected: PASS — all four tests green.
+
+- [ ] **Step 6: Run the full policies test suite to confirm no regressions**
+
+Run: `./test.sh tests/unit/policies/ -v`
+Expected: PASS — all tests still green (count matches Task 1 baseline).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/shared/policies/ast.py api/src/models/contracts/policies.py api/tests/unit/policies/test_engine_protocols.py
+git commit -m "refactor(policies): extract AST types into shared.policies.ast
+
+Move Expr/Policy/PolicyDocument and the AST validator out of
+src/models/contracts/policies.py and into shared/policies/ast.py.
+The contracts file remains as a re-export shim so existing imports
+keep working; subsequent commits migrate them.
+
+Action is widened to list[str] in the shared Policy class; each
+domain (tables, files) re-types it via Literal at its router boundary."
+```
+
+---
+
+## Task 4: Make `evaluate.py` Resolver-driven
+
+**Files:**
+- Modify: `api/shared/policies/evaluate.py`
+- Modify: `api/tests/unit/policies/test_evaluate.py`
+
+- [ ] **Step 1: Write the failing test for resolver-driven evaluate**
+
+Append to: `api/tests/unit/policies/test_engine_protocols.py`
+
+```python
+from shared.policies.ast import Expr
+from shared.policies.evaluate import evaluate
+
+
+class _U:
+    user_id = "u-1"
+    email = "u@x"
+    organization_id = None
+    is_platform_admin = False
+    role_ids: list = []
+    role_names: list = []
+
+
+def test_evaluate_with_stub_resolver():
+    """Engine evaluates `{row: ...}` references via the Resolver — no domain code in walker."""
+    expr = Expr.model_validate({"eq": [{"row": "owner_id"}, {"user": "user_id"}]})
+    resolver = StubResolver()
+    assert evaluate(expr, ctx={"owner_id": "u-1"}, user=_U(), resolver=resolver) is True
+    assert evaluate(expr, ctx={"owner_id": "u-2"}, user=_U(), resolver=resolver) is False
+
+
+def test_evaluate_with_alternate_namespace():
+    """A different-namespace resolver handles its own references."""
+
+    class FileResolverStub:
+        namespace = "file"
+
+        def resolve(self, path: str, ctx: Any) -> Any:
+            return (ctx or {}).get(path)
+
+    expr = Expr.model_validate({"eq": [{"file": "created_by"}, {"user": "user_id"}]})
+    resolver = FileResolverStub()
+    assert evaluate(expr, ctx={"created_by": "u-1"}, user=_U(), resolver=resolver) is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py::test_evaluate_with_stub_resolver -v`
+Expected: FAIL — `evaluate()` does not yet accept a `resolver` kwarg.
+
+- [ ] **Step 3: Rewrite `evaluate.py` to be Resolver-driven**
+
+Replace: `api/shared/policies/evaluate.py`
+
+```python
+"""Pure-function policy evaluator. Domain-agnostic.
+
+Reference resolution is delegated to a Resolver. The walker only knows
+about literals, the `{user: ...}` namespace, `{call: ...}`, operators,
+and "everything else is a domain reference handled by the Resolver".
+"""
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from shared.policies.ast import Expr
+from shared.policies.functions import FUNCTIONS
+from shared.policies.resolver import Resolver
+
+
+def evaluate(expr: Expr, ctx: Any, user: Any, resolver: Resolver) -> bool:
+    """Evaluate an expression against a domain ctx + user, return bool."""
+    return bool(_eval_node(expr.root, ctx, user, resolver))
+
+
+def _eval_node(node: Any, ctx: Any, user: Any, resolver: Resolver) -> Any:
+    if isinstance(node, (str, int, float, bool)) or node is None:
+        return node
+    if isinstance(node, list):
+        return [_eval_node(item, ctx, user, resolver) for item in node]
+
+    if isinstance(node, dict):
+        keys = set(node.keys())
+        if keys == {"user"}:
+            return _resolve_user_field(user, node["user"])
+        if keys == {resolver.namespace}:
+            return resolver.resolve(node[resolver.namespace], ctx)
+        if "call" in keys:
+            return _eval_call(node, ctx, user, resolver)
+        if len(keys) == 1:
+            op = next(iter(keys))
+            return _eval_op(op, node[op], ctx, user, resolver)
+
+    raise ValueError(f"unevaluatable node: {node!r}")
+
+
+def _resolve_user_field(user: Any, field: str) -> Any:
+    val = getattr(user, field, None)
+    if isinstance(val, UUID):
+        return str(val)
+    if isinstance(val, list):
+        return [str(v) if isinstance(v, UUID) else v for v in val]
+    return val
+
+
+def _eval_call(node: dict, ctx: Any, user: Any, resolver: Resolver) -> bool:
+    target = node["call"]
+    args = [_eval_node(a, ctx, user, resolver) for a in node.get("args", [])]
+    fn = FUNCTIONS[target]
+    return fn.evaluate(args, user, ctx if isinstance(ctx, dict) else {})
+
+
+def _eval_op(op: str, value: Any, ctx: Any, user: Any, resolver: Resolver) -> bool:
+    if op == "and":
+        for item in value:
+            if not _eval_node(item, ctx, user, resolver):
+                return False
+        return True
+    if op == "or":
+        for item in value:
+            if _eval_node(item, ctx, user, resolver):
+                return True
+        return False
+    if op == "not":
+        return not _eval_node(value, ctx, user, resolver)
+    if op == "eq":
+        return _scalar_eq(
+            _eval_node(value[0], ctx, user, resolver),
+            _eval_node(value[1], ctx, user, resolver),
+        )
+    if op == "neq":
+        return not _scalar_eq(
+            _eval_node(value[0], ctx, user, resolver),
+            _eval_node(value[1], ctx, user, resolver),
+        )
+    if op in ("lt", "lte", "gt", "gte"):
+        a = _eval_node(value[0], ctx, user, resolver)
+        b = _eval_node(value[1], ctx, user, resolver)
+        if a is None or b is None:
+            return False
+        try:
+            if op == "lt":
+                return a < b
+            if op == "lte":
+                return a <= b
+            if op == "gt":
+                return a > b
+            if op == "gte":
+                return a >= b
+        except TypeError:
+            return False
+    if op == "in":
+        a = _eval_node(value[0], ctx, user, resolver)
+        if a is None:
+            return False
+        return a in value[1]
+    if op == "is_null":
+        return _eval_node(value, ctx, user, resolver) is None
+    raise ValueError(f"unknown operator {op!r}")
+
+
+def _scalar_eq(a: Any, b: Any) -> bool:
+    if a is None or b is None:
+        return False
+    return a == b
+```
+
+- [ ] **Step 4: Migrate existing `test_evaluate.py` to pass a Resolver**
+
+Modify: `api/tests/unit/policies/test_evaluate.py`
+
+Find every call to `evaluate(expr, row=..., user=...)` and update to `evaluate(expr, ctx=..., user=..., resolver=RowResolver())`. Add at the top:
+
+```python
+from shared.table_policies import RowResolver
+```
+
+Note: `RowResolver` doesn't exist yet — Task 6 creates it. Use a local stub in this file *for now*:
+
+```python
+# At top of test file, before any test:
+class _RowResolverForTest:
+    namespace = "row"
+    def resolve(self, path, ctx):
+        # Mirror the old _resolve_row_path semantics: dot-paths against the dict
+        parts = path.split(".")
+        cur = ctx
+        for p in parts:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(p)
+            if cur is None:
+                return None
+        return cur
+```
+
+Then in every test, the call becomes:
+
+```python
+result = evaluate(expr, ctx=row, user=user, resolver=_RowResolverForTest())
+```
+
+(After Task 6 lands `RowResolver`, Task 7 replaces this stub with the real import.)
+
+- [ ] **Step 5: Run engine-protocols tests**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py -v`
+Expected: PASS — all six tests green.
+
+- [ ] **Step 6: Run test_evaluate.py**
+
+Run: `./test.sh tests/unit/policies/test_evaluate.py -v`
+Expected: PASS — all tests green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/shared/policies/evaluate.py api/tests/unit/policies/test_evaluate.py api/tests/unit/policies/test_engine_protocols.py
+git commit -m "refactor(policies): make evaluate.py Resolver-driven
+
+Reference resolution moves behind the Resolver protocol. The walker no
+longer hardcodes the 'row' namespace. The {user: ...} namespace and
+function dispatch stay in the walker (domain-agnostic). Tests use a
+local _RowResolverForTest stub; a follow-up commit replaces it with
+the real RowResolver from shared.table_policies."
+```
+
+---
+
+## Task 5: Make `compile.py` Binding-driven
+
+**Files:**
+- Modify: `api/shared/policies/compile.py`
+- Modify: `api/tests/unit/policies/test_compile.py`
+
+- [ ] **Step 1: Write the failing test for Binding-driven compile**
+
+Append to: `api/tests/unit/policies/test_engine_protocols.py`
+
+```python
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.sql import ColumnElement
+
+from shared.policies.compile import compile_to_sql
+
+_Base = declarative_base()
+
+
+class _Doc(_Base):
+    __tablename__ = "_test_doc"
+    id = Column(Integer, primary_key=True)
+    owner_id = Column(String)
+
+
+class _StubBinding:
+    namespace = "row"
+
+    def resolve_reference(self, path: str) -> ColumnElement[Any]:
+        col = getattr(_Doc, path, None)
+        if col is None:
+            raise ValueError(f"unknown column: {path}")
+        return col
+
+
+def test_compile_with_stub_binding():
+    """compile_to_sql delegates row-reference resolution to the Binding."""
+    expr = Expr.model_validate({"eq": [{"row": "owner_id"}, {"user": "user_id"}]})
+    sql = compile_to_sql(expr, user=_U(), binding=_StubBinding())
+    # Compile to a string just to assert the right column shows up
+    s = str(sql.compile(compile_kwargs={"literal_binds": True}))
+    assert "owner_id" in s
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py::test_compile_with_stub_binding -v`
+Expected: FAIL — `compile_to_sql` does not yet accept a `binding` kwarg.
+
+- [ ] **Step 3: Rewrite `compile.py` to be Binding-driven**
+
+Replace: `api/shared/policies/compile.py`
+
+```python
+"""SQL compiler for policy expressions. Domain-agnostic.
+
+Reference resolution at compile time is delegated to a Binding. The compiler
+walker knows literals, the `{user: ...}` namespace, `{call: ...}`, and
+operators; everything else under a single-key dict is treated as a domain
+reference and dispatched to the Binding.
+
+User-side facts and function calls are resolved at compile time. The
+resulting SQL contains only parameterized literals against the columns the
+Binding produces.
+"""
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import and_ as sa_and
+from sqlalchemy import false as sa_false
+from sqlalchemy import literal
+from sqlalchemy import not_ as sa_not
+from sqlalchemy import or_ as sa_or
+from sqlalchemy import true as sa_true
+from sqlalchemy.sql import ColumnElement
+
+from shared.policies.ast import Expr
+from shared.policies.binding import Binding
+from shared.policies.functions import FUNCTIONS
+
+
+def compile_to_sql(expr: Expr, user: Any, binding: Binding) -> ColumnElement[Any]:
+    """Compile an Expr to a SQLAlchemy boolean expression for the binding's domain."""
+    return _compile_node(expr.root, user, binding)
+
+
+def _compile_node(node: Any, user: Any, binding: Binding) -> ColumnElement[Any]:
+    if isinstance(node, dict):
+        keys = set(node.keys())
+        if keys == {"user"}:
+            return _resolve_user_to_literal(user, node["user"])
+        if keys == {binding.namespace}:
+            return binding.resolve_reference(node[binding.namespace])
+        if "call" in keys:
+            return _compile_call(node, user)
+        if len(keys) == 1:
+            op = next(iter(keys))
+            return _compile_op(op, node[op], user, binding)
+    if isinstance(node, (str, int, float, bool)) or node is None:
+        return literal(node)
+    raise ValueError(f"unrendable node: {node!r}")
+
+
+def _resolve_user_to_literal(user: Any, field: str) -> ColumnElement[Any]:
+    val = getattr(user, field, None)
+    if isinstance(val, UUID):
+        val = str(val)
+    return literal(val)
+
+
+def _compile_call(node: dict, user: Any) -> ColumnElement[Any]:
+    target = node["call"]
+    args = [_resolve_arg_for_call(a, user) for a in node.get("args", [])]
+    fn = FUNCTIONS[target]
+    result = fn.compile(args, user)
+    return sa_true() if result else sa_false()
+
+
+def _resolve_arg_for_call(arg: Any, user: Any) -> Any:
+    if isinstance(arg, dict):
+        keys = set(arg.keys())
+        if keys == {"user"}:
+            return getattr(user, arg["user"], None)
+        raise ValueError(
+            f"function call args must be literals or {{user: ...}}; "
+            f"got {arg!r} which the SQL compiler cannot resolve"
+        )
+    return arg
+
+
+def _compile_op(op: str, value: Any, user: Any, binding: Binding) -> ColumnElement[Any]:
+    if op == "and":
+        return sa_and(*(_compile_node(item, user, binding) for item in value))
+    if op == "or":
+        return sa_or(*(_compile_node(item, user, binding) for item in value))
+    if op == "not":
+        return sa_not(_compile_node(value, user, binding).self_group())
+    if op == "eq":
+        return _compile_node(value[0], user, binding) == _compile_node(value[1], user, binding)
+    if op == "neq":
+        return _compile_node(value[0], user, binding) != _compile_node(value[1], user, binding)
+    if op == "lt":
+        return _compile_node(value[0], user, binding) < _compile_node(value[1], user, binding)
+    if op == "lte":
+        return _compile_node(value[0], user, binding) <= _compile_node(value[1], user, binding)
+    if op == "gt":
+        return _compile_node(value[0], user, binding) > _compile_node(value[1], user, binding)
+    if op == "gte":
+        return _compile_node(value[0], user, binding) >= _compile_node(value[1], user, binding)
+    if op == "in":
+        left = _compile_node(value[0], user, binding)
+        return left.in_(value[1])
+    if op == "is_null":
+        return _compile_node(value, user, binding).is_(None)
+    raise ValueError(f"unknown operator {op!r}")
+```
+
+- [ ] **Step 4: Migrate `test_compile.py` to pass a Binding**
+
+Modify: `api/tests/unit/policies/test_compile.py`
+
+Add at top:
+
+```python
+from shared.policies.binding import Binding
+from sqlalchemy.sql import ColumnElement
+from src.models.orm.tables import Document
+
+
+# Inline TableBinding so this test doesn't depend on Task 6.
+_COLUMN_MAPPED_ROW_FIELDS = {
+    "id": Document.id,
+    "organization_id": None,
+    "created_by": Document.created_by,
+    "updated_by": Document.updated_by,
+    "created_at": Document.created_at,
+    "updated_at": Document.updated_at,
+    "table_id": Document.table_id,
+}
+
+
+class _TableBindingForTest:
+    namespace = "row"
+
+    def resolve_reference(self, path: str) -> ColumnElement[Any]:
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in _COLUMN_MAPPED_ROW_FIELDS:
+            col = _COLUMN_MAPPED_ROW_FIELDS[parts[0]]
+            if col is not None:
+                return col
+        if len(parts) == 1:
+            return Document.data[parts[0]].astext
+        return Document.data[parts].astext
+```
+
+Replace every `compile_to_sql(expr, user)` call with `compile_to_sql(expr, user, _TableBindingForTest())`.
+
+- [ ] **Step 5: Run engine-protocols tests**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py -v`
+Expected: PASS — all seven tests green.
+
+- [ ] **Step 6: Run test_compile.py**
+
+Run: `./test.sh tests/unit/policies/test_compile.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/shared/policies/compile.py api/tests/unit/policies/test_compile.py api/tests/unit/policies/test_engine_protocols.py
+git commit -m "refactor(policies): make compile.py Binding-driven
+
+compile_to_sql now takes a Binding that knows how to project AST
+references to SQLAlchemy columns. The walker no longer imports
+Document or _COLUMN_MAPPED_ROW_FIELDS. Tests inline a _TableBindingForTest
+locally; a follow-up commit replaces it with the real TableBinding."
+```
+
+---
+
+## Task 6: Create `shared/table_policies.py` with RowResolver, TableBinding, and table-specific helpers
+
+**Files:**
+- Create: `api/shared/table_policies.py`
+- Modify: `api/shared/policies/probe.py` (drop `compile_read_filter` and `make_seed_admin_bypass`)
+- Modify: `api/shared/policies/subscription.py` (drop hardcoded `TablePolicies`, accept Resolver)
+
+- [ ] **Step 1: Write the failing test for `RowResolver` and `TableBinding`**
+
+Create: `api/tests/unit/policies/test_table_policies_binding.py`
+
+```python
+"""Tests for the table-domain bindings to the shared engine."""
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.sql import ColumnElement
+
+from shared.policies.ast import Expr, Policy, PolicyDocument
+from shared.table_policies import (
+    RowResolver,
+    TableBinding,
+    compile_read_filter,
+    make_seed_admin_bypass,
+)
+from src.models.orm.tables import Document
+
+
+class _U:
+    user_id = "u-1"
+    email = "u@x"
+    organization_id = None
+    is_platform_admin = True
+    role_ids: list = []
+    role_names: list = []
+
+
+def test_row_resolver_namespace():
+    assert RowResolver().namespace == "row"
+
+
+def test_row_resolver_dot_path():
+    r = RowResolver()
+    assert r.resolve("a", {"a": 1}) == 1
+    assert r.resolve("a.b", {"a": {"b": 2}}) == 2
+    assert r.resolve("missing", {}) is None
+    assert r.resolve("a.b", None) is None
+
+
+def test_table_binding_column_mapped():
+    b = TableBinding()
+    col = b.resolve_reference("created_by")
+    assert col is Document.created_by
+
+
+def test_table_binding_jsonb_fallback():
+    b = TableBinding()
+    col = b.resolve_reference("data_field")
+    # The JSONB path renders to the documents.data->>'data_field' style;
+    # asserting the column references Document.data is enough.
+    s = str(col)
+    assert "data" in s.lower()
+
+
+def test_make_seed_admin_bypass_uses_table_actions():
+    seed = make_seed_admin_bypass()
+    assert seed["policies"][0]["actions"] == ["read", "create", "update", "delete"]
+
+
+def test_compile_read_filter_returns_none_for_empty():
+    doc = PolicyDocument()
+    assert compile_read_filter(doc, user=_U()) is None
+
+
+def test_compile_read_filter_or_across_rules():
+    doc = PolicyDocument.model_validate({
+        "policies": [
+            {"name": "a", "actions": ["read"], "when": {"user": "is_platform_admin"}},
+            {"name": "b", "actions": ["read"], "when": {"eq": [{"row": "owner_id"}, {"user": "user_id"}]}},
+        ],
+    })
+    sql = compile_read_filter(doc, user=_U())
+    assert sql is not None
+    assert isinstance(sql, ColumnElement)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/policies/test_table_policies_binding.py -v`
+Expected: FAIL — `ModuleNotFoundError: shared.table_policies`.
+
+- [ ] **Step 3: Create `shared/table_policies.py`**
+
+Create: `api/shared/table_policies.py`
+
+```python
+"""Table-domain bindings for the shared policy engine.
+
+This module is the only thing that knows about `Document`, the `_COLUMN_MAPPED_ROW_FIELDS`
+mapping, the table action vocab (`read`, `create`, `update`, `delete`), and the
+seeded admin-bypass shape for tables. The shared engine in `shared/policies/`
+consumes these via the Resolver and Binding protocols.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from sqlalchemy import or_ as sa_or
+from sqlalchemy import true as sa_true
+from sqlalchemy.sql import ColumnElement
+
+from shared.policies.ast import PolicyDocument
+from shared.policies.compile import compile_to_sql
+from src.models.orm.tables import Document
+
+# Re-export so handlers can import the tables-typed name.
+TablePolicies = PolicyDocument
+
+# Column-mapped row references — read from the SQL column, not JSONB.
+_COLUMN_MAPPED_ROW_FIELDS: dict[str, Any] = {
+    "id": Document.id,
+    "organization_id": None,  # documents has no organization_id; comes from join
+    "created_by": Document.created_by,
+    "updated_by": Document.updated_by,
+    "created_at": Document.created_at,
+    "updated_at": Document.updated_at,
+    "table_id": Document.table_id,
+}
+
+# NOTE on `organization_id`: documents are scoped via their parent table.
+# When the compiler is invoked from a query handler, the handler already
+# applies a `Table.organization_id` filter at the join. References to
+# `row.organization_id` in policies fall through to the data JSONB lookup
+# (`data->>'organization_id'`) — apps that need this should denormalize
+# the org id into the row's data JSONB at insert time.
+
+
+class RowResolver:
+    """Resolves `{row: path}` references against a Document row dict."""
+
+    namespace: ClassVar[str] = "row"
+
+    def resolve(self, path: str, ctx: Any) -> Any:
+        parts = path.split(".")
+        cur: Any = ctx
+        for part in parts:
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(part)
+            if cur is None:
+                return None
+        return cur
+
+
+class TableBinding:
+    """Resolves `{row: path}` references to SQLAlchemy columns on Document."""
+
+    namespace: ClassVar[str] = "row"
+
+    def resolve_reference(self, path: str) -> ColumnElement[Any]:
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in _COLUMN_MAPPED_ROW_FIELDS:
+            col = _COLUMN_MAPPED_ROW_FIELDS[parts[0]]
+            if col is not None:
+                return col
+        if len(parts) == 1:
+            return Document.data[parts[0]].astext
+        return Document.data[parts].astext
+
+
+def compile_read_filter(
+    policies: PolicyDocument,
+    user: Any,
+) -> ColumnElement[Any] | None:
+    """Compile the OR of all read-allowing rules into a single WHERE clause.
+
+    Returns None if no policy grants read (the handler must deny). Table-specific
+    because files have no SQL pushdown.
+    """
+    binding = TableBinding()
+    fragments: list[ColumnElement[Any]] = []
+    for policy in policies.policies:
+        if "read" not in policy.actions:
+            continue
+        if policy.when is None:
+            fragments.append(sa_true())
+            continue
+        fragments.append(compile_to_sql(policy.when, user, binding))
+    if not fragments:
+        return None
+    if len(fragments) == 1:
+        return fragments[0]
+    return sa_or(*fragments)
+
+
+def make_seed_admin_bypass() -> dict:
+    """Seeded policy for a freshly-created table. Table-specific action vocab."""
+    return {
+        "policies": [
+            {
+                "name": "admin_bypass",
+                "description": "Platform admins bypass all checks. Edit or delete to enforce stricter audit.",
+                "actions": ["read", "create", "update", "delete"],
+                "when": {"user": "is_platform_admin"},
+            },
+        ],
+    }
+
+
+__all__ = [
+    "RowResolver",
+    "TableBinding",
+    "TablePolicies",
+    "compile_read_filter",
+    "make_seed_admin_bypass",
+]
+```
+
+- [ ] **Step 4: Update `probe.py` — drop the moved functions; update remaining signatures to accept Resolver**
+
+Replace: `api/shared/policies/probe.py`
+
+```python
+"""Action-level policy helpers. Domain-agnostic.
+
+`evaluate_action` and `is_subscribe_authorized` walk the rules in a
+PolicyDocument and dispatch to `evaluate` (which itself dispatches to a
+Resolver). Domain-specific helpers (e.g. `compile_read_filter`,
+`make_seed_admin_bypass`) live in the domain module.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from shared.policies.ast import PolicyDocument
+from shared.policies.evaluate import evaluate
+from shared.policies.resolver import Resolver
+
+
+def evaluate_action(
+    action: str,
+    policies: PolicyDocument,
+    ctx: Any,
+    user: Any,
+    resolver: Resolver,
+) -> bool:
+    """OR across all rules whose `actions` includes `action`. Default deny."""
+    for policy in policies.policies:
+        if action not in policy.actions:
+            continue
+        if policy.when is None:
+            return True
+        if evaluate(policy.when, ctx=ctx, user=user, resolver=resolver):
+            return True
+    return False
+
+
+def is_subscribe_authorized(
+    policies: PolicyDocument,
+    user: Any,
+    resolver: Resolver,
+) -> bool:
+    """Probe: would ANY read message ever reach this user?"""
+    for policy in policies.policies:
+        if "read" not in policy.actions:
+            continue
+        if policy.when is None:
+            return True
+        if _is_purely_user_dependent(policy.when.root, resolver):
+            if evaluate(policy.when, ctx={}, user=user, resolver=resolver):
+                return True
+            continue
+        return True
+    return False
+
+
+def _is_purely_user_dependent(node: Any, resolver: Resolver) -> bool:
+    """True if the expression references only USER fields and literals."""
+    if isinstance(node, (str, int, float, bool)) or node is None:
+        return True
+    if isinstance(node, list):
+        return all(_is_purely_user_dependent(x, resolver) for x in node)
+    if isinstance(node, dict):
+        keys = set(node.keys())
+        if keys == {resolver.namespace}:
+            return False
+        if keys == {"user"}:
+            return True
+        if "call" in keys:
+            return all(_is_purely_user_dependent(a, resolver) for a in node.get("args", []))
+        if len(keys) == 1:
+            return _is_purely_user_dependent(node[next(iter(keys))], resolver)
+    return False
+```
+
+- [ ] **Step 5: Update `subscription.py` to accept Resolver**
+
+Replace: `api/shared/policies/subscription.py`
+
+```python
+"""Per-message visibility decision for subscriptions.
+
+Domain-agnostic. The four-way visibility transition table
+(old_visible × new_visible → emitted action) is the same for any
+domain that ships row-like change events.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from shared.policies.ast import Expr, PolicyDocument
+from shared.policies.evaluate import evaluate
+from shared.policies.probe import evaluate_action
+from shared.policies.resolver import Resolver
+
+Action = Literal["insert", "update", "delete"]
+
+
+def is_row_visible(
+    ctx: dict | None,
+    policies: PolicyDocument,
+    user: Any,
+    resolver: Resolver,
+    user_filter: Expr | None = None,
+) -> bool:
+    """True iff ctx is readable AND passes the user-supplied filter."""
+    if ctx is None:
+        return False
+    if not evaluate_action("read", policies, ctx, user, resolver):
+        return False
+    if user_filter is not None and not evaluate(user_filter, ctx=ctx, user=user, resolver=resolver):
+        return False
+    return True
+
+
+def decide_visibility_change(
+    old_ctx: dict | None,
+    new_ctx: dict | None,
+    policies: PolicyDocument,
+    user: Any,
+    resolver: Resolver,
+    user_filter: Expr | None = None,
+) -> tuple[Action, dict | str | None] | None:
+    """Compute the four-way fanout decision."""
+    old_visible = is_row_visible(old_ctx, policies, user, resolver, user_filter)
+    new_visible = is_row_visible(new_ctx, policies, user, resolver, user_filter)
+
+    if not old_visible and not new_visible:
+        return None
+    if not old_visible and new_visible:
+        return ("insert", new_ctx)
+    if old_visible and not new_visible:
+        return ("delete", (old_ctx or {}).get("id"))
+    return ("update", new_ctx)
+```
+
+- [ ] **Step 6: Run the new table-binding test**
+
+Run: `./test.sh tests/unit/policies/test_table_policies_binding.py -v`
+Expected: PASS — all seven tests green.
+
+- [ ] **Step 7: Run the full policies suite — expect import failures in other tests/handlers (we fix in Tasks 7–9)**
+
+Run: `./test.sh tests/unit/policies/ -v 2>&1 | tail -20`
+Expected: Some import failures in `test_probe.py`, `test_subscription_logic.py`, `test_round_trip.py` — they still call old signatures. Those are addressed in Task 7. Do not commit yet.
+
+- [ ] **Step 8: Migrate `test_probe.py` to new signatures**
+
+Modify: `api/tests/unit/policies/test_probe.py`
+
+Replace the `make_seed_admin_bypass` import line:
+
+```python
+# OLD
+from shared.policies.probe import (
+    evaluate_action,
+    compile_read_filter,
+    is_subscribe_authorized,
+    make_seed_admin_bypass,
+)
+# NEW
+from shared.policies.probe import (
+    evaluate_action,
+    is_subscribe_authorized,
+)
+from shared.table_policies import (
+    RowResolver,
+    compile_read_filter,
+    make_seed_admin_bypass,
+)
+```
+
+Then update every call to pass `resolver=RowResolver()`:
+
+```python
+# OLD
+evaluate_action("read", policies, row, user)
+# NEW
+evaluate_action("read", policies, row, user, resolver=RowResolver())
+
+# OLD
+is_subscribe_authorized(policies, user)
+# NEW
+is_subscribe_authorized(policies, user, resolver=RowResolver())
+```
+
+`compile_read_filter` signature is unchanged from the test's perspective (still `(policies, user)`).
+
+- [ ] **Step 9: Migrate `test_subscription_logic.py`**
+
+Modify: `api/tests/unit/policies/test_subscription_logic.py`
+
+Add import:
+
+```python
+from shared.table_policies import RowResolver
+```
+
+Update every call site:
+
+```python
+# OLD
+decide_visibility_change(old_row, new_row, policies, user)
+# NEW
+decide_visibility_change(old_row, new_row, policies, user, resolver=RowResolver())
+```
+
+If `user_filter=` is supplied, keep it.
+
+- [ ] **Step 10: Migrate `test_round_trip.py`**
+
+Modify: `api/tests/unit/policies/test_round_trip.py`
+
+Add imports:
+
+```python
+from shared.table_policies import RowResolver, TableBinding
+```
+
+Update every call:
+
+```python
+# OLD
+evaluate(expr, row=row, user=user)
+compile_to_sql(expr, user)
+# NEW
+evaluate(expr, ctx=row, user=user, resolver=RowResolver())
+compile_to_sql(expr, user, binding=TableBinding())
+```
+
+- [ ] **Step 11: Migrate `test_evaluate.py` to use the real `RowResolver`**
+
+Modify: `api/tests/unit/policies/test_evaluate.py`
+
+Remove the inline `_RowResolverForTest` class. Replace with:
+
+```python
+from shared.table_policies import RowResolver
+```
+
+Update every test that referenced `_RowResolverForTest()` to use `RowResolver()`.
+
+- [ ] **Step 12: Migrate `test_compile.py` to use the real `TableBinding`**
+
+Modify: `api/tests/unit/policies/test_compile.py`
+
+Remove the inline `_TableBindingForTest`. Replace with:
+
+```python
+from shared.table_policies import TableBinding
+```
+
+Update every call to use `TableBinding()`.
+
+- [ ] **Step 13: Run the full policies suite**
+
+Run: `./test.sh tests/unit/policies/ -v`
+Expected: PASS — test count ≥ baseline from Task 1.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add api/shared/table_policies.py api/shared/policies/probe.py api/shared/policies/subscription.py api/tests/unit/policies/test_table_policies_binding.py api/tests/unit/policies/test_probe.py api/tests/unit/policies/test_subscription_logic.py api/tests/unit/policies/test_round_trip.py api/tests/unit/policies/test_evaluate.py api/tests/unit/policies/test_compile.py
+git commit -m "refactor(policies): extract RowResolver/TableBinding into shared.table_policies
+
+Move table-specific code out of the engine:
+- RowResolver + TableBinding (Protocol implementations)
+- compile_read_filter (SQL-pushdown helper, table-specific)
+- make_seed_admin_bypass (table action vocab)
+
+probe.py drops compile_read_filter and make_seed_admin_bypass and takes
+a Resolver parameter on evaluate_action / is_subscribe_authorized.
+subscription.py takes a Resolver. All policies tests migrate to the
+new signatures and import paths."
+```
+
+---
+
+## Task 7: Migrate `routers/tables.py` to new imports + signatures
+
+**Files:**
+- Modify: `api/src/routers/tables.py`
+
+- [ ] **Step 1: Confirm current call sites**
+
+Run: `grep -n "compile_read_filter\|evaluate_action\|make_seed_admin_bypass" api/src/routers/tables.py`
+Expected output: lines 24, 25, 145, 159, 1130, 1256, 1323, 1334, 1421 (approximately).
+
+- [ ] **Step 2: Rewrite the imports**
+
+Modify: `api/src/routers/tables.py`
+
+Find the import block:
+
+```python
+from shared.policies.probe import (
+    compile_read_filter,
+    evaluate_action,
+    is_subscribe_authorized,
+    make_seed_admin_bypass,
+)
+```
+
+(The actual import lines may include `compile_read_filter`, `make_seed_admin_bypass`, etc. — confirm by reading lines 23–27.)
+
+Replace with:
+
+```python
+from shared.policies.probe import evaluate_action
+from shared.table_policies import (
+    RowResolver,
+    TablePolicies,
+    compile_read_filter,
+    make_seed_admin_bypass,
+)
+```
+
+Also remove `TablePolicies` from the `from src.models.contracts.policies import (...)` block (it's now imported from `shared.table_policies`). Keep `PolicyValidationError` / `PolicyValidationResponse` imports from `contracts/policies` if they appear.
+
+- [ ] **Step 3: Update every call to `evaluate_action`**
+
+Use sed-style search-and-replace, then manually verify. Each call needs `resolver=RowResolver()` appended. Pattern:
+
+```python
+# OLD
+evaluate_action(action, policies, row, user)
+# NEW
+evaluate_action(action, policies, row, user, resolver=RowResolver())
+```
+
+Search:
+
+```bash
+grep -n "evaluate_action" api/src/routers/tables.py
+```
+
+For each line, add `, resolver=RowResolver()` as the last argument.
+
+`compile_read_filter` calls do **not** need to change — the signature `(policies, user)` is unchanged.
+
+- [ ] **Step 4: Run pyright on the file**
+
+Run: `cd api && pyright src/routers/tables.py`
+Expected: 0 errors.
+
+- [ ] **Step 5: Run table E2E tests**
+
+Run: `./test.sh tests/e2e/platform/test_table_policies_rest.py -v`
+Expected: PASS — table behavior unchanged.
+
+- [ ] **Step 6: Run the full table test suite to confirm no regressions**
+
+Run: `./test.sh tests/e2e/platform/ -k "table" -v`
+Expected: PASS — all table-related E2E tests still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/src/routers/tables.py
+git commit -m "refactor(tables): switch router to shared.table_policies imports
+
+Move policy helper imports from shared.policies.probe to
+shared.table_policies. Pass RowResolver() into every evaluate_action
+call site. No behavior change."
+```
+
+---
+
+## Task 8: Migrate `routers/websocket.py` and other `make_seed_admin_bypass` consumers
+
+**Files:**
+- Modify: `api/src/routers/websocket.py`
+- Modify: `api/src/routers/cli.py`
+- Modify: `api/src/services/manifest_import.py`
+- Modify: `api/src/services/mcp_server/tools/tables.py`
+- Modify: `api/src/routers/export_import.py`
+- Modify: `api/tests/unit/test_admin_bypass_seed_migration.py`
+
+- [ ] **Step 1: Migrate websocket.py**
+
+Find the imports and call sites:
+
+```bash
+grep -n "is_subscribe_authorized\|decide_visibility_change\|make_seed_admin_bypass" api/src/routers/websocket.py
+```
+
+Update imports:
+
+```python
+# OLD
+from shared.policies.probe import is_subscribe_authorized
+from shared.policies.subscription import decide_visibility_change
+# NEW
+from shared.policies.probe import is_subscribe_authorized
+from shared.policies.subscription import decide_visibility_change
+from shared.table_policies import RowResolver
+```
+
+Pass `resolver=RowResolver()` to every `is_subscribe_authorized(...)` and `decide_visibility_change(...)` call.
+
+- [ ] **Step 2: Migrate cli.py, manifest_import.py, mcp_server/tools/tables.py, export_import.py**
+
+Each of these currently does `from shared.policies.probe import make_seed_admin_bypass`. Change to:
+
+```python
+from shared.table_policies import make_seed_admin_bypass
+```
+
+Run for each:
+
+```bash
+grep -rn "from shared.policies.probe import make_seed_admin_bypass" api/src/
+```
+
+Update every match.
+
+- [ ] **Step 3: Migrate test_admin_bypass_seed_migration.py**
+
+Modify: `api/tests/unit/test_admin_bypass_seed_migration.py`
+
+```python
+# OLD
+from shared.policies.probe import make_seed_admin_bypass
+# NEW
+from shared.table_policies import make_seed_admin_bypass
+```
+
+Find the `evaluate_action` import:
+
+```python
+# OLD
+from shared.policies.probe import evaluate_action
+# NEW
+from shared.policies.probe import evaluate_action
+from shared.table_policies import RowResolver
+```
+
+Add `, resolver=RowResolver()` to every `evaluate_action(...)` call.
+
+- [ ] **Step 4: Confirm no stragglers**
+
+Run: `grep -rn "from shared.policies.probe import" api/`
+Expected: every remaining match imports only `evaluate_action` and/or `is_subscribe_authorized` (never `make_seed_admin_bypass` or `compile_read_filter`).
+
+- [ ] **Step 5: Pyright + ruff**
+
+Run: `cd api && pyright && ruff check .`
+Expected: 0 errors.
+
+- [ ] **Step 6: Run unit test suite**
+
+Run: `./test.sh unit -v 2>&1 | tail -30`
+Expected: PASS.
+
+- [ ] **Step 7: Run table-related E2E suite**
+
+Run: `./test.sh tests/e2e/platform/ -k "table or websocket" -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/src/routers/websocket.py api/src/routers/cli.py api/src/services/manifest_import.py api/src/services/mcp_server/tools/tables.py api/src/routers/export_import.py api/tests/unit/test_admin_bypass_seed_migration.py
+git commit -m "refactor(policies): migrate remaining make_seed_admin_bypass imports
+
+Every caller now imports make_seed_admin_bypass from shared.table_policies
+(not shared.policies.probe). websocket.py passes RowResolver() into
+is_subscribe_authorized and decide_visibility_change."
+```
+
+---
+
+## Task 9: Verify the engine is genuinely domain-agnostic (proof test)
+
+**Files:**
+- Modify: `api/tests/unit/policies/test_engine_protocols.py`
+
+This task adds an end-to-end proof that the engine never imports table-specific code.
+
+- [ ] **Step 1: Add an import-isolation test**
+
+Append to: `api/tests/unit/policies/test_engine_protocols.py`
+
+```python
+def test_engine_does_not_import_domain_code():
+    """The shared engine modules must not import any table-specific code.
+
+    Static analysis: parse each engine module and assert nothing under
+    `shared.policies.` imports `src.models.orm`, `shared.table_policies`,
+    or any other table-specific surface.
+    """
+    import ast
+    import pathlib
+
+    engine_root = pathlib.Path("/app/shared/policies")
+    forbidden_prefixes = (
+        "src.models.orm",
+        "shared.table_policies",
+        "shared.file_policies",
+    )
+
+    bad: list[str] = []
+    for py in engine_root.rglob("*.py"):
+        tree = ast.parse(py.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if any(node.module.startswith(p) for p in forbidden_prefixes):
+                    bad.append(f"{py.name}: imports {node.module}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if any(alias.name.startswith(p) for p in forbidden_prefixes):
+                        bad.append(f"{py.name}: imports {alias.name}")
+
+    assert not bad, "engine reaches into domain code:\n" + "\n".join(bad)
+```
+
+Note: the path `/app/shared/policies` is the container path (test stack mounts `/app` to `api/`). If running tests outside the stack returns a different path, the test loader (`./test.sh`) handles this — the file is read from the container's filesystem at runtime.
+
+- [ ] **Step 2: Run the proof test**
+
+Run: `./test.sh tests/unit/policies/test_engine_protocols.py::test_engine_does_not_import_domain_code -v`
+Expected: PASS — no forbidden imports.
+
+- [ ] **Step 3: Run the entire policies suite**
+
+Run: `./test.sh tests/unit/policies/ -v`
+Expected: PASS — all tests green, count ≥ Task 1 baseline + new tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/tests/unit/policies/test_engine_protocols.py
+git commit -m "test(policies): assert shared engine has no domain imports
+
+Static-analysis test that walks every module in shared/policies/ and
+fails if any import reaches into src.models.orm, shared.table_policies,
+or shared.file_policies. This prevents future regressions from re-coupling
+the engine to a specific domain."
+```
+
+---
+
+## Task 10: Pre-completion verification + PR
+
+**Files:** None.
+
+- [ ] **Step 1: Type-check the whole API**
+
+Run: `cd api && pyright`
+Expected: 0 errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `cd api && ruff check .`
+Expected: 0 issues.
+
+- [ ] **Step 3: Run the full unit suite**
+
+Run: `./test.sh unit`
+Expected: PASS.
+
+- [ ] **Step 4: Run E2E for tables and websocket**
+
+Run: `./test.sh tests/e2e/platform/ -k "table or policy or websocket" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Frontend type regeneration (sanity)**
+
+The refactor touches no API endpoints or response models, so types should be unchanged.
+
+Run: `./debug.sh status | grep "Status:   UP" || ./debug.sh up`
+Then: `cd client && npm run generate:types`
+Expected: `git diff client/src/lib/v1.d.ts` shows no changes.
+
+- [ ] **Step 6: Open PR**
+
+```bash
+git push -u origin 170-file-policies
+gh pr create --title "refactor(policies): domain-agnostic engine with Resolver/Binding protocols" --body "$(cat <<'EOF'
+## Summary
+
+- Extract `Expr`/`Policy`/`PolicyDocument` into `shared/policies/ast.py`
+- Introduce `Resolver` and `Binding` protocols for domain-agnostic reference resolution
+- Move table-specific code (RowResolver, TableBinding, compile_read_filter, make_seed_admin_bypass) into `shared/table_policies.py`
+- All 8 consumers migrated to new import paths and signatures
+- Add a static-analysis test that fails if engine modules ever re-import domain code
+
+Tables behavior is bit-for-bit unchanged. This is the precondition for
+the file-policies plan (#170) and is independently valuable per the
+file-policies design doc §10.2.
+
+Spec: `docs/superpowers/specs/2026-05-01-file-policies-design.md`
+Plan: `docs/superpowers/plans/2026-05-19-policy-engine-extraction.md`
+
+## Test plan
+
+- [ ] Backend unit tests green (`./test.sh unit`)
+- [ ] Table E2E suite green (`./test.sh tests/e2e/platform/ -k table`)
+- [ ] Websocket E2E suite green (`./test.sh tests/e2e/platform/ -k websocket`)
+- [ ] Pyright + ruff clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes on parallelism for agent teams
+
+This plan is mostly **sequential** — each task depends on the previous one's commits being on disk. If you spin up a team:
+
+- **Tasks 1–6** must execute serially (each task's commit is a precondition for the next).
+- **Tasks 7 and 8** can run in **parallel** once Task 6 is committed — they touch disjoint files and depend only on Task 6's `shared.table_policies` module.
+- **Task 9** depends on Tasks 7+8.
+- **Task 10** depends on Task 9.
+
+A reasonable team split: one agent does Tasks 1–6 serially; two agents fan out on Tasks 7 + 8; then re-converge for Tasks 9 + 10.

--- a/docs/superpowers/specs/2026-05-01-file-policies-design.md
+++ b/docs/superpowers/specs/2026-05-01-file-policies-design.md
@@ -1,0 +1,553 @@
+# File Policies — RLS-style policies for direct file reads/writes from apps
+
+## Status
+
+**Experimental. Spec, awaiting plan.**
+
+Tracked at jackmusick/bifrost#170. Dependent on the in-flight `feat/table-access`
+branch (table policies) and on the merged unified file-path resolution
+(jackmusick/bifrost#155). This is a deliberate parallel to table-policies; many
+sections below mirror or reference
+`docs/superpowers/specs/2026-04-30-table-policies-design.md` on that branch.
+
+This spec is being shipped knowing it represents significant additional
+complexity for the platform. It is the right move because the alternative —
+apps continuing to proxy file reads through workflows — caps what apps can
+practically do (galleries, document viewers, attachment libraries). It is also
+acknowledged as work that may exceed what an OSS project can sustainably
+maintain. The design has explicit fallback positions called out in §10.
+
+## Problem
+
+Apps cannot read or write files directly from the browser. The CLI uses the
+files endpoints under `/api/files/*` but those require `CurrentSuperuser`. To
+display a file in an app, or to upload from the browser, the app currently
+either (a) has the workflow engine proxy the read, adding queue + worker
+round-trips, or (b) goes through the form-upload flow, which is purpose-built
+for that one use case.
+
+Tables faced the same problem and the resolution there was table-policies: a
+JSON-AST policy language with an evaluator (per-row check) and a compiler
+(SQL pushdown). We adopt the same skeleton for files, with a deliberately
+reduced operator set for v1 and a smaller reference resolver.
+
+## Non-goals
+
+- **Reaching parity with table-policies' operator set in v1.** Six AST node
+  types are sufficient to express Everyone / Role / Creator and combinations.
+  Additional operators (`lt`, `gt`, `in`, `is_null`, etc.) are additive — they
+  do not change the data shape and are added when concrete use cases land.
+- **Arbitrary file metadata predicates.** Content-type, size, S3 tags, and
+  custom metadata are out of v1. The `{file: ...}` reference set is small and
+  deliberate. Anything beyond `created_by`, `created_at`, `path`, and
+  `location` requires a sidecar-schema decision and is out of scope.
+- **SQL pushdown.** Tables push predicates into Postgres. Files do not have a
+  SQL surface — list operations are prefix-bound and return everything under
+  the prefix. The evaluator filters per-row in Python after the list. This is
+  acceptable at v1 scale (hundreds to low-thousands of files per folder) and
+  is revisited if a tenant hits list latency.
+- **Cross-prefix queries.** Mirroring the S3 list semantics, policies match
+  on `(location, path)` and lists are prefix-bound. No `WHERE location IN
+  (...)`-style queries.
+- **Migration of legacy unscoped uploads.** PR #155 established that
+  pre-scoped form uploads at `uploads/{form_id}/...` (no scope segment) are
+  unreachable through the resolver. File policies inherit that decision;
+  legacy keys remain accessible only via direct S3 (admin) or via workflows
+  that hit the bucket directly.
+
+## Dependencies
+
+### Hard dependencies
+
+1. **`feat/table-access` (table policies, in-flight).** Provides the policy
+   engine in `api/shared/policies/`: AST models, evaluator, SQL compiler,
+   function registry, probe, and the websocket subscribe path. Provides the
+   admin editor pattern (Monaco JSON + templates + reference panel), the
+   `useTable` hook design we mirror as `useFiles`, the manifest+CLI plumbing,
+   and the role-cache.
+2. **Unified file-path resolution (#155, merged).** Provides `resolve_s3_key`
+   and the `(location, scope, path)` decomposition. File policies operate on
+   the user-meaningful `(location, path)` identity; scope is a structural
+   segment owned by the resolver and **never appears in policy ASTs**.
+
+### Soft dependency: shared engine extraction
+
+When file policies land, we **also** refactor `api/shared/policies/` so the
+engine is domain-agnostic and the table-specific bits move to a separate
+binding. This refactor is a precondition for file policies, not an aside.
+See §6.
+
+## Model
+
+A `FilePolicy` is a row keyed by `(location, path)` plus a list of named
+rules, each with `actions` and `when`:
+
+```yaml
+location: shared
+path: finance
+policies:
+  - name: admin_bypass
+    actions: [read, write, delete, list]
+    when: { user: is_platform_admin }
+
+  - name: finance_writes
+    actions: [read, write, delete, list]
+    when: { call: has_role, args: [finance] }
+
+  - name: own_uploads
+    actions: [read, write, delete]
+    when:
+      eq: [{ file: created_by }, { user: user_id }]
+```
+
+Resolution within a policy is **additive OR**: if any rule allows the action,
+the action is allowed. Default deny.
+
+Resolution across policies on different paths is **longest-prefix wins**:
+when a request comes in for `(location=shared, path=finance/2026-Q1.pdf)`,
+the resolver finds the policy whose `(location, path)` is the longest prefix
+of `shared/finance/2026-Q1.pdf` and evaluates only that policy. There is no
+inheritance or union across policies at different paths.
+
+This matches the SharePoint / Google Drive / filesystem mental model: each
+folder has its own access, and the most-specific folder's rules apply. It is
+strictly simpler than the additive-across-rules model and makes the audit
+question ("why does Alice have this access?") have one answer per request.
+
+### Default deny
+
+A new file location with no policies is workflow-only. Brand-new folders
+inherit the longest-prefix policy from above; if no policy exists at any
+prefix, default deny. The seeded `admin_bypass` rule is a non-removable
+template that ensures admins can always edit.
+
+### Admin bypass
+
+Platform admins (superusers) bypass via a seeded `admin_bypass` rule on
+every policy, identical to the table-policies pattern. Admin bypass is not
+special-cased in the evaluator — it is just rule #1, evaluated like any
+other. This keeps the evaluator pure and makes admin access auditable in
+the rule list.
+
+## Expression model
+
+JSON ASTs. No string DSL, no parser, no injection surface.
+
+### Operators (v1)
+
+Six total. Every operator must have a per-row evaluator form. SQL/storage
+pushdown is **not** required for files (see Non-goals).
+
+| Op | Shape | Semantics |
+|---|---|---|
+| `and` | `{ and: [Expr, ...] }` | Boolean AND, short-circuit |
+| `or` | `{ or: [Expr, ...] }` | Boolean OR, short-circuit |
+| `not` | `{ not: Expr }` | Boolean NOT |
+| `eq` | `{ eq: [a, b] }` | Equality (NULL == NULL is false) |
+| `call` | `{ call: <fn>, args: [...] }` | Function call (allow-listed) |
+| literal | `true \| false \| <string> \| <number> \| null` | Literal |
+
+Operands are nested expressions, references (`{file: ...}`, `{user: ...}`),
+or literals. A bare scalar in an operand position is a literal.
+
+### Forward compatibility
+
+Adding `neq`, `lt`, `lte`, `gt`, `gte`, `in`, `is_null` is purely additive —
+the AST shape does not change, only the set of recognized node types. We
+add these on demand. The first request from a real use case (e.g., "files
+where `created_at > ?` for retention") motivates `gt`. Until then, six
+node types is enough.
+
+### `{user: ...}` references
+
+Identical to table-policies. Resolves against the calling user's principal.
+
+| Field | Type | Source |
+|---|---|---|
+| `user.user_id` | UUID | `ctx.user.user_id` |
+| `user.email` | string | `ctx.user.email` |
+| `user.organization_id` | UUID \| null | `ctx.user.organization_id` |
+| `user.is_platform_admin` | bool | `ctx.user.is_superuser` |
+| `user.role_ids` | list[UUID] | `ctx.user.roles` |
+| `user.role_names` | list[str] | derived once per request |
+
+### `{file: ...}` references
+
+Deliberately small. Resolves against the file's metadata (sidecar) and the
+user-meaningful `(location, path)`.
+
+| Field | Type | Source |
+|---|---|---|
+| `file.created_by` | UUID \| null | `file_index` sidecar |
+| `file.created_at` | ISO datetime | `file_index` sidecar |
+| `file.path` | string | the user-meaningful path (no scope segment) |
+| `file.location` | string | the location component |
+
+### Functions
+
+Identical to table-policies. v1 = `has_role`. Function calls are restricted
+to the registered allow-list. The registry is shared between tables and
+files (see §6).
+
+## Storage
+
+### `FilePolicy` ORM table
+
+```
+file_policies
+├── id              UUID  PK
+├── organization_id UUID  NULL  FK organizations.id   -- null = global policy
+├── location        TEXT  NOT NULL
+├── path            TEXT  NOT NULL                    -- user-meaningful, no scope
+├── policies        JSONB NOT NULL                    -- list of rules
+├── created_by      UUID  NOT NULL  FK users.id
+├── created_at      TIMESTAMPTZ
+└── updated_at      TIMESTAMPTZ
+
+UNIQUE INDEX ON (organization_id, location, path)
+```
+
+`policies` is a strict-shape JSONB list of rules:
+
+```json
+[
+  {"name": "admin_bypass", "actions": ["read", "write", "delete", "list"], "when": {"user": "is_platform_admin"}},
+  {"name": "finance_writes", "actions": ["read", "write", "delete", "list"], "when": {"call": "has_role", "args": ["finance"]}}
+]
+```
+
+Validated on write by a Pydantic model (`FilePolicyDocument`).
+
+### `file_index` sidecar (extension)
+
+The existing `file_index` table is extended (or a sibling table is added —
+decided in plan-writing) to track:
+
+- `created_by` (UUID, the user that wrote the file)
+- `created_at` (TIMESTAMPTZ)
+- `(location, scope, path)` decomposition
+
+Every write path that lands a file in S3 must populate this row:
+
+- Form uploads (`api/src/routers/forms.py`)
+- SDK uploads (`bifrost.files.write`, `bifrost.files.write_bytes`)
+- Workflow writes (`sdk.files.write`)
+- Direct admin writes via the file browser
+
+The sidecar is the source of truth for `{file: ...}` references and for
+list filtering. Without it, Creator-scope policies cannot list-filter
+correctly. The plan must enumerate every write path and confirm the
+sidecar is populated.
+
+### Migration
+
+One Alembic migration creates `file_policies`. Sidecar extensions to
+`file_index` are a separate migration in the same change. No backfill of
+existing files (we do not retroactively guess `created_by`); existing files
+without a sidecar row are accessible only to admins until they are
+re-written.
+
+## Engine: shared with tables
+
+`api/shared/policies/` is refactored to make the engine domain-agnostic.
+Per-domain bindings move to separate modules.
+
+### Target layout
+
+```
+api/shared/policies/
+├── ast.py              # Pydantic AST models. Shared.
+├── evaluate.py         # Generic walker. Takes a Resolver. Shared.
+├── compile.py          # Generic predicate compiler. Takes a Binding. Shared.
+├── functions.py        # has_role, has_permission, ... — domain-agnostic. Shared.
+├── probe.py            # Static analysis (extracted referenced fields). Shared.
+└── subscription.py     # Websocket subscribe filtering. Shared at the AST level.
+
+api/shared/table_policies.py   # RowResolver + JSONB binding for tables.
+api/shared/file_policies.py    # FileResolver + (file_index) binding for files.
+```
+
+### What is genuinely shared
+
+- **AST node models.** `Expr`, `And`, `Or`, `Not`, `Eq`, `Call`, references,
+  literals. Same Pydantic types. Tables and files use the same parser.
+- **Evaluator skeleton.** The walker is a pure function over the AST that
+  delegates `{row: ...}` / `{file: ...}` to a `Resolver` interface. Two
+  resolvers (`RowResolver`, `FileResolver`); one walker.
+- **Compiler skeleton.** The walker emits predicates against a `Binding`
+  that knows how to project AST references onto the underlying storage.
+  Two bindings (Postgres rows + JSONB for tables; `file_index` rows for
+  files); one walker.
+- **Function registry.** `has_role` lives in `functions.py`. New functions
+  default to the shared registry unless they are inherently domain-specific
+  (e.g., `path_starts_with` for files; not in v1).
+
+### What stays per-domain
+
+- The resolver (how `{row: ...}` or `{file: ...}` references are resolved
+  to values).
+- The binding (how references project onto the underlying storage for
+  query rewriting).
+- The wiring into the REST handlers, the SDK adapters, and the websocket
+  subscribe path.
+
+### Sequencing
+
+The shared-engine refactor lands as the first task of this work, *after*
+table-policies merges. The diff is mostly mechanical: move table-specific
+resolver code out of `evaluate.py` behind an interface; same for compiler.
+Both engines (table and file) consume the refactored core thereafter.
+
+## REST surface
+
+The existing `/api/files/*` endpoints (today gated by `CurrentSuperuser`)
+relax to `Context`. The handler resolves the `(location, path)`, looks up
+the longest-prefix `FilePolicy`, hydrates the caller principal, and runs
+the evaluator.
+
+Endpoint-by-endpoint:
+
+| Endpoint | Action | Notes |
+|---|---|---|
+| `POST /api/files/read` | `read` | Per-file check |
+| `POST /api/files/write` | `write` | Sidecar row written or updated |
+| `POST /api/files/delete` | `delete` | Sidecar row deleted |
+| `POST /api/files/list` | `list` | Filter results by per-row `read` check |
+| `POST /api/files/exists` | `read` | Existence-non-leak: 403 for both deny and not-found |
+| `POST /api/files/signed-url` | `read` (GET) / `write` (PUT) | Single signing |
+| `POST /api/files/signed-urls` (NEW) | `read` / `write` | Batch signing |
+
+The batch signed-URL endpoint is new and is the immediate unblocker for
+gallery use cases. It accepts `paths: list[str]` and returns
+`[{path, url, expires_in}]` for allowed paths and `[{path, error}]` for
+denied paths. One auth check, N HMACs.
+
+## Web SDK
+
+`client/src/lib/app-sdk/files.ts`. Mirrors the Python files SDK:
+
+```ts
+files.read(path)
+files.write(path, content)
+files.delete(path)
+files.list(prefix)
+files.exists(path)
+files.signedUrl(path, method?)
+files.signedUrls(paths, method?)
+files.upload(path, blob)        // signed-PUT helper for browser file inputs
+files.download(path)            // signed-GET helper
+```
+
+Plus a `useFiles(prefix)` hook (mirroring `useTable`) that returns a live
+listing — backed by REST list + websocket invalidation events when files
+land/move/delete in the prefix.
+
+## CLI / MCP / Manifest
+
+Per CLAUDE.md "Keeping CLI, MCP, and manifest in sync":
+
+- **CLI** (`bifrost files policies ...`): `set`, `get`, `list`, `delete`.
+  Set takes a JSON file or `--policies <inline-json>`. The exact surface is
+  decided in plan-writing.
+- **MCP**: `api/src/services/mcp_server/tools/files.py` follows the
+  thin-HTTP-wrapper rule for any new tools (per `_http_bridge.py`). Existing
+  files MCP tools, if any divergent ones exist, are reconciled separately
+  per `docs/plans/2026-04-18-mcp-router-reconciliation.md`.
+- **Manifest** (`api/bifrost/manifest.py`, `manifest_generator.py`,
+  `github_sync.py`): a new `ManifestFilePolicy` is added, with role-name
+  rewriting on portable export to match the table-policies pattern. Per-org
+  policies are scrubbed on portable export; global policies (with
+  `organization_id IS NULL`) round-trip unchanged.
+- **DTO parity** (`api/bifrost/dto_flags.py`): the new `FilePolicyCreate` /
+  `FilePolicyUpdate` DTOs are exposed via CLI; UI-only fields go in
+  `DTO_EXCLUDES` with a comment.
+
+## Frontend admin surfaces
+
+Three new surfaces. All three share a tree-view component family.
+
+### File browser
+
+Tree of `(location, path)` rooted at each location. Scope segment is hidden
+by default — what the author sees is `shared/finance/2026-Q1.pdf`, not
+`shared/<scope>/finance/2026-Q1.pdf`. An admin-mode toggle ("Show raw
+scopes") exposes the full S3 key for incident response.
+
+Right-click on a folder → menu with **Manage rules**, **Rename**,
+**Delete**, **Test access here…**. Right-click on a file → **Open**,
+**Download**, **Copy signed URL**, **Test access here…**, **Delete**.
+
+The OrgSelect at the top scopes the tree (single-org default). Admin-mode
+"Show raw scopes" turns OrgSelect into a filter and shows all scope
+segments inline.
+
+### Rule editor
+
+Same Monaco-JSON editor + templates + reference panel as table-policies.
+The reference panel shows the v1 `{file: ...}` and `{user: ...}` field
+sets. Templates seed common cases:
+
+- "Everyone reads, role X writes"
+- "Only the file's creator"
+- "Admin bypass" (always present, non-removable on first save)
+
+### Effective access tester
+
+The safety-net surface. Picks a user (or synthesizes a hypothetical user
+with extra roles), picks a path, picks an action. Calls a backend endpoint
+that runs the **real** evaluator and returns the resolution trail:
+
+- which policy matched (longest-prefix lookup result)
+- which rule fired (or "no rule allowed")
+- the AST evaluation trace (what each `eq` / `call` resolved to)
+- the resolved S3 key (for sanity-checking scope substitution)
+
+The hypothetical-user feature ("test as Alice + Role Y, even though Alice
+doesn't have Role Y") is the most valuable bit — it lets authors verify a
+new rule before granting anyone the role.
+
+Available from two entry points: a button in the file browser ("Test
+access here…", with the path pre-filled), and a standalone page under
+Settings → Files → Access (no path pre-fill, for support cases).
+
+### Renames as a UI primitive
+
+S3 doesn't rename — it copies and deletes. A folder rename in the UI is a
+single user action that does:
+
+1. Rewrites every key under the old prefix to the new prefix (S3 copy +
+   delete; per-key, with progress feedback).
+2. Updates `file_index` sidecar rows for those keys.
+3. Updates every `FilePolicy` row whose `(location, path)` falls under the
+   renamed prefix.
+
+The rename dialog surfaces the secondary effect: "this will move 47 files
+and update 3 policies." Confirmation does all three. Without this, every
+folder rename silently breaks access.
+
+The DB-side rule update is one transaction. The S3-side copy is best-effort
+(S3 isn't transactional); rules update first, so the worst-case interleaving
+is "rules point at the new path before the files have finished copying" —
+which means the new prefix is briefly empty, never that access is mismatched.
+
+## Subscriptions
+
+The websocket subscribe path is mirrored from table-policies. A new
+channel kind:
+
+- **Channel name:** `files:{location}:{path}` (per-prefix, with the user-
+  meaningful path).
+- **Subscribe handshake:** runs the evaluator with `action=list` against
+  the subscribing user. Reject if denied.
+- **Server-side fanout:** every write path (`files.write`, signed-PUT
+  completion, form uploads, deletes, renames) calls a
+  `publish_file_change(location, path, action, file_meta)` helper that
+  broadcasts to all subscribed prefixes.
+- **Per-recipient filtering:** for subscribers whose effective `read` is
+  Creator-only, the per-connection send-path drops events whose
+  `created_by != subscriber.user_id`. Same machinery as table-policies'
+  Creator filter.
+- **Invalidation on policy changes:** `publish_file_policy_changed` fires
+  when a `FilePolicy` row changes; subscribed clients recompute. Revoked
+  read = subscription closed with `subscription_revoked`.
+- **Reconnect semantics:** no replay. Same as table subscriptions.
+
+## Testing
+
+Mirrors the table-policies coverage shape.
+
+**Backend unit:**
+- `tests/unit/test_file_policies_evaluator.py` — every operator × every
+  reference; default-deny; admin-bypass; longest-prefix match.
+- `tests/unit/test_file_policies_resolver.py` — `{file: ...}` resolution
+  against synthetic sidecar rows.
+- `tests/unit/test_manifest.py` — `ManifestFilePolicy` round-trip with
+  role-name rewriting.
+- `tests/unit/test_dto_flags.py` — DTO parity for new file-policy DTOs.
+- `tests/unit/test_pubsub_file_changes.py` — `publish_file_change` envelope
+  shape; `publish_file_policy_changed` invalidation.
+
+**Backend e2e:**
+- `tests/e2e/platform/test_file_policies_rest.py` — REST matrix: 3 users
+  (admin, role-holder, plain) × 4 actions × representative policy configs.
+  Asserts 200/403 + the Creator-filter case on list (Bob sees only his
+  files).
+- `tests/e2e/platform/test_files.py` — updated to assert default-deny: a
+  non-superuser hitting a file with no governing policy gets 403.
+- `tests/e2e/platform/test_file_subscriptions.py` — websocket flow:
+  subscribe accepted/rejected, receive write/delete events, Creator-only
+  filtering, access revocation.
+- `tests/e2e/platform/test_file_signed_urls_batch.py` — batch signing
+  with mixed allowed/denied paths.
+
+**Client unit (vitest):**
+- `client/src/lib/app-sdk/files.test.ts` — every method in the web SDK,
+  shape parity with the Python SDK.
+- `client/src/lib/app-sdk/use-files.test.tsx` — happy path, reconnect,
+  cleanup, access-denied, `subscription_revoked`.
+- `client/src/components/files/FilePolicyEditor.test.tsx` — Monaco editor
+  + templates + reference panel.
+- `client/src/components/files/EffectiveAccessTester.test.tsx` —
+  user/path/action picker + resolution trail rendering.
+- `client/src/components/files/FileBrowser.test.tsx` — tree view, scope
+  hiding, right-click menu.
+
+**Client e2e (Playwright):**
+- `client/e2e/files-app-direct.spec.ts` — embedded test app uses the web
+  SDK to upload + read a file via signed URLs; assert no workflow
+  execution is created.
+- `client/e2e/files-rename.spec.ts` — rename a folder in the admin UI;
+  assert files moved, sidecar updated, policy updated, dialog warned.
+- `client/e2e/files-effective-access.spec.ts` — open the tester, pick a
+  user + path, see the resolution trail.
+
+## Rollout
+
+1. Shared-engine refactor lands first. Table-policies and (eventually)
+   file-policies both consume the refactored core.
+2. `FilePolicy` schema migration + sidecar extension migration.
+3. REST endpoints relax from `CurrentSuperuser` to `Context`. Default deny
+   means yesterday's non-superuser callers still cannot call these
+   endpoints today — only the error code changes (401 → 403 in some paths)
+   plus the opportunity to opt in.
+4. Web SDK ships with the batch signed-URL endpoint as the primary
+   unblocker.
+5. Admin UI ships: file browser → rule editor → effective-access tester.
+6. Apps that want direct file access opt their files in per-folder.
+7. Subscriptions ship after the REST + SDK + UI surfaces are stable.
+
+No flag day. No data migration of existing files (we do not retroactively
+populate `created_by`; existing files are admin-only until rewritten).
+
+## Open questions for plan-writing
+
+1. **Sidecar table structure.** Extend `file_index` or add a sibling
+   table? The existing `file_index` is search-focused and has different
+   write semantics; sidecar metadata may want its own table.
+2. **Rename progress feedback.** S3 prefix copy is per-key; for large
+   folders this can take seconds-to-minutes. Streaming progress to the
+   browser vs. background job + notification — UX call.
+3. **CLI ergonomics.** Inline JSON vs. file-based vs. flag-style for
+   policy edits. Same question table-policies answered; we pick the same
+   answer.
+4. **Hypothetical-user UX in the tester.** "Test as Alice + Role Y" needs
+   to be obvious without making it look like Alice has Role Y in reality.
+
+## Fallback positions (if the work outgrows us)
+
+Called out so we know where to stop if we have to:
+
+1. **Reduced operator set is a viable shipping subset.** If the full
+   policy editor + manifest + websocket plumbing is too much, ship just
+   the v1 operator set with a JSON textarea editor and no live
+   subscriptions. The static-three-scope model (Everyone / Role /
+   Creator) is expressible as a small set of templates inside that
+   subset; a UI that emits only those templates is a third fallback if
+   even Monaco-JSON is too much.
+2. **Shared-engine refactor is independently valuable for tables.** If
+   file policies stall, the engine refactor still cleans up the
+   table-policies code and pays for itself.
+3. **Batch signed-URL endpoint stands alone.** Even without policy
+   evaluation, the batch endpoint solves the gallery use case for
+   admin-only file access — a useful intermediate state if the policy
+   work has to slip.


### PR DESCRIPTION
## Summary

Precondition for file policies (#170). Refactors `api/shared/policies/` into a domain-agnostic engine consumed via `Resolver` and `Binding` protocols, with table-specific code moved into a new `api/shared/table_policies.py`. Tables behavior is bit-for-bit unchanged.

This PR is independently valuable per the file-policies design doc §10.2 (engine refactor pays for itself for tables alone).

## What changed

- **New protocols** (`shared/policies/resolver.py`, `shared/policies/binding.py`) — Resolver handles `{<namespace>: ...}` reference lookup at evaluate time; Binding handles it at compile time.
- **AST extraction** (`shared/policies/ast.py`) — `Expr`, `Policy`, `PolicyDocument`, and the AST validator moved out of `src/models/contracts/policies.py`. The contracts file is now a thin shim that re-exports + defines a tables-narrowed `Policy` to preserve the table action vocab (`read/create/update/delete`).
- **Resolver-driven evaluator** (`shared/policies/evaluate.py`) — `evaluate(expr, ctx, user, resolver)`. No hardcoded `"row"` namespace; the walker dispatches on `resolver.namespace`.
- **Binding-driven compiler** (`shared/policies/compile.py`) — `compile_to_sql(expr, user, binding)`. No `Document` import in the engine.
- **Table bindings** (`shared/table_policies.py`) — new module owning `RowResolver`, `TableBinding`, `compile_read_filter`, `make_seed_admin_bypass`, and `TablePolicies = PolicyDocument`. The only place that imports `src.models.orm.tables.Document` from the policy stack.
- **Domain namespace allowlist** — AST validator accepts `{row: ...}` and `{file: ...}` references opaquely; rejects unknown single-key dicts with a clear error (closes a regression where `{has_role: "support"}` was silently treated as a reference).
- **All consumers migrated** — `routers/tables.py`, `routers/websocket.py`, `routers/cli.py`, `services/manifest_import.py`, `services/mcp_server/tools/tables.py`, `routers/export_import.py`, and `tests/unit/test_admin_bypass_seed_migration.py` use the new import paths and pass `RowResolver()` where required.
- **Engine isolation test** — `tests/unit/policies/test_engine_protocols.py::test_engine_does_not_import_domain_code` statically asserts no module under `shared/policies/` imports `src.models.orm`, `shared.table_policies`, or `shared.file_policies`. A self-check test confirms the scanner actually flags violations.

## Plan + spec

- Spec: \`docs/superpowers/specs/2026-05-01-file-policies-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-19-policy-engine-extraction.md\` (executed task-by-task with two-stage review per the superpowers:subagent-driven-development skill)

## Test plan

- [x] \`./test.sh unit\` — 3848 passed
- [x] \`./test.sh tests/e2e/platform/test_policies.py tests/e2e/platform/test_tables.py\` — 53 passed
- [x] \`./test.sh tests/e2e/api/test_websocket.py\` — 13 passed
- [x] \`pyright\` clean (zero errors from the refactor; only pre-existing missing-deps warnings from running pyright outside the venv)
- [x] \`ruff check .\` clean
- [ ] CI \`./test.sh all\` (running locally in background; will report)

No API endpoints or response models changed, so no client type regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)