### PR TITLE
perf(logo): inline entity logos in list response to kill N+1 GETs

### DIFF
--- a/api/src/models/contracts/agents.py
+++ b/api/src/models/contracts/agents.py
@@ -169,6 +169,10 @@ class AgentPublic(BaseModel):
     llm_max_tokens: int | None = None
     max_iterations: int | None = None
     max_token_budget: int | None = None
+    logo: str | None = Field(
+        default=None,
+        description="Inline logo as a data URL, or null when no logo is set.",
+    )
 
     @field_serializer("id")
     def serialize_id(self, v: UUID) -> str:
@@ -201,6 +205,10 @@ class AgentSummary(BaseModel):
     mcp_connection_count: int = Field(
         default=0,
         description="Number of MCP connections explicitly granted to this agent.",
+    )
+    logo: str | None = Field(
+        default=None,
+        description="Inline logo as a data URL, or null when no logo is set. Avoids an N+1 GET per card in list views.",
     )
 
     @field_serializer("id")

--- a/api/src/models/contracts/applications.py
+++ b/api/src/models/contracts/applications.py
@@ -147,6 +147,10 @@ class ApplicationPublic(ApplicationBase):
     repo_path: str = Field(
         description="Workspace-relative path to the app's source directory. Mutated via POST /api/applications/{id}/replace."
     )
+    logo: str | None = Field(
+        default=None,
+        description="Inline logo as a data URL, or null when no logo is set. Avoids an N+1 GET per card in list views.",
+    )
 
     @field_serializer("created_at", "updated_at", "published_at")
     def serialize_dt(self, dt: datetime | None) -> str | None:

--- a/api/src/routers/agents.py
+++ b/api/src/routers/agents.py
@@ -8,6 +8,7 @@ Agents are virtual entities stored only in the database.
 Git sync serializes agents on-the-fly from the database.
 """
 
+import base64
 import logging
 from datetime import datetime, timezone
 from uuid import UUID, uuid4
@@ -189,6 +190,14 @@ async def _user_has_permission(
     return False
 
 
+def _logo_data_url(data: bytes | None, content_type: str | None) -> str | None:
+    """Encode a binary logo as a data URL, or None if no logo is set."""
+    if not data:
+        return None
+    mime = content_type or "application/octet-stream"
+    return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+
+
 def _agent_to_public(agent: Agent) -> AgentPublic:
     """Convert Agent ORM to AgentPublic with relationships."""
     valid_system_tool_ids = set(get_system_tool_ids())
@@ -221,6 +230,7 @@ def _agent_to_public(agent: Agent) -> AgentPublic:
         llm_max_tokens=agent.llm_max_tokens,
         max_iterations=agent.max_iterations,
         max_token_budget=agent.max_token_budget,
+        logo=_logo_data_url(agent.logo_data, agent.logo_content_type),
     )
 
 
@@ -306,6 +316,7 @@ async def list_agents(
         summary = AgentSummary.model_validate(a)
         summary.dependency_count = dep_counts.get(a.id, 0)
         summary.mcp_connection_count = mcp_counts.get(a.id, 0)
+        summary.logo = _logo_data_url(a.logo_data, a.logo_content_type)
         result.append(summary)
 
     return result
@@ -1006,7 +1017,12 @@ async def get_agent_delegations(
             detail=f"Agent {agent_id} not found",
         )
 
-    return [AgentSummary.model_validate(a) for a in agent.delegated_agents]
+    summaries = []
+    for a in agent.delegated_agents:
+        s = AgentSummary.model_validate(a)
+        s.logo = _logo_data_url(a.logo_data, a.logo_content_type)
+        summaries.append(s)
+    return summaries
 
 
 @router.post("/{agent_id}/logo")

--- a/api/src/routers/applications.py
+++ b/api/src/routers/applications.py
@@ -12,6 +12,7 @@ Applications use code-based files (TSX/TypeScript) stored in app_files table.
 File operations are handled through the app_files router.
 """
 
+import base64
 import logging
 import re
 from datetime import datetime, timezone
