### PR TITLE
fix(diagnostics): report cgroup working set, not memory.current

### DIFF
--- a/api/src/models/contracts/platform.py
+++ b/api/src/models/contracts/platform.py
@@ -79,7 +79,8 @@ class PoolSummary(BaseModel):
     )
     memory_current_bytes: int | None = Field(
         default=None,
-        description="Current memory usage of the worker container in bytes (from cgroup)"
+        description="Working-set memory of the worker container in bytes "
+        "(cgroup anon + active_file, matches kubelet/kubectl top)"
     )
     memory_max_bytes: int | None = Field(
         default=None,
@@ -202,7 +203,10 @@ class WorkerMetricPoint(BaseModel):
 
     group: str = Field(..., description="Formatted time bucket label")
     worker_id: str = Field(..., description="Container/pool identifier")
-    memory_current: int = Field(..., description="cgroup memory.current in bytes")
+    memory_current: int = Field(
+        ...,
+        description="Working-set memory in bytes (cgroup anon + active_file)",
+    )
     memory_max: int = Field(..., description="cgroup memory.max in bytes")
     fork_count: int = Field(default=0)
     busy_count: int = Field(default=0)

--- a/api/src/services/execution/memory_monitor.py
+++ b/api/src/services/execution/memory_monitor.py
@@ -58,20 +58,27 @@ _warned_no_cgroup = False
 
 def get_cgroup_memory() -> tuple[int, int]:
     """
-    Read current and max memory from cgroup v2.
+    Read working-set and max memory from cgroup v2.
+
+    The "current" value returned here is the **working set** — anonymous memory
+    plus active file cache, parsed from `memory.stat`. This matches kubelet's
+    working-set definition (and therefore `kubectl top`) and reflects the memory
+    that actually determines OOM-eviction risk. Inactive file cache is excluded
+    because the kernel can evict it under pressure without affecting the
+    workload — counting it inflates apparent usage by ~2x in practice.
 
     Returns:
-        Tuple of (current_bytes, max_bytes). `current_bytes` is -1 only when
-        memory.current is unreadable. `max_bytes` is -1 when memory.max is
+        Tuple of (working_set_bytes, max_bytes). `working_set_bytes` is -1 only
+        when `memory.stat` is unreadable. `max_bytes` is -1 when `memory.max` is
         unset ("max") or unreadable — callers that need a hard limit (e.g.
         admission control) should treat that as "unknown".
     """
     global _warned_no_cgroup
 
-    cgroup_current = Path("/sys/fs/cgroup/memory.current")
+    cgroup_stat = Path("/sys/fs/cgroup/memory.stat")
     cgroup_max = Path("/sys/fs/cgroup/memory.max")
 
-    if not cgroup_current.exists():
+    if not cgroup_stat.exists():
         if not _warned_no_cgroup:
             logger.warning(
                 "cgroup v2 memory files not found - cgroup admission disabled. "
@@ -81,10 +88,30 @@ def get_cgroup_memory() -> tuple[int, int]:
         return (-1, -1)
 
     try:
-        with open(cgroup_current) as f:
-            current = int(f.read().strip())
+        anon = 0
+        active_file = 0
+        seen_anon = False
+        seen_active_file = False
+        with open(cgroup_stat) as f:
+            for line in f:
+                key, _, value = line.partition(" ")
+                if key == "anon":
+                    anon = int(value.strip())
+                    seen_anon = True
+                elif key == "active_file":
+                    active_file = int(value.strip())
+                    seen_active_file = True
+                if seen_anon and seen_active_file:
+                    break
+        if not seen_anon or not seen_active_file:
+            logger.warning(
+                "cgroup memory.stat missing anon/active_file keys - "
+                "working-set calculation unavailable"
+            )
+            return (-1, -1)
+        current = anon + active_file
     except (OSError, ValueError) as e:
-        logger.warning(f"Failed to read cgroup memory.current: {e}")
+        logger.warning(f"Failed to read cgroup memory.stat: {e}")
         return (-1, -1)
 
     limit = -1

--- a/api/tests/unit/execution/test_memory_monitor.py
+++ b/api/tests/unit/execution/test_memory_monitor.py
@@ -118,17 +118,30 @@ class TestHasSufficientMemory:
 
 
 class TestGetCgroupMemory:
-    """Tests for cgroup v2 memory reading."""
+    """Tests for cgroup v2 memory reading (working-set semantics)."""
 
-    def test_reads_cgroup_memory_current_and_max(self):
-        """Should read memory.current and memory.max from cgroup v2."""
+    # Realistic memory.stat excerpt — order intentionally interleaved.
+    STAT_DATA = (
+        "anon 400000000\n"
+        "file 500000000\n"
+        "kernel_stack 1048576\n"
+        "active_anon 0\n"
+        "inactive_anon 400000000\n"
+        "active_file 100000000\n"
+        "inactive_file 400000000\n"
+    )
+
+    def test_returns_anon_plus_active_file_as_working_set(self):
+        """Should sum anon + active_file (kubelet working-set), excluding inactive_file."""
         with patch("builtins.open", side_effect=[
-            mock_open(read_data="524288000\n")(),   # memory.current = 500MB
+            mock_open(read_data=self.STAT_DATA)(),
             mock_open(read_data="1073741824\n")(),   # memory.max = 1GB
         ]):
             with patch("pathlib.Path.exists", return_value=True):
                 current, limit = get_cgroup_memory()
-                assert current == 524288000
+                # 400MB anon + 100MB active_file = 500MB working set,
+                # NOT 900MB (which would include the 400MB inactive_file cache).
+                assert current == 500_000_000
                 assert limit == 1073741824
 
     def test_returns_negative_when_cgroup_files_missing(self):
@@ -139,20 +152,30 @@ class TestGetCgroupMemory:
             assert limit == -1
 
     def test_returns_current_with_negative_limit_when_memory_max_is_max(self):
-        """Should return (current, -1) when memory.max is 'max' (no limit set)."""
+        """Should return (working_set, -1) when memory.max is 'max' (no limit set)."""
         with patch("builtins.open", side_effect=[
-            mock_open(read_data="524288000\n")(),
+            mock_open(read_data=self.STAT_DATA)(),
             mock_open(read_data="max\n")(),
         ]):
             with patch("pathlib.Path.exists", return_value=True):
                 current, limit = get_cgroup_memory()
-                assert current == 524288000
+                assert current == 500_000_000
                 assert limit == -1
 
     def test_handles_read_error_gracefully(self):
         """Should return (-1, -1) on read failure."""
         with patch("pathlib.Path.exists", return_value=True):
             with patch("builtins.open", side_effect=OSError("Permission denied")):
+                current, limit = get_cgroup_memory()
+                assert current == -1
+                assert limit == -1
+
+    def test_returns_negative_when_stat_missing_required_keys(self):
+        """Should return (-1, -1) when memory.stat lacks anon or active_file."""
+        # Only `anon`, no `active_file` — pre-v2-style stat or oddball runtime.
+        bad_stat = "anon 400000000\nfile 500000000\n"
+        with patch("builtins.open", mock_open(read_data=bad_stat)):
+            with patch("pathlib.Path.exists", return_value=True):
                 current, limit = get_cgroup_memory()
                 assert current == -1
                 assert limit == -1


### PR DESCRIPTION
## Summary
- `get_cgroup_memory()` was reading `/sys/fs/cgroup/memory.current` directly, which counts inactive file cache that the kernel happily evicts under pressure. In prod this inflated the Diagnostics "Total Memory Usage" / per-container bars to ~2× `kubectl top`.
- Switch to **anon + active_file** parsed from `memory.stat` — kubelet's working-set definition. This is the number that actually drives OOM-eviction risk and matches `kubectl top`.
- Side benefit: `has_sufficient_memory_cgroup` (admission control's 85% threshold) was firing late because the cgroup looked fuller than it really was. Same fix applies automatically since it shares `get_cgroup_memory()`.

Return shape unchanged (`tuple[int, int]`), so all downstream consumers (heartbeat → WebSocket → MemoryChart/ContainerTable, WorkerMetric time-series, admission gate) pick up the corrected value with no schema changes. Updated the Pydantic field docstrings to reflect working-set semantics.

## Test plan
- [x] `./test.sh tests/unit/execution/test_memory_monitor.py -v` — 20/20 pass, including a new test asserting `anon + active_file` is summed (and `inactive_file` is excluded) and a new test for the missing-keys fallback
- [x] `ruff check` clean
- [x] `pyright` clean
- [ ] Spot-check in prod after deploy: Diagnostics "Total Memory Usage" should now track `kubectl top pods -n bifrost | grep worker` within rounding (currently shows ~2×)

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)