### PR TITLE
fix(cli): silence keyring fallback warning on routine calls

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -217,6 +217,10 @@ async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool
 
     api_url = api_url.rstrip("/")
 
+    # Surface keyring fallback here — login is the user's chance to fix it.
+    from bifrost.credentials import warn_if_keyring_fallback
+    warn_if_keyring_fallback()
+
     try:
         async with httpx.AsyncClient(base_url=api_url, timeout=30.0) as client:
             # Step 1: Request device code

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -203,6 +203,10 @@ async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool
 
     api_url = api_url.rstrip("/")
 
+    # Surface keyring fallback here — login is the user's chance to fix it.
+    from bifrost.credentials import warn_if_keyring_fallback
+    warn_if_keyring_fallback()
+
     try:
         async with httpx.AsyncClient(base_url=api_url, timeout=30.0) as client:
             # Step 1: Request device code

--- a/api/bifrost/credentials.py
+++ b/api/bifrost/credentials.py
@@ -243,20 +243,27 @@ class KeyringBackend:
 # Backend selection
 # --------------------------------------------------------------------------- #
 
+_keyring_fallback_reason: str | None = None
+
+
 def _select_persistent_backend() -> Backend:
     """
     Choose the persistent backend.
 
     Order: try `keyring` (probe with a no-op read so headless Linux fails
-    fast at startup), fall back to JSON. On fallback, print a one-time
-    stderr warning so users know why their tokens aren't in the OS keychain.
+    fast at startup), fall back to JSON. On fallback, stash the reason in
+    `_keyring_fallback_reason` so `warn_if_keyring_fallback()` can surface
+    it during interactive flows like `bifrost login`. Routine calls stay
+    silent — every `bifrost files` invocation would otherwise pollute
+    stderr (and tool_result text for MCP/agent callers).
     """
-    import sys
+    global _keyring_fallback_reason
 
     try:
         import keyring
         import keyring.errors
     except ImportError:
+        _keyring_fallback_reason = "keyring package not installed"
         return JsonBackend()
 
     try:
@@ -266,13 +273,27 @@ def _select_persistent_backend() -> Backend:
         keyring.get_password(KEYRING_SERVICE, "__probe__")
         return KeyringBackend(_keyring=keyring)
     except (keyring.errors.NoKeyringError, keyring.errors.KeyringError, Exception) as e:
+        _keyring_fallback_reason = type(e).__name__
+        return JsonBackend()
+
+
+def warn_if_keyring_fallback() -> None:
+    """
+    Print a one-time stderr warning if the persistent backend fell back to
+    JSON. Call this from interactive entry points (e.g. `bifrost login`)
+    where the user is actively configuring credentials and should know
+    their tokens aren't in the OS keychain.
+    """
+    import sys
+
+    get_persistent_backend()  # ensure selection has run
+    if _keyring_fallback_reason is not None:
         print(
-            f"warning: OS keychain unavailable ({type(e).__name__}); "
+            f"warning: OS keychain unavailable ({_keyring_fallback_reason}); "
             "falling back to ~/.bifrost/credentials.json. "
             "Install/enable a keyring service to upgrade.",
             file=sys.stderr,
         )
-        return JsonBackend()
 
 
 _persistent_backend: Backend | None = None
@@ -288,8 +309,9 @@ def get_persistent_backend() -> Backend:
 
 def _reset_persistent_backend_for_tests() -> None:
     """Clear the cached backend so tests can swap it out."""
-    global _persistent_backend
+    global _persistent_backend, _keyring_fallback_reason
     _persistent_backend = None
+    _keyring_fallback_reason = None
 
 
 # --------------------------------------------------------------------------- #

--- a/api/tests/unit/test_credentials.py
+++ b/api/tests/unit/test_credentials.py
@@ -268,7 +268,11 @@ class TestBackendSelection:
         assert isinstance(backend, KeyringBackend)
 
     def test_no_keyring_falls_back_to_json(self, monkeypatch, capsys):
-        from bifrost.credentials import JsonBackend, _select_persistent_backend
+        from bifrost.credentials import (
+            JsonBackend,
+            _select_persistent_backend,
+            warn_if_keyring_fallback,
+        )
         creds_mod._reset_persistent_backend_for_tests()
         import keyring
         import keyring.errors
@@ -281,7 +285,11 @@ class TestBackendSelection:
         monkeypatch.setattr(keyring, "get_password", fake_get_password)
         backend = _select_persistent_backend()
         assert isinstance(backend, JsonBackend)
-        # Stderr warning so users know.
+        # Selection itself is silent — every `bifrost files` call would
+        # otherwise pollute stderr / MCP tool_result text.
+        assert capsys.readouterr().err == ""
+        # Warning surfaces only when explicitly requested (e.g. from login).
+        warn_if_keyring_fallback()
         captured = capsys.readouterr()
         assert "keyring" in captured.err.lower()
         assert "fallback" in captured.err.lower() or "falling back" in captured.err.lower()


### PR DESCRIPTION
## Summary
- `NoKeyringError` warning was firing on every CLI invocation that touched credentials (every `bifrost files` call), polluting stderr and MCP `tool_result` text for workspace builders and agents
- Backend selection now stashes the fallback reason silently; new `warn_if_keyring_fallback()` helper surfaces it on demand
- Wired into both `login_flow`s — login is the user's chance to fix it

## Test plan
- [x] `./test.sh tests/unit/test_credentials.py` (28 pass)
- [x] `./test.sh tests/unit/test_cli_login_ephemeral.py` (18 pass)
- [x] Updated `test_no_keyring_falls_back_to_json` to assert both: selection is silent, warning surfaces only when `warn_if_keyring_fallback()` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)