### PR TITLE
fix(oauth): build authorize URL with & when template has existing query string

### DIFF
--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -8,7 +8,6 @@ Integrations combine OAuth providers, data providers, and configuration schemas.
 import logging
 import secrets
 from datetime import datetime, timezone
-from urllib.parse import urlencode
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -47,7 +46,11 @@ from src.models import (
 from src.models.orm import Config as ConfigModel
 from src.models.orm import IntegrationConfigSchema
 from src.models.orm import OAuthToken
-from src.services.oauth_provider import get_url_resolution_defaults, resolve_url_template
+from src.services.oauth_provider import (
+    append_query_params,
+    get_url_resolution_defaults,
+    resolve_url_template,
+)
 from src.services.oauth_state import encode_state, remember_nonce
 
 logger = logging.getLogger(__name__)
@@ -1299,7 +1302,7 @@ async def authorize_mapping(
     )
 
     return MappingAuthorizeResponse(
-        authorization_url=f"{resolved_url}?{urlencode(params)}",
+        authorization_url=append_query_params(resolved_url, params),
     )
 
 
@@ -1511,7 +1514,7 @@ async def get_oauth_authorization_url(
         "redirect_uri": redirect_uri,
     }
 
-    authorization_url = f"{oauth_provider.authorization_url}?{urlencode(params)}"
+    authorization_url = append_query_params(oauth_provider.authorization_url, params)
 
     logger.info(
         f"Generated OAuth authorization URL for integration {log_safe(integration_id)}, "

--- a/api/src/routers/mcp_connections.py
+++ b/api/src/routers/mcp_connections.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 from typing import Literal, Union
-from urllib.parse import urlencode
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -56,6 +55,7 @@ from src.services.mcp_client.oauth_state import (
 )
 from src.services.oauth_provider import (
     OAuthProviderClient,
+    append_query_params,
     get_url_resolution_defaults,
     resolve_url_template,
 )
@@ -279,7 +279,7 @@ async def _build_authorization_url(
     if provider.audience:
         params["audience"] = provider.audience
 
-    return f"{resolved}?{urlencode(params)}"
+    return append_query_params(resolved, params)
 
 
 async def _activate_client_credentials(

--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -9,7 +9,6 @@ import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any
-from urllib.parse import urlencode
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
@@ -34,6 +33,7 @@ from src.models import OAuthProvider, OAuthToken
 from src.models.orm.integrations import IntegrationMapping
 from src.services.oauth_entity_id import extract_entity_id
 from src.services.oauth_provider import (
+    append_query_params,
     build_token_refresh_context,
     get_url_resolution_defaults,
     refresh_oauth_token_http,
@@ -614,7 +614,7 @@ async def authorize_connection(
         "redirect_uri": redirect_uri,
     }
 
-    authorization_url = f"{resolved_authorization_url}?{urlencode(params)}"
+    authorization_url = append_query_params(resolved_authorization_url, params)
 
     # Update status to waiting
     await repo.update_status(

--- a/api/src/services/oauth_provider.py
+++ b/api/src/services/oauth_provider.py
@@ -94,6 +94,41 @@ def resolve_url_template(
     return result
 
 
+def append_query_params(url: str, params: dict[str, Any]) -> str:
+    """
+    Append query parameters to a URL, preserving any existing query string.
+
+    Uses ``&`` as the separator when the URL already contains ``?``, and ``?``
+    otherwise. This matters for authorize URLs that bake provider-specific
+    flags into the configured template (e.g. Google's ``access_type=offline``
+    or Microsoft's ``prompt=login``) — without this, a naive ``f"{url}?{...}"``
+    produces ``...?baked=1?client_id=...`` which providers reject.
+
+    Args:
+        url: Base URL, with or without an existing query string.
+        params: Mapping of parameter names to values to append.
+
+    Returns:
+        URL with the new parameters appended.
+
+    Examples:
+        >>> append_query_params("https://example.com/auth", {"client_id": "abc"})
+        'https://example.com/auth?client_id=abc'
+
+        >>> append_query_params(
+        ...     "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline",
+        ...     {"client_id": "abc"},
+        ... )
+        'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&client_id=abc'
+    """
+    from urllib.parse import urlencode
+
+    if not params:
+        return url
+    separator = "&" if "?" in url else "?"
+    return f"{url}{separator}{urlencode(params)}"
+
+
 class OAuthProviderClient:
     """
     Client for interacting with OAuth 2.0 providers

--- a/api/src/services/oauth_sso.py
+++ b/api/src/services/oauth_sso.py
@@ -16,7 +16,6 @@ import secrets
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import urlencode
 from uuid import UUID
 
 import httpx
@@ -26,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.core.log_safety import log_safe
 from src.models import User, UserOAuthAccount
 from src.services.oauth_config_service import OAuthConfigService
+from src.services.oauth_provider import append_query_params
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +225,7 @@ class OAuthService:
             params["access_type"] = "offline"
             params["prompt"] = "consent"
 
-        return f"{config['authorize_url']}?{urlencode(params)}"
+        return append_query_params(config["authorize_url"], params)
 
     async def exchange_code_for_tokens(
         self,

--- a/api/tests/unit/services/test_oauth_provider.py
+++ b/api/tests/unit/services/test_oauth_provider.py
@@ -9,7 +9,7 @@ import asyncio
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from src.services.oauth_provider import OAuthProviderClient
+from src.services.oauth_provider import OAuthProviderClient, append_query_params
 
 
 @pytest.fixture
@@ -602,3 +602,56 @@ class TestOAuthProviderRetry:
             # After max_retries, should fail
             assert success is False
             assert "max_retries_exceeded" in result["error"]
+
+
+class TestAppendQueryParams:
+    """Tests for append_query_params helper."""
+
+    def test_appends_with_question_mark_when_url_has_no_query(self):
+        url = append_query_params(
+            "https://example.com/auth", {"client_id": "abc"}
+        )
+        assert url == "https://example.com/auth?client_id=abc"
+
+    def test_appends_with_ampersand_when_url_already_has_query(self):
+        # Regression test: a naive f"{url}?{urlencode(params)}" produces
+        # "...?access_type=offline?client_id=abc", which Google rejects with
+        # "missing required parameter: client_id". The helper must detect the
+        # existing query string and use & instead.
+        url = append_query_params(
+            "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline",
+            {"client_id": "abc", "scope": "openid"},
+        )
+        assert url == (
+            "https://accounts.google.com/o/oauth2/v2/auth"
+            "?access_type=offline&client_id=abc&scope=openid"
+        )
+
+    def test_preserves_multiple_existing_params(self):
+        url = append_query_params(
+            "https://accounts.google.com/o/oauth2/v2/auth"
+            "?access_type=offline&prompt=consent",
+            {"client_id": "abc"},
+        )
+        assert url == (
+            "https://accounts.google.com/o/oauth2/v2/auth"
+            "?access_type=offline&prompt=consent&client_id=abc"
+        )
+
+    def test_empty_params_returns_url_unchanged(self):
+        assert append_query_params("https://example.com/auth", {}) == (
+            "https://example.com/auth"
+        )
+        assert append_query_params(
+            "https://example.com/auth?foo=bar", {}
+        ) == "https://example.com/auth?foo=bar"
+
+    def test_url_encodes_special_characters_in_values(self):
+        url = append_query_params(
+            "https://example.com/auth",
+            {"redirect_uri": "https://app.example.com/cb?env=prod"},
+        )
+        assert url == (
+            "https://example.com/auth"
+            "?redirect_uri=https%3A%2F%2Fapp.example.com%2Fcb%3Fenv%3Dprod"
+        )


### PR DESCRIPTION
## Summary

Five call sites build the OAuth authorize URL as `f\"{url}?{urlencode(params)}\"`, which produces a malformed URL when the configured `authorization_url` already contains a query string. Google's authorize endpoint requires `access_type=offline&prompt=consent` baked into the URL to issue a refresh token — putting those in `authorization_url` currently produces `...?access_type=offline?client_id=...`, which Google rejects with \"missing required parameter: client_id\". Same shape of bug applies to any provider where flags need to be baked into the authorize URL (Microsoft `prompt=login`, Salesforce sandbox login URLs, etc.).

Fix: add a small `append_query_params(url, params)` helper in `oauth_provider` that picks `&` vs `?` based on whether the URL already contains a `?`, and use it at all five call sites.

## Call sites updated

- `api/src/routers/oauth_connections.py:617` — per-mapping authorize flow
- `api/src/routers/mcp_connections.py:282` — MCP server connect popup
- `api/src/routers/integrations.py:1302` — integration mapping authorize (response)
- `api/src/routers/integrations.py:1514` — integration mapping authorize (legacy)
- `api/src/services/oauth_sso.py:228` — Bifrost-as-RP SSO login

Also drops the now-unused `urlencode` imports from each file (still used inside the helper).

## Why not a dedicated `extra_params` field on `OAuthProvider`?

That was the first thing I considered, since it's a cleaner data model — params live as structured data rather than embedded in a URL string. But it requires a schema migration, manifest model change, serializer + indexer updates, and CLI/MCP DTO updates, and it solves the same problem this 35-line helper does. Happy to follow up with an `extra_params` field if needed for *dynamic* per-request params (varying per user/org), but for the static \"this provider always needs `prompt=consent`\" case, allowing the operator to bake them into `authorization_url` is the simplest path.

## Test plan

- [x] New `TestAppendQueryParams` class in `api/tests/unit/services/test_oauth_provider.py` covers:
  - URL with no existing query string → appends with `?`
  - URL with existing query string → appends with `&` (regression test for Google `access_type=offline`)
  - URL with multiple existing params → preserved + new params appended
  - Empty params dict → URL unchanged
  - Values with reserved characters → URL-encoded correctly
- [x] Verified pure-function logic against test assertions out-of-band (no aiohttp dependency in CI-equivalent run)
- [ ] Full `./test.sh tests/unit/services/test_oauth_provider.py` once Docker test stack is up
- [ ] Manual prod verification at SpireTech: Google integration completes connect flow without two `?`s, returns refresh token (will cherry-pick this commit onto our deploy branch to ship before the upstream merge — happy to revert that local patch once this lands)

## Background

Reported by an engineer at SpireTech configuring a new Google integration (Search Console + Analytics). Tracked the issue down to URL construction; same buggy pattern existed in four other files.