### PR TITLE
Fix platform admin user creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# Bifrost Agent Guide
+
+This is the tool-neutral guidance for AI coding agents working in this repo. `CLAUDE.md` remains the detailed Bifrost playbook, but agents that support `AGENTS.md` should start here.
+
+## Read First
+
+- Work from the current checkout state. Do not revert user or other-agent changes unless explicitly asked.
+- Use `rg` for search, inspect nearby code before editing, and follow existing patterns.
+- Keep changes narrow and reviewable. Avoid drive-by refactors, dead code, commented-out code, and unrequested fallback paths.
+- Treat `.bifrost/` as export-only. Mutate platform entities through the CLI or MCP surfaces described in `docs/llm.txt`.
+- New MCP tools must be thin HTTP wrappers around REST endpoints. Do not add direct ORM/repository access in MCP tools.
+
+## Local Coordination
+
+This machine may have several Codex threads working in the same repos. Before meaningful edits, claim your scope with:
+
+Windows/PowerShell on this workstation:
+
+```powershell
+C:\Users\ThomasBray\.codex\bin\codex-agent-coordinator.ps1 claim --owner "<thread-or-role>" --repo "<repo-path>" --scope "<path-or-task>" --note "<short note>"
+```
+
+Portable command shape for other environments:
+
+```bash
+~/.codex/bin/codex-agent-coordinator claim --owner "<thread-or-role>" --repo "<repo-path>" --scope "<path-or-task>" --note "<short note>"
+```
+
+Check `status` and `conflicts` when working near active agents. Release the claim after meaningful work. The coordinator is warning-only local state under `%USERPROFILE%\.codex`; never add coordination files to the repo unless asked.
+
+## Development Environment
+
+Everything runs in Docker. Do not start host-side FastAPI, Vite, pytest, Postgres, Redis, RabbitMQ, or MinIO processes for normal development.
+
+Use the repo scripts:
+
+```bash
+./debug.sh             # Boot the per-worktree dev stack
+./debug.sh status      # Show URL, login, and mode
+./debug.sh logs api    # Follow one service log
+./test.sh stack up     # Boot the per-worktree test stack
+./test.sh              # Backend unit tests
+./test.sh all          # Backend unit + e2e
+./test.sh client unit  # Vitest
+./test.sh client e2e   # Playwright
+```
+
+Hot reload is expected. Do not restart containers for ordinary code changes. Use targeted restarts only when dependencies, migrations, or generated API types require them.
+
+## Code Boundaries
+
+- Backend API is FastAPI/Python. Keep HTTP handlers thin and put business logic in the shared/service layer used by existing code.
+- Request and response contracts should use Pydantic models.
+- Frontend API types are generated from OpenAPI. Do not hand-write endpoint response types.
+- If API contracts change, run type generation from `client/` while the dev stack is running.
+- Manifest, CLI, and MCP surfaces must stay in sync when DTOs change. Run the DTO parity test called out in `CLAUDE.md`.
+
+## Testing And Verification
+
+Route testing through an e2e testing VM on `pve-t340` unless the user explicitly asks for a local-only check. Do not treat host-side runs on the operator workstation as the verification bar for Bifrost changes.
+
+On the VM, use `./test.sh`; do not run raw host `pytest` for repo tests. The script manages the Dockerized test dependencies and writes result artifacts.
+
+Match verification to the change:
+
+- Backend logic: focused unit tests under `api/tests/unit/`.
+- Endpoint, queue, DB, or workflow behavior: e2e tests under `api/tests/e2e/`.
+- React components: sibling `*.test.tsx`.
+- Functional frontend modules under `client/src/lib/**` or `client/src/services/**`: sibling `*.test.ts`.
+- User-facing UI flows: Playwright happy-path coverage in `client/e2e/`.
+
+Before calling significant work complete, run the relevant checks from `CLAUDE.md` and report anything skipped with the reason.
+
+## Security And Sensitive Paths
+
+Use extra care around auth, execution, multi-tenancy filters, migrations, secrets, manifest round-trips, and audit logging. Call out sensitive-path changes in summaries and PR descriptions.
+
+Do not expose secret values in chat, logs, test fixtures, screenshots, or committed files. Prefer live shape/status validation over copying credentials.
+
+## Useful References
+
+- `CLAUDE.md` - detailed repo rules, commands, and Bifrost-specific invariants.
+- `CONTRIBUTING.md` - human-facing PR and contribution expectations.
+- `docs/llm.txt` - CLI and MCP command reference for LLMs.
+- `.claude/skills/` - Claude-specific skills that document Bifrost setup, testing, release, security, and build workflows.
+- `api/tests/README.md` - test structure and fixture notes.

