### PR TITLE
Fix RabbitMQ readiness connection churn

### DIFF
--- a/api/src/main.py
+++ b/api/src/main.py
@@ -21,6 +21,7 @@ from src.core.csrf import CSRFMiddleware
 from src.core.embed_middleware import EmbedScopeMiddleware
 from src.core.database import close_db, init_db
 from src.core.pubsub import manager as pubsub_manager
+from src.routers.health import close_rabbitmq_health_connection
 from src.routers import (
     auth_router,
     mfa_router,
@@ -160,6 +161,7 @@ async def app_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Shutting down Bifrost API...")
 
     await pubsub_manager.close()
+    await close_rabbitmq_health_connection()
     await close_db()
     logger.info("Bifrost API shutdown complete")
 

--- a/api/src/routers/health.py
+++ b/api/src/routers/health.py
@@ -26,9 +26,58 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 CHECK_TIMEOUT_SECONDS = 2.0
 ComponentStatus = dict[str, str]
-_rabbitmq_health_connection: AbstractRobustConnection | None = None
-_rabbitmq_health_connection_url: str | None = None
-_rabbitmq_health_lock = asyncio.Lock()
+
+
+class RabbitMQHealthConnection:
+    def __init__(self) -> None:
+        self.connection: AbstractRobustConnection | None = None
+        self.url: str | None = None
+        self.lock = asyncio.Lock()
+
+    @staticmethod
+    def _is_open(connection: AbstractRobustConnection) -> bool:
+        return not bool(connection.is_closed)
+
+    async def close(self) -> None:
+        connection = self.connection
+        self.connection = None
+        self.url = None
+        if connection is not None and self._is_open(connection):
+            await connection.close()
+
+    async def get(self, settings: Settings) -> AbstractRobustConnection:
+        connection = self.connection
+        if (
+            connection is not None
+            and self.url == settings.rabbitmq_url
+            and self._is_open(connection)
+        ):
+            return connection
+
+        async with self.lock:
+            connection = self.connection
+            if (
+                connection is not None
+                and self.url == settings.rabbitmq_url
+                and self._is_open(connection)
+            ):
+                return connection
+
+            if connection is not None and self._is_open(connection):
+                await connection.close()
+
+            self.connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+            self.url = settings.rabbitmq_url
+            return self.connection
+
+    async def discard(self, connection: AbstractRobustConnection) -> None:
+        await connection.close()
+        if self.connection is connection:
+            self.connection = None
+            self.url = None
+
+
+_rabbitmq_health_connection = RabbitMQHealthConnection()
 
 
 class HealthCheck(BaseModel):
@@ -90,46 +139,12 @@ async def check_redis(settings: Settings) -> tuple[str, ComponentStatus]:
     return await _checked_component("redis", "redis", ping())
 
 
-def _rabbitmq_connection_is_open(connection: AbstractRobustConnection) -> bool:
-    return not bool(connection.is_closed)
-
-
 async def close_rabbitmq_health_connection() -> None:
-    global _rabbitmq_health_connection, _rabbitmq_health_connection_url
-
-    connection = _rabbitmq_health_connection
-    _rabbitmq_health_connection = None
-    _rabbitmq_health_connection_url = None
-    if connection is not None and _rabbitmq_connection_is_open(connection):
-        await connection.close()
+    await _rabbitmq_health_connection.close()
 
 
 async def _get_rabbitmq_health_connection(settings: Settings) -> AbstractRobustConnection:
-    global _rabbitmq_health_connection, _rabbitmq_health_connection_url
-
-    connection = _rabbitmq_health_connection
-    if (
-        connection is not None
-        and _rabbitmq_health_connection_url == settings.rabbitmq_url
-        and _rabbitmq_connection_is_open(connection)
-    ):
-        return connection
-
-    async with _rabbitmq_health_lock:
-        connection = _rabbitmq_health_connection
-        if (
-            connection is not None
-            and _rabbitmq_health_connection_url == settings.rabbitmq_url
-            and _rabbitmq_connection_is_open(connection)
-        ):
-            return connection
-
-        if connection is not None and _rabbitmq_connection_is_open(connection):
-            await connection.close()
-
-        _rabbitmq_health_connection = await aio_pika.connect_robust(settings.rabbitmq_url)
-        _rabbitmq_health_connection_url = settings.rabbitmq_url
-        return _rabbitmq_health_connection
+    return await _rabbitmq_health_connection.get(settings)
 
 
 async def check_rabbitmq(settings: Settings) -> tuple[str, ComponentStatus]:
@@ -139,11 +154,7 @@ async def check_rabbitmq(settings: Settings) -> tuple[str, ComponentStatus]:
             channel = await connection.channel()
             await channel.close()
         except Exception:
-            await connection.close()
-            global _rabbitmq_health_connection, _rabbitmq_health_connection_url
-            if _rabbitmq_health_connection is connection:
-                _rabbitmq_health_connection = None
-                _rabbitmq_health_connection_url = None
+            await _rabbitmq_health_connection.discard(connection)
             raise
 
     return await _checked_component("rabbitmq", "rabbitmq", open_channel())

--- a/api/src/routers/health.py
+++ b/api/src/routers/health.py
@@ -12,6 +12,7 @@ from typing import cast
 import aio_pika
 import redis.asyncio as redis
 from aiobotocore.session import get_session
+from aio_pika.abc import AbstractRobustConnection
 from fastapi import APIRouter, Depends, Response, status
 from pydantic import BaseModel, Field
 from sqlalchemy import text
@@ -25,6 +26,9 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 CHECK_TIMEOUT_SECONDS = 2.0
 ComponentStatus = dict[str, str]
+_rabbitmq_health_connection: AbstractRobustConnection | None = None
+_rabbitmq_health_connection_url: str | None = None
+_rabbitmq_health_lock = asyncio.Lock()
 
 
 class HealthCheck(BaseModel):
@@ -86,14 +90,61 @@ async def check_redis(settings: Settings) -> tuple[str, ComponentStatus]:
     return await _checked_component("redis", "redis", ping())
 
 
+def _rabbitmq_connection_is_open(connection: AbstractRobustConnection) -> bool:
+    return not bool(connection.is_closed)
+
+
+async def close_rabbitmq_health_connection() -> None:
+    global _rabbitmq_health_connection, _rabbitmq_health_connection_url
+
+    connection = _rabbitmq_health_connection
+    _rabbitmq_health_connection = None
+    _rabbitmq_health_connection_url = None
+    if connection is not None and _rabbitmq_connection_is_open(connection):
+        await connection.close()
+
+
+async def _get_rabbitmq_health_connection(settings: Settings) -> AbstractRobustConnection:
+    global _rabbitmq_health_connection, _rabbitmq_health_connection_url
+
+    connection = _rabbitmq_health_connection
+    if (
+        connection is not None
+        and _rabbitmq_health_connection_url == settings.rabbitmq_url
+        and _rabbitmq_connection_is_open(connection)
+    ):
+        return connection
+
+    async with _rabbitmq_health_lock:
+        connection = _rabbitmq_health_connection
+        if (
+            connection is not None
+            and _rabbitmq_health_connection_url == settings.rabbitmq_url
+            and _rabbitmq_connection_is_open(connection)
+        ):
+            return connection
+
+        if connection is not None and _rabbitmq_connection_is_open(connection):
+            await connection.close()
+
+        _rabbitmq_health_connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+        _rabbitmq_health_connection_url = settings.rabbitmq_url
+        return _rabbitmq_health_connection
+
+
 async def check_rabbitmq(settings: Settings) -> tuple[str, ComponentStatus]:
     async def open_channel() -> None:
-        connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+        connection = await _get_rabbitmq_health_connection(settings)
         try:
             channel = await connection.channel()
             await channel.close()
-        finally:
+        except Exception:
             await connection.close()
+            global _rabbitmq_health_connection, _rabbitmq_health_connection_url
+            if _rabbitmq_health_connection is connection:
+                _rabbitmq_health_connection = None
+                _rabbitmq_health_connection_url = None
+            raise
 
     return await _checked_component("rabbitmq", "rabbitmq", open_channel())
 

--- a/api/tests/unit/routers/test_health.py
+++ b/api/tests/unit/routers/test_health.py
@@ -39,6 +39,33 @@ async def _build_components(db, settings):
     }
 
 
