### PR TITLE
revert: roll back process-pool zombie-reap (#243) — caused crash storm

### DIFF
--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -33,7 +33,7 @@ import subprocess
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from enum import Enum
 from queue import Empty
 from typing import Any, Awaitable, Callable
@@ -47,9 +47,6 @@ from src.services.execution.simple_worker import install_requirements
 from src.services.execution.template_process import TemplateProcess
 
 logger = logging.getLogger(__name__)
-
-_CLEAN_EXIT_RESULT_GRACE = timedelta(seconds=10)
-_EXITED_PROCESS_RESULT_READ_TIMEOUT = 0.25
 
 
 def _get_installed_packages() -> list[dict[str, str]]:
@@ -150,9 +147,6 @@ class ProcessHandle:
     # Used by the orphan sweep to wait out the grace-sleep window before treating
     # a KILLED handle as truly stuck.
     killed_at: datetime | None = None
-    # Timestamp set when health checks first observe a cleanly exited process
-    # whose result has not reached the result queue yet.
-    clean_exit_observed_at: datetime | None = None
 
     @property
     def is_alive(self) -> bool:
@@ -177,24 +171,7 @@ class _PidWrapper:
         self.pid = pid
         self.exitcode: int | None = None
 
-    def _reap_if_exited(self) -> bool:
-        """Reap the child if it has exited, returning True when no child remains."""
-        if self.exitcode is not None:
-            return True
-        try:
-            pid, status = os.waitpid(self.pid, os.WNOHANG)
-            if pid == 0:
-                return False
-            self.exitcode = os.waitstatus_to_exitcode(status)
-            return True
-        except ChildProcessError:
-            # Already reaped elsewhere.
-            self.exitcode = 0 if self.exitcode is None else self.exitcode
-            return True
-
     def is_alive(self) -> bool:
-        if self._reap_if_exited():
-            return False
         try:
             os.kill(self.pid, 0)
             return True
@@ -208,10 +185,11 @@ class _PidWrapper:
                 # Non-blocking waitpid with polling
                 deadline = time.monotonic() + timeout
                 while time.monotonic() < deadline:
-                    if self._reap_if_exited():
+                    pid, status = os.waitpid(self.pid, os.WNOHANG)
+                    if pid != 0:
+                        self.exitcode = os.waitstatus_to_exitcode(status)
                         return
                     time.sleep(0.1)
-                self._reap_if_exited()
             else:
                 _, status = os.waitpid(self.pid, 0)
                 self.exitcode = os.waitstatus_to_exitcode(status)
@@ -630,13 +608,6 @@ class ProcessPoolManager:
                 pass
             handle.process.join(timeout=1)
 
-    async def _reap_process(self, handle: ProcessHandle, timeout: float = 1.0) -> None:
-        """Reap a raw forked child so completed on-demand work does not become a zombie."""
-        try:
-            await asyncio.to_thread(handle.process.join, timeout)
-        except Exception as e:
-            logger.debug(f"Failed to reap process {handle.id}: {e}")
-
     def _get_idle_process(self) -> ProcessHandle | None:
         """
         Get an IDLE process from the pool.
@@ -730,7 +701,6 @@ class ProcessPoolManager:
             timeout_seconds=timeout,
         )
         idle.result_reported = False
-        idle.clean_exit_observed_at = None
 
         # Send to process
         idle.work_queue.put_nowait(execution_id)
@@ -1156,33 +1126,8 @@ class ProcessPoolManager:
         """
         to_remove: list[str] = []
 
-        for process_id, handle in list(self.processes.items()):
+        for process_id, handle in self.processes.items():
             if not handle.is_alive and handle.state != ProcessState.KILLED:
-                try:
-                    # A forked child can be reaped before the pipe payload is
-                    # visible to poll(0), especially on loaded CI runners.
-                    # Give completed children a short blocking read before
-                    # deciding the execution crashed.
-                    result = handle.result_queue.get(
-                        block=True,
-                        timeout=_EXITED_PROCESS_RESULT_READ_TIMEOUT,
-                    )
-                    if isinstance(result, dict):
-                        await self._handle_result(handle, result)
-                        continue
-                except Empty:
-                    if (
-                        handle.process.exitcode == 0
-                        and handle.current_execution
-                        and not handle.result_reported
-                    ):
-                        now = datetime.now(timezone.utc)
-                        if handle.clean_exit_observed_at is None:
-                            handle.clean_exit_observed_at = now
-
-                        if now - handle.clean_exit_observed_at < _CLEAN_EXIT_RESULT_GRACE:
-                            continue
-
                 # Case A: unexpected crash
                 logger.warning(
                     f"Process {process_id} crashed "
@@ -1215,8 +1160,6 @@ class ProcessPoolManager:
 
         # Remove crashed/orphaned processes
         for process_id in to_remove:
-            handle = self.processes[process_id]
-            await self._reap_process(handle)
             del self.processes[process_id]
 
         # Spawn replacements to maintain min_workers
@@ -1380,7 +1323,6 @@ class ProcessPoolManager:
 
         # On-demand mode: child exits after one execution, just clean up
         if self.min_workers == 0:
-            await self._reap_process(handle)
             if handle.id in self.processes:
                 del self.processes[handle.id]
             # Forward result to callback

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -16,7 +16,6 @@ NOTE: These tests use mocks to avoid spawning real processes.
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from queue import Empty
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -26,7 +25,6 @@ from src.services.execution.process_pool import (
     ProcessHandle,
     ProcessPoolManager,
     ProcessState,
-    _PidWrapper,
 )
 
 
@@ -994,65 +992,6 @@ class TestMinWorkersZero:
                     assert len(pool_zero.processes) == 0
                     mock_spawn.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_handle_result_reaps_completed_child(self):
-        """On-demand children should be joined after returning a result."""
-        callback = AsyncMock()
-        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
-
-        mock_process = MagicMock()
-        handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.BUSY,
-            work_queue=MagicMock(),
-            result_queue=MagicMock(),
-            started_at=datetime.now(timezone.utc),
-            current_execution=ExecutionInfo(
-                execution_id="exec-123",
-                started_at=datetime.now(timezone.utc),
-                timeout_seconds=300,
-            ),
-        )
-        pool.processes[handle.id] = handle
-
-        result = {
-            "type": "result",
-            "execution_id": "exec-123",
-            "success": True,
-            "result": {},
-        }
-
-        await pool._handle_result(handle, result)
-
-        mock_process.join.assert_called_once_with(1.0)
-        assert handle.id not in pool.processes
-        callback.assert_awaited_once_with(result)
-
-
-class TestPidWrapper:
-    """Tests for raw PID lifecycle handling."""
-
-    def test_is_alive_reaps_exited_child(self):
-        """A zombie child should be reaped and reported not alive."""
-        wrapper = _PidWrapper(12345)
-
-        with patch("src.services.execution.process_pool.os.waitpid", return_value=(12345, 0)):
-            assert wrapper.is_alive() is False
-
-        assert wrapper.exitcode == 0
-
-    def test_is_alive_keeps_running_child_alive(self):
-        """A running child should still be reported alive."""
-        wrapper = _PidWrapper(12345)
-
-        with patch("src.services.execution.process_pool.os.waitpid", return_value=(0, 0)):
-            with patch("src.services.execution.process_pool.os.kill") as mock_kill:
-                assert wrapper.is_alive() is True
-
-        mock_kill.assert_called_once_with(12345, 0)
-
 
 class TestAdmissionControl:
     """Tests for cgroup-based admission control."""
@@ -1330,116 +1269,3 @@ class TestCrashedProcessReport:
 
         # Handle still removed from pool (cleanup still happens)
         assert "process-sigkill-2" not in pool.processes
-
-    @pytest.mark.asyncio
-    async def test_exited_worker_with_queued_result_is_not_reported_as_crash(self):
-        """A completed child can exit before the result loop reads its pipe."""
-        callback = AsyncMock()
-        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
-
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = False
-        mock_process.exitcode = 0
-
-        result = {
-            "type": "result",
-            "execution_id": "exec-finished",
-            "success": True,
-            "result": {},
-        }
-        result_queue = MagicMock()
-        result_queue.get.return_value = result
-
-        handle = ProcessHandle(
-            id="process-finished",
-            process=mock_process,
-            pid=99997,
-            state=ProcessState.BUSY,
-            work_queue=MagicMock(),
-            result_queue=result_queue,
-            started_at=datetime.now(timezone.utc),
-            current_execution=ExecutionInfo(
-                execution_id="exec-finished",
-                started_at=datetime.now(timezone.utc),
-                timeout_seconds=300,
-            ),
-        )
-        pool.processes[handle.id] = handle
-
-        await pool._check_process_health()
-
-        callback.assert_awaited_once_with(result)
-        mock_process.join.assert_called_once_with(1.0)
-        assert handle.id not in pool.processes
-
-    @pytest.mark.asyncio
-    async def test_clean_exit_waits_for_result_queue_delivery(self):
-        """A cleanly exited worker gets a short grace period for result delivery."""
-        pool = ProcessPoolManager(min_workers=0, max_workers=2)
-        pool.on_result = AsyncMock()
-
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = False
-        mock_process.exitcode = 0
-
-        result_queue = MagicMock()
-        result_queue.get.side_effect = Empty
-
-        handle = ProcessHandle(
-            id="process-clean-exit",
-            process=mock_process,
-            pid=99996,
-            state=ProcessState.BUSY,
-            work_queue=MagicMock(),
-            result_queue=result_queue,
-            started_at=datetime.now(timezone.utc),
-            current_execution=ExecutionInfo(
-                execution_id="exec-clean-exit",
-                started_at=datetime.now(timezone.utc),
-                timeout_seconds=300,
-            ),
-        )
-        pool.processes[handle.id] = handle
-
-        await pool._check_process_health()
-
-        pool.on_result.assert_not_awaited()
-        assert handle.id in pool.processes
-        assert handle.clean_exit_observed_at is not None
-
-    @pytest.mark.asyncio
-    async def test_clean_exit_without_result_after_grace_is_reported(self):
-        """A clean exit without a delivered result eventually reports failure."""
-        pool = ProcessPoolManager(min_workers=0, max_workers=2)
-        pool.on_result = AsyncMock()
-
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = False
-        mock_process.exitcode = 0
-        mock_process.join = MagicMock()
-
-        result_queue = MagicMock()
-        result_queue.get.side_effect = Empty
-
-        handle = ProcessHandle(
-            id="process-stale-clean-exit",
-            process=mock_process,
-            pid=99995,
-            state=ProcessState.BUSY,
-            work_queue=MagicMock(),
-            result_queue=result_queue,
-            started_at=datetime.now(timezone.utc),
-            current_execution=ExecutionInfo(
-                execution_id="exec-stale-clean-exit",
-                started_at=datetime.now(timezone.utc),
-                timeout_seconds=300,
-            ),
-            clean_exit_observed_at=datetime.now(timezone.utc) - timedelta(seconds=11),
-        )
-        pool.processes[handle.id] = handle
-
-        await pool._check_process_health()
-
-        pool.on_result.assert_awaited_once()
-        mock_process.join.assert_called_once_with(1.0)
-        assert handle.id not in pool.processes


### PR DESCRIPTION
## Summary

Reverts the `process_pool.py` / `test_process_pool.py` portions of #243 and the follow-up grace bump from #280. Restores the state immediately before #243 landed.

## Why

#243 introduced `_PidWrapper._reap_if_exited` which calls `os.waitpid(pid, WNOHANG)` on every `is_alive()` check, and treats `ChildProcessError` (ECHILD) as "child exited cleanly with code 0". In production this fires while the child is still actively running its workflow — `is_alive` returns False, `_check_process_health` then declares the still-running execution as a `ProcessCrashError`.

## Symptoms in prod (covi)

- "Worker process crashed unexpectedly" first observed **2026-05-22 03:29 UTC** — within 10 minutes of #243's deploy.
- ~10-30 crashes/hour sustained since.
- Followed by "No idle process available after timeout" cascades when crashed workers don't free their pool slots cleanly.

## Reproduction

In this worktree's debug stack, **before** revert (#243 + #280 applied):

```bash
for i in $(seq 1 30); do bifrost workflows execute crash_repro & done
```

```
Statuses: {'Failed': 12, 'Success': 19}
Of failures: 3 × "Worker process crashed unexpectedly"
              9 × "No idle process available after timeout"
```

**After** revert, same workload, same stack:

```
Statuses: {'Failed': 10, 'Success': 20}
Of failures: 0 × crashes
             10 × idle-process timeouts (pre-existing, unrelated)
```

The crash failure mode is gone. The idle-timeout failure mode is a separate, pre-existing issue (the `_idle_condition.notify_all()` at line 1427 is only reached in the persistent-worker branch; on-demand workers exit without notifying waiters). Will be filed as its own issue.

## Out of scope

The legitimate goal of #243 (avoid zombie children, avoid reporting a finished execution as crashed when its result is queued) still stands. A follow-up fix should:

- Narrow the ECHILD path — ECHILD does not imply clean exit, only "kernel has no record of this PID".
- Not sample `waitpid(WNOHANG)` during normal `is_alive()` calls; only when we're already certain the child should be dead.

## Test plan

- [x] 30-parallel stress test in debug stack — 0 crashes after revert (vs 3 before)
- [ ] CI green