--- a/client/src/components/users/CreateUserDialog.test.tsx
+++ b/client/src/components/users/CreateUserDialog.test.tsx
@@ -156,4 +156,56 @@ describe("CreateUserDialog — happy path", () => {
 		});
 		expect(onOpenChange).toHaveBeenCalledWith(false);
 	});
+
+	it("auto-selects the provider organization for platform admins after orgs load", async () => {
+		const onOpenChange = vi.fn();
+		let orgsLoaded = false;
+		mockOrganizations.mockImplementation(() => ({
+			data: orgsLoaded
+				? [
+						{
+							id: "org-1",
+							name: "Acme",
+							domain: "acme.com",
+							is_provider: false,
+						},
+						{
+							id: "org-provider",
+							name: "Provider",
+							domain: null,
+							is_provider: true,
+						},
+					]
+				: undefined,
+			isLoading: !orgsLoaded,
+		}));
+
+		const { user, rerender } = renderWithProviders(
+			<CreateUserDialog open={true} onOpenChange={onOpenChange} />,
+		);
+
+		await user.type(
+			screen.getByLabelText(/email address/i),
+			"admin@example.com",
+		);
+		await user.type(screen.getByLabelText(/display name/i), "Admin User");
+		await user.selectOptions(screen.getByLabelText(/userType/i), "platform");
+
+		orgsLoaded = true;
+		rerender(<CreateUserDialog open={true} onOpenChange={onOpenChange} />);
+
+		await user.click(screen.getByRole("button", { name: /create user/i }));
+
+		await waitFor(() => expect(mockCreateMutate).toHaveBeenCalled());
+		expect(mockCreateMutate.mock.calls[0]![0]).toEqual({
+			body: {
+				email: "admin@example.com",
+				name: "Admin User",
+				is_active: true,
+				is_superuser: true,
+				organization_id: "org-provider",
+			},
+		});
+		expect(screen.queryByText(/select an organization/i)).not.toBeInTheDocument();
+	});
 });

--- a/client/src/components/users/CreateUserDialog.tsx
+++ b/client/src/components/users/CreateUserDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -67,6 +67,12 @@ function CreateUserDialogContent({
 
 	// Find the provider org (for auto-selecting when platform admin is chosen)
 	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
+
+	useEffect(() => {
+		if (isPlatformAdmin && providerOrg && orgId !== providerOrg.id) {
+			setOrgId(providerOrg.id);
+		}
+	}, [isPlatformAdmin, orgId, providerOrg]);
 
 	// Auto-select provider org when switching to platform admin
 	const handleUserTypeChange = (value: string) => {

--- a/client/src/components/users/EditUserDialog.tsx
+++ b/client/src/components/users/EditUserDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -93,6 +93,12 @@ function EditUserDialogContent({
 
 	// Find the provider org (for auto-selecting when promoting to platform admin)
 	const providerOrg = organizations?.find((org: Organization) => org.is_provider);
+
+	useEffect(() => {
+		if (isPlatformAdmin && providerOrg && orgId !== providerOrg.id) {
+			setOrgId(providerOrg.id);
+		}
+	}, [isPlatformAdmin, orgId, providerOrg]);
 
 	// Check if editing own account
 	const isEditingSelf = !!(currentUser && user.id === currentUser.id);


### PR DESCRIPTION
## Summary
- auto-select the provider organization when platform-admin user forms receive organization data after the user type is selected
- cover the delayed-organization load path in CreateUserDialog
- codify that Bifrost verification should route through an e2e VM on pve-t340 unless local-only testing is explicitly requested

## Verification
- Not run locally; repo guidance now requires Bifrost testing through an e2e VM on pve-t340 unless explicitly requested otherwise.