### PR TITLE
Fix data provider overhead from readiness client churn

### DIFF
--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -521,6 +521,8 @@ class WorkflowExecutionConsumer(BaseConsumer):
             roi_value = 0.0
             workflow_function_name: str | None = None  # Function name for exec_from_db()
             content_hash: str | None = None  # Content hash pinned at dispatch time
+            workflow_type = "workflow"
+            cache_ttl_seconds = 300
 
             if not is_script and workflow_id:
                 from src.services.execution.service import get_workflow_for_execution, WorkflowNotFoundError
@@ -533,6 +535,8 @@ class WorkflowExecutionConsumer(BaseConsumer):
                     workflow_name = workflow_data["name"]
                     workflow_function_name = workflow_data["function_name"]
                     file_path = workflow_data["path"]  # Used for __file__ injection and Redis/S3 loading
+                    workflow_type = workflow_data["type"]
+                    cache_ttl_seconds = workflow_data["cache_ttl_seconds"]
 
                     timeout_seconds = workflow_data["timeout_seconds"]
                     # Initialize ROI from workflow defaults
@@ -661,8 +665,9 @@ class WorkflowExecutionConsumer(BaseConsumer):
                     "name": user_name,
                 },
                 "organization": org_data,
-                "tags": ["workflow"] if not is_script else [],
+                "tags": [workflow_type] if not is_script else [],
                 "timeout_seconds": timeout_seconds,
+                "cache_ttl_seconds": cache_ttl_seconds,
                 "transient": False,
                 "is_platform_admin": pending.get("is_platform_admin", False),
                 "startup": startup,  # Launch workflow results (available via context.startup)

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -21,7 +21,7 @@ from src.core.csrf import CSRFMiddleware
 from src.core.embed_middleware import EmbedScopeMiddleware
 from src.core.database import close_db, init_db
 from src.core.pubsub import manager as pubsub_manager