+class FakeRabbitMQChannel:
+    def __init__(self):
+        self.close_count = 0
+
+    async def close(self):
+        self.close_count += 1
+
+
+class FakeRabbitMQConnection:
+    def __init__(self, channel_error: Exception | None = None):
+        self.channel_error = channel_error
+        self.channels: list[FakeRabbitMQChannel] = []
+        self.close_count = 0
+        self.is_closed = False
+
+    async def channel(self):
+        if self.channel_error:
+            raise self.channel_error
+        channel = FakeRabbitMQChannel()
+        self.channels.append(channel)
+        return channel
+
+    async def close(self):
+        self.close_count += 1
+        self.is_closed = True
+
+
 @pytest.mark.asyncio
 async def test_health_is_liveness_and_does_not_check_dependencies(monkeypatch):
     async def fail_if_called(*args, **kwargs):
@@ -125,6 +152,76 @@ async def test_s3_not_configured_does_not_fail_readiness(monkeypatch):
     assert response.status_code == 200
     assert result.status == "healthy"
     assert result.components["s3"] == {"status": "not_configured", "type": "s3"}
+
+
+@pytest.mark.asyncio
+async def test_rabbitmq_check_reuses_cached_connection(monkeypatch):
+    await health.close_rabbitmq_health_connection()
+    connections: list[FakeRabbitMQConnection] = []
+
+    async def connect_robust(url):
+        connection = FakeRabbitMQConnection()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(health.aio_pika, "connect_robust", connect_robust)
+
+    try:
+        first_name, first_component = await health.check_rabbitmq(_settings())
+        second_name, second_component = await health.check_rabbitmq(_settings())
+    finally:
+        await health.close_rabbitmq_health_connection()
+
+    assert first_name == "rabbitmq"
+    assert second_name == "rabbitmq"
+    assert first_component == {"status": "healthy", "type": "rabbitmq"}
+    assert second_component == {"status": "healthy", "type": "rabbitmq"}
+    assert len(connections) == 1
+    assert len(connections[0].channels) == 2
+    assert [channel.close_count for channel in connections[0].channels] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_rabbitmq_check_reports_unhealthy_when_channel_fails(monkeypatch):
+    await health.close_rabbitmq_health_connection()
+    failed_connection = FakeRabbitMQConnection(channel_error=RuntimeError("channel failed"))
+
+    async def connect_robust(url):
+        return failed_connection
+
+    monkeypatch.setattr(health.aio_pika, "connect_robust", connect_robust)
+
+    try:
+        component_name, component = await health.check_rabbitmq(_settings())
+    finally:
+        await health.close_rabbitmq_health_connection()
+
+    assert component_name == "rabbitmq"
+    assert component == {
+        "status": "unhealthy",
+        "type": "rabbitmq",
+        "error": "RuntimeError",
+    }
+    assert failed_connection.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_rabbitmq_check_reports_unhealthy_when_connect_fails(monkeypatch):
+    await health.close_rabbitmq_health_connection()
+
+    async def connect_robust(url):
+        raise ConnectionError("cannot connect")
+
+    monkeypatch.setattr(health.aio_pika, "connect_robust", connect_robust)
+
+    component_name, component = await health.check_rabbitmq(_settings())
+
+    assert component_name == "rabbitmq"
+    assert component == {
+        "status": "unhealthy",
+        "type": "rabbitmq",
+        "error": "ConnectionError",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- cache the RabbitMQ readiness AMQP connection instead of reconnecting every probe
- still open a channel per readiness check and report unhealthy on connect/channel failures
- close the cached readiness connection during API shutdown

## Tests
- ./test.sh tests/unit/routers/test_health.py -v
- ruff check api/src/main.py api/src/routers/health.py api/tests/unit/routers/test_health.py

Fixes #286