@@ -616,6 +617,14 @@ export default function RootLayout() {
 # =============================================================================
 
 
+def _logo_data_url(data: bytes | None, content_type: str | None) -> str | None:
+    """Encode a binary logo as a data URL, or None if no logo is set."""
+    if not data:
+        return None
+    mime = content_type or "application/octet-stream"
+    return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+
+
 async def application_to_public(
     application: Application,
     repo: "ApplicationRepository",
@@ -638,6 +647,7 @@ async def application_to_public(
         access_level=application.access_level,
         role_ids=role_ids,
         repo_path=application.repo_path,
+        logo=_logo_data_url(application.logo_data, application.logo_content_type),
     )
 
 

--- a/client/src/components/EntityLogo.test.tsx
+++ b/client/src/components/EntityLogo.test.tsx
@@ -48,6 +48,35 @@ describe("EntityLogo", () => {
 		expect(screen.queryByTestId("entity-logo")).toBeNull();
 	});
 
+	it("renders inline logo (data URL) directly without hitting the per-entity endpoint", () => {
+		const dataUrl = "data:image/svg+xml;base64,PHN2Zy8+";
+		render(
+			<EntityLogo
+				entityType="app"
+				entityId="11111111-1111-1111-1111-111111111111"
+				logo={dataUrl}
+				fallback={<span data-testid="fallback">F</span>}
+				size={32}
+			/>,
+		);
+		const img = screen.getByTestId("entity-logo");
+		expect(img.getAttribute("src")).toBe(dataUrl);
+	});
+
+	it("renders fallback without making any request when logo is explicitly null", () => {
+		render(
+			<EntityLogo
+				entityType="agent"
+				entityId="22222222-2222-2222-2222-222222222222"
+				logo={null}
+				fallback={<span data-testid="fallback">F</span>}
+				size={32}
+			/>,
+		);
+		expect(screen.getByTestId("fallback")).toBeInTheDocument();
+		expect(screen.queryByTestId("entity-logo")).toBeNull();
+	});
+
 	it("appends cacheKey to bust browser cache", () => {
 		render(
 			<EntityLogo

--- a/client/src/components/EntityLogo.tsx
+++ b/client/src/components/EntityLogo.tsx
@@ -8,6 +8,14 @@ export type EntityLogoProps = {
 	size: number;
 	cacheKey?: string;
 	className?: string;
+	/**
+	 * Inline logo (data URL) from the list/detail response. When provided as a
+	 * string, renders directly — no extra GET. When explicitly `null`, renders
+	 * the fallback without hitting the per-entity endpoint. When `undefined`,
+	 * falls back to fetching /api/{type}/{id}/logo (preserves the upload
+	 * dialog's live-preview behavior).
+	 */
+	logo?: string | null;
 };
 
 const PATHS: Record<EntityLogoProps["entityType"], string> = {
@@ -22,14 +30,27 @@ export function EntityLogo({
 	size,
 	cacheKey,
 	className,
+	logo,
 }: EntityLogoProps) {
-	// Track which "version" of the URL we last failed to load. When a new
-	// version is bumped (after upload/delete), this stale marker no longer
-	// matches and we retry — no setState-in-useEffect dance needed.
 	const [erroredVersion, setErroredVersion] = useState<string | null>(null);
-
-	// Global per-entity version bumped by LogoDropZone after upload/delete.
 	const globalVersion = useEntityLogoVersion(entityType, entityId);
+
+	if (logo === null) {
+		return <>{fallback}</>;
+	}
+
+	if (typeof logo === "string") {
+		return (
+			<img
+				data-testid="entity-logo"
+				src={logo}
+				alt=""
+				width={size}
+				height={size}
+				className={className}
+			/>
+		);
+	}
 
 	const base = `${PATHS[entityType]}/${entityId}/logo`;
 	const effectiveKey = cacheKey ?? globalVersion?.toString() ?? null;

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -3472,22 +3472,22 @@ export interface paths {
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        get: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        get: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        put: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        put: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        post: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        post: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        delete: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        delete: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -8638,6 +8638,11 @@ export interface components {
             max_iterations?: number | null;
             /** Max Token Budget */
             max_token_budget?: number | null;
+            /**
+             * Logo
+             * @description Inline logo as a data URL, or null when no logo is set.
+             */
+            logo?: string | null;
         };
         /** AgentRunCreateRequest */
         AgentRunCreateRequest: {
@@ -8965,6 +8970,11 @@ export interface components {
              * @default 0
              */
             mcp_connection_count: number;
+            /**
+             * Logo
+             * @description Inline logo as a data URL, or null when no logo is set. Avoids an N+1 GET per card in list views.
+             */
+            logo?: string | null;
         };
         /**
          * AgentUpdate
@@ -9314,6 +9324,11 @@ export interface components {
              * @description Workspace-relative path to the app's source directory. Mutated via POST /api/applications/{id}/replace.
              */
             repo_path: string;
+            /**
+             * Logo
+             * @description Inline logo as a data URL, or null when no logo is set. Avoids an N+1 GET per card in list views.
+             */
+            logo?: string | null;
         };
         /**
          * ApplicationPublishRequest
@@ -26612,7 +26627,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {
@@ -26645,7 +26660,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {
@@ -26678,7 +26693,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {
@@ -26711,7 +26726,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {

--- a/client/src/pages/Applications.tsx
+++ b/client/src/pages/Applications.tsx
@@ -293,6 +293,7 @@ export function Applications() {
 												<EntityLogo
 													entityType="app"
 													entityId={app.id}
+													logo={app.logo ?? null}
 													fallback={
 														<AppWindow className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
 													}

--- a/client/src/pages/agents/FleetPage.tsx
+++ b/client/src/pages/agents/FleetPage.tsx
@@ -386,6 +386,7 @@ function AgentGridCard({
 						<EntityLogo
 							entityType="agent"
 							entityId={agent.id}
+							logo={agent.logo ?? null}
 							fallback={<Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
 							size={20}
 							className="h-5 w-5 rounded shrink-0 object-cover"


### PR DESCRIPTION
## Summary

- Apps and agents list pages were firing one `GET /api/{type}/{id}/logo` per card (404 when no logo was set), so a 100-card page meant 100+ extra round trips.
- Inline the logo as a base64 data URL on `ApplicationPublic` / `AgentSummary` / `AgentPublic` so list/detail responses carry it directly — zero extra requests.
- `EntityLogo` gains a `logo?: string | null` prop. `string` renders inline; `null` renders the fallback; `undefined` preserves the legacy per-entity GET for the `LogoDropZone` live-preview path.

## Test plan

- [x] Vitest: `EntityLogo` covers inline-string, explicit-null, and legacy-fetch modes (6 tests pass).
- [x] `npm run tsc` + `npm run lint` clean.
- [x] `ruff` + `pyright` clean on touched files.
- [x] End-to-end against the running debug stack: agent with uploaded SVG logo serializes as `data:image/svg+xml;base64,...` in `GET /api/agents`; agent without a logo returns `null`.
- [ ] Smoke-test Apps grid and Fleet page in the browser after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)