-from src.routers.health import close_rabbitmq_health_connection
+from src.routers.health import close_health_check_clients
 from src.routers import (
     auth_router,
     mfa_router,
@@ -162,7 +162,7 @@ async def app_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Shutting down Bifrost API...")
 
     await pubsub_manager.close()
-    await close_rabbitmq_health_connection()
+    await close_health_check_clients()
     await close_db()
     logger.info("Bifrost API shutdown complete")
 

--- a/api/src/routers/health.py
+++ b/api/src/routers/health.py
@@ -5,9 +5,9 @@ Provides endpoints for monitoring application health.
 """
 
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Hashable
 from datetime import datetime, timezone
-from typing import cast
+from typing import Any, cast
 
 import aio_pika
 import redis.asyncio as redis
@@ -77,7 +77,102 @@ class RabbitMQHealthConnection:
             self.url = None
 
 
+class RedisHealthConnection:
+    def __init__(self) -> None:
+        self.client: Any | None = None
+        self.url: str | None = None
+        self.lock = asyncio.Lock()
+
+    async def close(self) -> None:
+        client = self.client
+        self.client = None
+        self.url = None
+        if client is not None:
+            await client.aclose()
+
+    async def get(self, settings: Settings) -> Any:
+        client = self.client
+        if client is not None and self.url == settings.redis_url:
+            return client
+
+        async with self.lock:
+            client = self.client
+            if client is not None and self.url == settings.redis_url:
+                return client
+
+            if client is not None:
+                await client.aclose()
+
+            self.client = redis.from_url(settings.redis_url, decode_responses=True)
+            self.url = settings.redis_url
+            return self.client
+
+    async def discard(self, client: Any) -> None:
+        await client.aclose()
+        if self.client is client:
+            self.client = None
+            self.url = None
+
+
+class S3HealthClient:
+    def __init__(self) -> None:
+        self.client: Any | None = None
+        self.context: Any | None = None
+        self.key: Hashable | None = None
+        self.lock = asyncio.Lock()
+
+    @staticmethod
+    def _key(settings: Settings) -> Hashable:
+        return (
+            settings.s3_endpoint_url,
+            settings.s3_bucket,
+            settings.s3_access_key,
+            settings.s3_secret_key,
+            settings.s3_region,
+        )
+
+    async def close(self) -> None:
+        context = self.context
+        self.client = None
+        self.context = None
+        self.key = None
+        if context is not None:
+            await context.__aexit__(None, None, None)
+
+    async def get(self, settings: Settings) -> Any:
+        key = self._key(settings)
+        client = self.client
+        if client is not None and self.key == key:
+            return client
+
+        async with self.lock:
+            client = self.client
+            if client is not None and self.key == key:
+                return client
+
+            await self.close()
+            session = get_session()
+            context = session.create_client(
+                "s3",
+                endpoint_url=settings.s3_endpoint_url,
+                aws_access_key_id=settings.s3_access_key,
+                aws_secret_access_key=settings.s3_secret_key,
+                region_name=settings.s3_region,
+            )
+            client = await context.__aenter__()
+            self.client = client
+            self.context = context
+            self.key = key
+            return client
+
+    async def discard(self, client: Any) -> None:
+        if self.client is client:
+            await self.close()
+
+
 _rabbitmq_health_connection = RabbitMQHealthConnection()
+_redis_health_connection = RedisHealthConnection()
+_s3_health_client = S3HealthClient()
 
 
 class HealthCheck(BaseModel):
@@ -130,17 +225,24 @@ async def check_database(db: AsyncSession) -> tuple[str, ComponentStatus]:
 
 async def check_redis(settings: Settings) -> tuple[str, ComponentStatus]:
     async def ping() -> None:
-        client = redis.from_url(settings.redis_url, decode_responses=True)
+        client = await _redis_health_connection.get(settings)
         try:
             await cast(Awaitable[object], client.ping())
-        finally:
-            await client.aclose()
+        except Exception:
+            await _redis_health_connection.discard(client)
+            raise
 
     return await _checked_component("redis", "redis", ping())
 
 
-async def close_rabbitmq_health_connection() -> None:
+async def close_health_check_clients() -> None:
     await _rabbitmq_health_connection.close()
+    await _redis_health_connection.close()
+    await _s3_health_client.close()
+
+
+async def close_rabbitmq_health_connection() -> None:
+    await close_health_check_clients()
 
 
 async def _get_rabbitmq_health_connection(settings: Settings) -> AbstractRobustConnection:
@@ -162,18 +264,16 @@ async def check_rabbitmq(settings: Settings) -> tuple[str, ComponentStatus]:
 
 async def check_s3(settings: Settings) -> tuple[str, ComponentStatus]:
     if not settings.s3_configured:
+        await _s3_health_client.close()
         return "s3", _component("not_configured", "s3")
 
     async def head_bucket() -> None:
-        session = get_session()
-        async with session.create_client(
-            "s3",
-            endpoint_url=settings.s3_endpoint_url,
-            aws_access_key_id=settings.s3_access_key,
-            aws_secret_access_key=settings.s3_secret_key,
-            region_name=settings.s3_region,
-        ) as client:
+        client = await _s3_health_client.get(settings)
+        try:
             await cast(Awaitable[object], client.head_bucket(Bucket=settings.s3_bucket))
+        except Exception:
+            await _s3_health_client.discard(client)
+            raise
 
     return await _checked_component("s3", "s3", head_bucket())
 

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -66,6 +66,7 @@ from src.core.auth import Context, CurrentActiveUser, CurrentSuperuser
 from src.core.database import DbSession
 from src.core.log_safety import log_safe
 from src.core.pubsub import publish_execution_update, publish_history_update
+from src.core.cache import get_cached_data_provider
 
 logger = logging.getLogger(__name__)
 
@@ -891,23 +892,45 @@ async def execute_workflow(
                 transient=request.transient,
             )
         elif workflow and workflow.type == "data_provider":
-            # Execute data provider through normal workflow path
-            # Data providers are transient (no execution tracking) and always sync
+            # Only short-circuit on the sync/transient hot path. A non-transient
+            # request (e.g. manual "Execute" from the workflows page) expects a
+            # tracked execution row to navigate to — returning a synthetic
+            # execution_id would 404 the history detail page.
+            if request.transient and workflow.cache_ttl_seconds > 0:
+                cached_result = await get_cached_data_provider(
+                    str(execution_org_id) if execution_org_id else None,
+                    workflow.name,
+                    request.input_data,
+                )
+                if cached_result:
+                    return WorkflowExecutionResponse(
+                        execution_id=shared_ctx.execution_id,
+                        workflow_id=str(workflow.id),
+                        workflow_name=workflow.name,
+                        status=ExecutionStatus.SUCCESS,
+                        result=cached_result.get("data"),
+                        duration_ms=0,
+                        is_transient=True,
+                    )
+
+            # Data providers always run sync (small payloads, no UI poll flow),
+            # but honor the caller's transient flag: dropdown-options pass
+            # transient=True for the fast path, the manual Execute page passes
+            # transient=False and expects a tracked execution row.
             result = await run_workflow(
                 context=shared_ctx,
                 workflow_id=str(workflow.id),
                 input_data=request.input_data,
-                transient=True,
+                transient=request.transient,
                 sync=True,
             )
-            # Return with is_transient flag for consistency
             return WorkflowExecutionResponse(
                 execution_id=result.execution_id,
                 workflow_id=str(workflow.id),
                 workflow_name=workflow.name,
                 status=result.status,
-                result=result.result,  # list[dict] with value, label, description
-                is_transient=True,
+                result=result.result,
+                is_transient=request.transient,
             )
         elif workflow:
             # Execute workflow by ID

--- a/api/src/services/execution/engine.py
+++ b/api/src/services/execution/engine.py
@@ -353,7 +353,12 @@ async def execute(request: ExecutionRequest) -> ExecutionResult:
             )
 
             # Cache result to Redis if data provider
-            if is_data_provider and DATA_PROVIDER_CACHE_AVAILABLE and cache_data_provider_result:
+            if (
+                is_data_provider
+                and request.cache_ttl_seconds > 0
+                and DATA_PROVIDER_CACHE_AVAILABLE
+                and cache_data_provider_result
+            ):
                 org_id = request.organization.id if request.organization else None
                 expires_at = await cache_data_provider_result(
                     org_id,

--- a/api/src/services/execution/service.py
+++ b/api/src/services/execution/service.py
@@ -151,6 +151,8 @@ async def get_workflow_for_execution(
         - value: ROI value
         - execution_mode: sync or async
         - organization_id: Org scope (or None for global)
+        - type: Executable type (workflow, tool, or data_provider)
+        - cache_ttl_seconds: Data provider cache TTL
 
     Raises:
         WorkflowNotFoundError: If workflow doesn't exist in database
@@ -181,6 +183,8 @@ async def get_workflow_for_execution(
             "value": float(workflow_record.value) if workflow_record.value else 0.0,
             "execution_mode": workflow_record.execution_mode or "async",
             "organization_id": str(workflow_record.organization_id) if workflow_record.organization_id else None,
+            "type": workflow_record.type or "workflow",
+            "cache_ttl_seconds": workflow_record.cache_ttl_seconds or 0,
         }
 
     if db is not None:

--- a/api/tests/e2e/api/test_data_providers.py
+++ b/api/tests/e2e/api/test_data_providers.py
@@ -6,6 +6,8 @@ Uses write_and_register() to write files and register decorated functions
 in a single step, avoiding poll-based discovery.
 """
 
+from uuid import uuid4
+
 import pytest
 
 from tests.e2e.conftest import write_and_register
@@ -139,6 +141,158 @@ async def e2e_creation_test():
         # Verify category and cache_ttl_seconds have defaults
         assert "category" in provider, "Provider missing category"
         assert "cache_ttl_seconds" in provider, "Provider missing cache_ttl_seconds"
+
+    def test_data_provider_cache_is_scoped_by_inputs_and_bypasses_execution(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        """Repeated identical provider calls return from cache before worker dispatch."""
+        suffix = uuid4().hex[:8]
+        provider_name = f"e2e_cache_provider_{suffix}"
+        provider_path = f"e2e_cache_provider_{suffix}.py"
+        data_provider_content = f'''"""E2E Data Provider Cache Test"""
+from bifrost import data_provider
+
+@data_provider(
+    name="{provider_name}",
+    description="Test data provider cache"
+)
+async def {provider_name}(value: str = "default"):
+    """Returns input-sensitive test data."""
+    return [{{"value": value, "label": value}}]
+'''
+        result = write_and_register(
+            e2e_client,
+            platform_admin.headers,
+            provider_path,
+            data_provider_content,
+            provider_name,
+        )
+        provider_id = result["id"]
+
+        def execution_count() -> int:
+            response = e2e_client.get(
+                f"/api/executions?workflowId={provider_id}&limit=1000",
+                headers=platform_admin.headers,
+            )
+            assert response.status_code == 200, response.text
+            return len(response.json()["executions"])
+
+        def execute(value: str) -> dict:
+            response = e2e_client.post(
+                "/api/workflows/execute",
+                headers=platform_admin.headers,
+                json={
+                    "workflow_id": provider_id,
+                    "input_data": {"value": value},
+                    "transient": True,
+                },
+                timeout=30,
+            )
+            assert response.status_code == 200, response.text
+            data = response.json()
+            assert data["status"] == "Success"
+            return data
+
+        try:
+            initial_count = execution_count()
+
+            first = execute("alpha")
+            assert first["result"] == [{"value": "alpha", "label": "alpha"}]
+            assert execution_count() == initial_count + 1
+
+            cached = execute("alpha")
+            assert cached["result"] == [{"value": "alpha", "label": "alpha"}]
+            assert execution_count() == initial_count + 1
+
+            miss = execute("beta")
+            assert miss["result"] == [{"value": "beta", "label": "beta"}]
+            assert execution_count() == initial_count + 2
+        finally:
+            e2e_client.delete(
+                f"/api/files/editor?path={provider_path}",
+                headers=platform_admin.headers,
+            )
+
+    def test_non_transient_data_provider_execution_is_tracked_and_bypasses_cache(
+        self,
+        e2e_client,
+        platform_admin,
+    ):
+        """transient=False (manual Execute) must produce a tracked row, not a cache hit."""
+        suffix = uuid4().hex[:8]
+        provider_name = f"e2e_tracked_provider_{suffix}"
+        provider_path = f"e2e_tracked_provider_{suffix}.py"
+        data_provider_content = f'''"""E2E Data Provider Non-Transient Test"""
+from bifrost import data_provider
+
+@data_provider(
+    name="{provider_name}",
+    description="Test tracked data provider execution"
+)
+async def {provider_name}(value: str = "default"):
+    return [{{"value": value, "label": value}}]
+'''
+        result = write_and_register(
+            e2e_client,
+            platform_admin.headers,
+            provider_path,
+            data_provider_content,
+            provider_name,
+        )
+        provider_id = result["id"]
+
+        def execution_count() -> int:
+            response = e2e_client.get(
+                f"/api/executions?workflowId={provider_id}&limit=1000",
+                headers=platform_admin.headers,
+            )
+            assert response.status_code == 200, response.text
+            return len(response.json()["executions"])
+
+        def execute(transient: bool) -> dict:
+            response = e2e_client.post(
+                "/api/workflows/execute",
+                headers=platform_admin.headers,
+                json={
+                    "workflow_id": provider_id,
+                    "input_data": {"value": "gamma"},
+                    "transient": transient,
+                },
+                timeout=30,
+            )
+            assert response.status_code == 200, response.text
+            return response.json()
+
+        try:
+            initial_count = execution_count()
+
+            # Warm the cache with a transient call.
+            warm = execute(transient=True)
+            assert warm["status"] == "Success"
+            assert execution_count() == initial_count + 1
+
+            # transient=False must NOT be served from cache: it should produce
+            # a new tracked row AND return a real execution_id that the history
+            # detail page can navigate to.
+            tracked = execute(transient=False)
+            assert tracked["status"] == "Success"
+            assert tracked["is_transient"] is False
+            assert execution_count() == initial_count + 2
+
+            detail = e2e_client.get(
+                f"/api/executions/{tracked['execution_id']}",
+                headers=platform_admin.headers,
+            )
+            assert detail.status_code == 200, (
+                f"execution_id from non-transient run must be retrievable: {detail.text}"
+            )
+        finally:
+            e2e_client.delete(
+                f"/api/files/editor?path={provider_path}",
+                headers=platform_admin.headers,
+            )
 
 
 @pytest.mark.e2e

--- a/api/tests/unit/routers/test_health.py
+++ b/api/tests/unit/routers/test_health.py
@@ -66,6 +66,58 @@ class FakeRabbitMQConnection:
         self.is_closed = True
 
 
+class FakeRedisClient:
+    def __init__(self, ping_error: Exception | None = None):
+        self.ping_error = ping_error
+        self.ping_count = 0
+        self.close_count = 0
+
+    async def ping(self):
+        self.ping_count += 1
+        if self.ping_error:
+            raise self.ping_error
+
+    async def aclose(self):
+        self.close_count += 1
+
+
+class FakeS3Client:
+    def __init__(self, head_bucket_error: Exception | None = None):
+        self.head_bucket_error = head_bucket_error
+        self.head_bucket_count = 0
+
+    async def head_bucket(self, Bucket):
+        self.head_bucket_count += 1
+        if self.head_bucket_error:
+            raise self.head_bucket_error
+
+
+class FakeS3ClientContext:
+    def __init__(self, client: FakeS3Client):
+        self.client = client
+        self.enter_count = 0
+        self.exit_count = 0
+
+    async def __aenter__(self):
+        self.enter_count += 1
+        return self.client
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exit_count += 1
+        return None
+
+
+class FakeS3Session:
+    def __init__(self, head_bucket_error: Exception | None = None):
+        self.client = FakeS3Client(head_bucket_error)
+        self.context = FakeS3ClientContext(self.client)
+        self.create_client_count = 0
+
+    def create_client(self, *args, **kwargs):
+        self.create_client_count += 1
+        return self.context
+
+
 @pytest.mark.asyncio
 async def test_health_is_liveness_and_does_not_check_dependencies(monkeypatch):
     async def fail_if_called(*args, **kwargs):
@@ -203,6 +255,88 @@ async def test_rabbitmq_check_reports_unhealthy_when_channel_fails(monkeypatch):
         "error": "RuntimeError",
     }
     assert failed_connection.close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_check_reuses_cached_client(monkeypatch):
+    await health.close_health_check_clients()
+    clients: list[FakeRedisClient] = []
+
+    def from_url(*args, **kwargs):
+        client = FakeRedisClient()
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(health.redis, "from_url", from_url)
+
+    try:
+        first_name, first_component = await health.check_redis(_settings())
+        second_name, second_component = await health.check_redis(_settings())
+    finally:
+        await health.close_health_check_clients()
+
+    assert first_name == "redis"
+    assert second_name == "redis"
+    assert first_component == {"status": "healthy", "type": "redis"}
+    assert second_component == {"status": "healthy", "type": "redis"}
+    assert len(clients) == 1
+    assert clients[0].ping_count == 2
+    assert clients[0].close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_s3_check_reuses_cached_client(monkeypatch):
+    await health.close_health_check_clients()
+    sessions: list[FakeS3Session] = []
+
+    def get_session():
+        session = FakeS3Session()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(health, "get_session", get_session)
+
+    try:
+        first_name, first_component = await health.check_s3(_settings())
+        second_name, second_component = await health.check_s3(_settings())
+    finally:
+        await health.close_health_check_clients()
+
+    assert first_name == "s3"
+    assert second_name == "s3"
+    assert first_component == {"status": "healthy", "type": "s3"}
+    assert second_component == {"status": "healthy", "type": "s3"}
+    assert len(sessions) == 1
+    assert sessions[0].create_client_count == 1
+    assert sessions[0].context.enter_count == 1
+    assert sessions[0].client.head_bucket_count == 2
+    assert sessions[0].context.exit_count == 1
+
+
+@pytest.mark.asyncio
+async def test_s3_check_closes_cached_client_when_settings_change(monkeypatch):
+    await health.close_health_check_clients()
+    sessions: list[FakeS3Session] = []
+
+    def get_session():
+        session = FakeS3Session()
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(health, "get_session", get_session)
+
+    try:
+        await health.check_s3(_settings())
+        settings = _settings()
+        settings.s3_bucket = "other-bucket-secret"
+        await health.check_s3(settings)
+    finally:
+        await health.close_health_check_clients()
+
+    assert len(sessions) == 2
+    assert [session.create_client_count for session in sessions] == [1, 1]
+    assert sessions[0].context.exit_count == 1
+    assert sessions[1].context.exit_count == 1
 
 
 @pytest.mark.asyncio

--- a/api/tests/unit/services/execution/test_service.py
+++ b/api/tests/unit/services/execution/test_service.py
@@ -91,6 +91,8 @@ class TestGetWorkflowForExecution:
         mock_workflow.value = 10.0
         mock_workflow.execution_mode = "async"
         mock_workflow.organization_id = org_id
+        mock_workflow.type = "workflow"
+        mock_workflow.cache_ttl_seconds = 0
 
         mock_wf_result = MagicMock()
         mock_wf_result.scalar_one_or_none.return_value = mock_workflow
@@ -101,6 +103,7 @@ class TestGetWorkflowForExecution:
         expected_keys = {
             "name", "function_name", "path", "timeout_seconds",
             "time_saved", "value", "execution_mode", "organization_id",
+            "type", "cache_ttl_seconds",
         }
         assert set(result.keys()) == expected_keys
         assert "code" not in result
@@ -109,6 +112,8 @@ class TestGetWorkflowForExecution:
         assert result["path"] == "workflows/test.py"
         assert result["timeout_seconds"] == 300
         assert result["organization_id"] == str(org_id)
+        assert result["type"] == "workflow"
+        assert result["cache_ttl_seconds"] == 0
 
     @pytest.mark.asyncio
     async def test_workflow_not_found_raises(self):

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -3645,22 +3645,22 @@ export interface paths {
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        get: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        get: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        put: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        put: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        post: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        post: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        delete: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        delete: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         options?: never;
         head?: never;
         patch?: never;
@@ -27555,7 +27555,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -27588,7 +27588,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -27621,7 +27621,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -27654,7 +27654,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {

--- a/docs/spot-checks/2026-05-23-issue-287-health-ready-profile.md
+++ b/docs/spot-checks/2026-05-23-issue-287-health-ready-profile.md
@@ -1,0 +1,101 @@
+# Issue 287 Readiness Probe Profiling
+
+Purpose: reproduce the profile reported in issue #287 and verify that the
+readiness fix removes repeated S3/Redis client construction before shipping.
+
+## Issue Signal
+
+The latest issue comment reports that a prod py-spy capture taken while
+hammering `/api/workflows/execute` had this shape:
+
+| Frame | Sample presence |
+|---|---:|
+| `_checked_component` | 48.4% |
+| `check_s3` | 46.4% |
+| `head_bucket` | 38.9% |
+| `botocore/loaders load_data_with_path` | 25.4% |
+| `aiobotocore _create_client` | 22.8% |
+| `json.raw_decode` | 22.8% |
+
+The important part is not S3 I/O itself. The expensive shape is
+`check_s3 -> get_session -> create_client -> botocore loader -> JSON decode`,
+which means the health probe is rebuilding the S3 client and rereading
+botocore metadata on each readiness check.
+
+## Local Reproduction
+
+Baseline was captured from `origin/main` at `3a086b96` in worktree:
+
+```bash
+/home/jack/GitHub/bifrost/.worktrees/287-health-profile-main
+```
+
+Patched was captured from branch `287-data-provider-overhead` after warming the
+readiness endpoint once.
+
+Both captures sampled the API worker while hammering `/health/ready`:
+
+```bash
+sudo -n /tmp/bifrost-pyspy/bin/py-spy record \
+  --pid "$worker_pid" \
+  --duration 15 \
+  --rate 20 \
+  --nonblocking \
+  --format raw \
+  --output /tmp/bifrost-287-profile/<label>.raw
+```
+
+## Results
+
+| Frame | `origin/main` | patched |
+|---|---:|---:|
+| `_checked_component` | 265 / 273 (97.1%) | 58 / 186 (31.2%) |
+| `check_s3` | 265 / 273 (97.1%) | 28 / 186 (15.1%) |
+| `head_bucket` | 264 / 273 (96.7%) | 27 / 186 (14.5%) |
+| `aiobotocore get_session` | 52 / 273 (19.0%) | 0 / 186 (0.0%) |
+| `aiobotocore _create_client` | 197 / 273 (72.2%) | 0 / 186 (0.0%) |
+| `botocore load_data_with_path` | 134 / 273 (49.1%) | 0 / 186 (0.0%) |
+| `json raw_decode` | 123 / 273 (45.1%) | 0 / 186 (0.0%) |
+| `check_redis` | 0 / 273 (0.0%) | 4 / 186 (2.2%) |
+| `redis from_url` | 0 / 273 (0.0%) | 0 / 186 (0.0%) |
+| `redis make_connection` | 0 / 273 (0.0%) | 0 / 186 (0.0%) |
+| `check_rabbitmq` | 0 / 273 (0.0%) | 20 / 186 (10.8%) |
+
+Artifacts:
+
+| Artifact | Path |
+|---|---|
+| Baseline raw | `/tmp/bifrost-287-profile/baseline.raw` |
+| Baseline flamegraph | `/tmp/bifrost-287-profile/baseline.svg` |
+| Patched raw | `/tmp/bifrost-287-profile/patched-clients.raw` |
+| Patched flamegraph | `/tmp/bifrost-287-profile/patched-clients.svg` |
+
+## Pass Criteria
+
+- Readiness still checks S3 with `head_bucket`.
+- Repeated readiness checks reuse the S3 health client.
+- Repeated readiness checks reuse the Redis health client.
+- Any cached health client is closed on app shutdown.
+- A failed S3/Redis health check discards the cached client so the next check can
+  reconnect.
+- Changing S3 settings closes the old S3 client and creates a new one.
+- The patched flamegraph has no `aiobotocore _create_client`,
+  `botocore load_data_with_path`, or `json raw_decode` frames under readiness.
+
+## Verification
+
+Commands run from `/home/jack/GitHub/bifrost/.worktrees/287-data-provider-overhead`:
+
+```bash
+cd api && ruff check .
+cd api && pyright
+./test.sh tests/unit/routers/test_health.py -v
+./test.sh
+```
+
+Observed results:
+
+- `ruff check .`: passed.
+- `pyright`: 0 errors, 0 warnings, 0 informations.
+- `./test.sh tests/unit/routers/test_health.py -v`: 16 passed.
+- `./test.sh`: 3939 passed, 230 warnings.


### PR DESCRIPTION
## Summary

- Preserve data-provider workflow cache hits across router and execution handoff.
- Reuse Redis and S3 readiness clients instead of recreating them on every `/health/ready` check.
- Add health-router tests for Redis/S3 client reuse and S3 client rebuild on settings changes.
- Add a spot-check note with baseline-vs-patched py-spy captures for the issue #287 health-probe graph.

## Profiling proof

Baseline `origin/main` while hammering `/health/ready`:

- `aiobotocore _create_client`: 197 / 273 samples (72.2%)
- `botocore load_data_with_path`: 134 / 273 samples (49.1%)
- `json raw_decode`: 123 / 273 samples (45.1%)

Patched branch after warming the reusable client:

- `aiobotocore _create_client`: 0 / 186 samples (0.0%)
- `botocore load_data_with_path`: 0 / 186 samples (0.0%)
- `json raw_decode`: 0 / 186 samples (0.0%)

Readiness still calls S3 `head_bucket`; it just no longer rebuilds the S3 client and botocore metadata path on each probe.

Artifacts are documented in `docs/spot-checks/2026-05-23-issue-287-health-ready-profile.md`.

## Verification

- `git diff --check`
- `cd api && ruff check .`
- `cd api && pyright`
- `./test.sh tests/unit/routers/test_health.py -v`
- `./test.sh` full unit suite: 3939 passed

Fixes #287
