### PR TITLE
refactor(process-pool): rip out dead persistent-pool code paths

### DIFF
--- a/api/src/config.py
+++ b/api/src/config.py
@@ -81,14 +81,11 @@ class Settings(BaseSettings):
         description="Max concurrent workflow executions (controls RabbitMQ prefetch)"
     )
 
-    # Process Pool Configuration
-    min_workers: int = Field(
-        default=2,
-        description="Minimum worker processes to maintain (warm pool)"
-    )
+    # Process Pool Configuration (on-demand only — every execution forks
+    # a fresh one-shot worker, capped at `max_workers` concurrent forks).
     max_workers: int = Field(
         default=10,
-        description="Maximum worker processes for scaling"
+        description="Maximum concurrent worker processes (queue cap)"
     )
     execution_timeout_seconds: int = Field(
         default=300,
@@ -97,14 +94,6 @@ class Settings(BaseSettings):
     graceful_shutdown_seconds: int = Field(
         default=5,
         description="Seconds to wait after SIGTERM before SIGKILL"
-    )
-    recycle_after_executions: int = Field(
-        default=100,
-        description="Recycle process after N executions (0 = never). Safety net for memory leaks."
-    )
-    recycle_memory_mb: int = Field(
-        default=768,
-        description="Recycle process when RSS exceeds this threshold in MB (0 = disabled)"
     )
     worker_heartbeat_interval_seconds: int = Field(
         default=10,

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -1,22 +1,27 @@
 """
 Process Pool Manager for Execution Isolation.
 
-This module provides a pool of long-lived worker processes that can handle
-concurrent executions. Unlike the one-process-per-execution model, this
-approach reuses processes for multiple executions, improving efficiency.
+Each execution forks a fresh worker process from a long-lived template
+and the worker exits after returning its result. There is no warm pool;
+the only throttles are `max_workers` (concurrency cap) and a cgroup
+memory-pressure check on the way in.
 
 Key features:
-- Dynamic scaling between min_workers and max_workers
+- One-shot worker processes (fork → run one execution → exit)
+- Cap concurrent forks at `max_workers`; queued executions wait on a
+  condition variable that is notified when a worker exits
+- Memory-pressure admission control (cgroup working-set)
 - Automatic timeout handling with graceful shutdown (SIGTERM -> SIGKILL)
-- Crash detection and process replacement
+- Crash detection
 - Heartbeat publishing for UI visibility
-- Manual process recycling via API
+- Drain + template restart after pip install (so future forks pick up
+  newly installed packages); also exposed as a manual "recycle" RPC
 
 Architecture:
     ProcessPoolManager (runs in consumer process)
         |
-        +-- min_workers to max_workers processes
-        +-- Each process: work_queue (in) + result_queue (out)
+        +-- up to max_workers concurrent one-shot children
+        +-- Each child: work_queue (in) + result_queue (out)
         +-- Monitor loop checks health and timeouts
         +-- Result loop collects execution results
         +-- Heartbeat loop publishes status to Redis/WebSocket
@@ -74,13 +79,13 @@ class ProcessState(Enum):
     """
     State of a worker process in the pool.
 
-    States:
-    - IDLE: Ready to accept work
-    - BUSY: Currently executing
-    - KILLED: Process was terminated (pending removal)
+    Workers are one-shot — they only ever exist in BUSY (running their
+    single execution) or KILLED (terminating). IDLE is kept as a
+    no-longer-used value purely for any external consumer that may parse
+    the heartbeat shape; nothing in this module emits it.
     """
 
-    IDLE = "idle"
+    IDLE = "idle"  # deprecated; unused since on-demand-only refactor
     BUSY = "busy"
     KILLED = "killed"
 
@@ -137,7 +142,6 @@ class ProcessHandle:
     started_at: datetime
     current_execution: ExecutionInfo | None = None
     executions_completed: int = 0
-    pending_recycle: bool = False  # Mark for recycle after current execution
     # True once we have *attempted* to fire on_result for current_execution
     # (set before the await; stays True even if on_result raised). Reset when
     # a new execution is assigned. Used by the orphan sweep to detect handles
@@ -224,18 +228,15 @@ def _get_private_dirty_kb(pid: int) -> int:
 
 class ProcessPoolManager:
     """
-    Manages a pool of worker processes for execution isolation.
+    Manages a pool of one-shot worker processes for execution isolation.
 
-    The ProcessPoolManager:
-    1. Spawns min_workers processes on startup
-    2. Scales up to max_workers under load
-    3. Routes executions to IDLE processes
-    4. Monitors for timeouts and crashes
-    5. Publishes heartbeats for UI visibility
+    Each execution forks a fresh child from the template process and the
+    child exits after returning its result. There is no warm pool — the
+    `max_workers` cap is the only throttle, plus a memory-pressure check
+    on the way in.
 
     Usage:
         pool = ProcessPoolManager(
-            min_workers=2,
             max_workers=10,
             on_result=handle_result,
         )
@@ -250,12 +251,9 @@ class ProcessPoolManager:
 
     def __init__(
         self,
-        min_workers: int = 2,
         max_workers: int = 10,
         execution_timeout_seconds: int = 300,
         graceful_shutdown_seconds: int = 5,
-        recycle_after_executions: int = 0,
-        recycle_memory_mb: int = 0,
         heartbeat_interval_seconds: int = 10,
         registration_ttl_seconds: int = 30,
         on_result: ResultCallback | None = None,
@@ -264,22 +262,16 @@ class ProcessPoolManager:
         Initialize the process pool manager.
 
         Args:
-            min_workers: Minimum number of worker processes to maintain
-            max_workers: Maximum number of worker processes
+            max_workers: Maximum number of concurrent worker processes
             execution_timeout_seconds: Default execution timeout in seconds
             graceful_shutdown_seconds: Seconds to wait between SIGTERM and SIGKILL
-            recycle_after_executions: Recycle process after N executions (0 = never)
-            recycle_memory_mb: Recycle process when RSS exceeds this MB (0 = disabled)
             heartbeat_interval_seconds: Interval for heartbeat publications
             registration_ttl_seconds: TTL for worker registration in Redis
             on_result: Async callback for handling execution results
         """
-        self.min_workers = min_workers
         self.max_workers = max_workers
         self.execution_timeout_seconds = execution_timeout_seconds
         self.graceful_shutdown_seconds = graceful_shutdown_seconds
-        self.recycle_after_executions = recycle_after_executions
-        self.recycle_memory_mb = recycle_memory_mb
         self.heartbeat_interval_seconds = heartbeat_interval_seconds
         self.registration_ttl_seconds = registration_ttl_seconds
         self.on_result = on_result
@@ -308,8 +300,10 @@ class ProcessPoolManager:
         # Redis connection
         self._redis: redis.Redis | None = None  # type: ignore[type-arg]
 
-        # Lock for idle process waiting
-        self._idle_condition = asyncio.Condition()
+        # Notified when a worker exits and frees a slot. Waiters in
+        # route_execution use this to wake up the moment a slot opens
+        # rather than spinning on a timeout.
+        self._slot_condition = asyncio.Condition()
 
         # Template process for fork-based workers
         self._template: TemplateProcess | None = None
@@ -363,55 +357,51 @@ class ProcessPoolManager:
 
     async def drain_and_restart_template(self, drain_timeout: float = 60.0) -> None:
         """
-        Drain all existing workers, restart the template process, then
-        respawn workers from the fresh template.
+        Drain in-flight executions and restart the template process so
+        subsequent forks see fresh sys.modules.
 
-        Called after pip install so children get a fresh sys.modules
-        that can see newly installed packages.
+        Called after pip install (and from the manual recycle RPCs).
+        While the restart lock is held, new routes block in
+        `route_execution`, so no work is lost — it just waits.
 
         Serialized via _restart_lock so concurrent package installs
         wait for the previous restart to complete rather than racing.
         """
         async with self._restart_lock:
-            # 1. Mark all for recycle (stops routing new work to them)
-            for handle in list(self.processes.values()):
-                handle.pending_recycle = True
-
-            # 2. Wait for busy processes to finish (bounded)
+            # Wait for in-flight one-shot workers to finish (bounded).
             deadline = time.monotonic() + drain_timeout
             while time.monotonic() < deadline:
-                busy = [h for h in self.processes.values() if h.state == ProcessState.BUSY]
-                if not busy:
+                if not self.processes:
                     break
                 await asyncio.sleep(0.2)
 
-            # 3. Terminate all remaining processes (don't spawn replacements yet)
+            # Terminate any survivors that didn't drain in time.
             for handle in list(self.processes.values()):
                 if handle.id in self.processes:
                     del self.processes[handle.id]
                 await self._terminate_process(handle)
 
-            # 4. Restart template with fresh sys.modules
+            # Wake anyone blocked on a slot — drain may have removed
+            # everything from self.processes while the route-side waiter
+            # was still parked.
+            await self._notify_slot_free()
+
+            # Restart template with fresh sys.modules — future forks
+            # (driven by route_execution) will see newly installed packages.
             await self.restart_template()
 
-            # 5. Respawn to min_workers
-            for _ in range(self.min_workers):
-                self._fork_process()
-
-    def _fork_process(self, persistent: bool | None = None) -> ProcessHandle:
+    def _fork_process(self) -> ProcessHandle:
         """
-        Create a new worker process by forking from the template.
+        Create a new one-shot worker process by forking from the template.
 
         Requires the template process to be running. The caller must
         ensure the pool has been started (and therefore _start_template
         has completed) before invoking this method.
 
-        Args:
-            persistent: If None, inferred from self.min_workers > 0.
-                        If True, child loops. If False, child runs once.
-
         Returns:
-            ProcessHandle instance for the new forked worker.
+            ProcessHandle for the new forked worker. State starts at BUSY
+            because every fork is claimed by the routing caller (there is
+            no warm pool / idle state).
 
         Raises:
             RuntimeError: If the template process is not alive.
@@ -422,23 +412,21 @@ class ProcessPoolManager:
                 "ProcessPoolManager.start() must complete before forking workers."
             )
 
-        if persistent is None:
-            persistent = self.min_workers > 0
-
         self._process_counter += 1
         process_id = f"process-{self._process_counter}"
 
-        # Fork from template (COW memory sharing)
+        # Fork from template (COW memory sharing). persistent=False is
+        # the only mode: child runs one execution then exits.
         child_pid, work_queue, result_queue = self._template.fork(
             worker_id=process_id,
-            persistent=persistent,
+            persistent=False,
         )
 
         handle = ProcessHandle(
             id=process_id,
             process=_PidWrapper(child_pid),
             pid=child_pid,
-            state=ProcessState.IDLE,
+            state=ProcessState.BUSY,
             work_queue=work_queue,
             result_queue=result_queue,
             started_at=datetime.now(timezone.utc),
@@ -447,7 +435,7 @@ class ProcessPoolManager:
         )
 
         self.processes[process_id] = handle
-        logger.info(f"Created worker {process_id} (PID={handle.pid}, persistent={persistent})")
+        logger.info(f"Created worker {process_id} (PID={handle.pid})")
         return handle
 
     async def start(self) -> None:
@@ -455,7 +443,7 @@ class ProcessPoolManager:
         Start the pool manager and spawn initial workers.
 
         This method:
-        1. Spawns min_workers processes
+        1. Starts the template process (so future forks are fast)
         2. Registers in Redis
         3. Starts background tasks (monitor, result, heartbeat loops)
         """
@@ -464,8 +452,7 @@ class ProcessPoolManager:
             return
 
         logger.info(
-            f"ProcessPoolManager starting with min_workers={self.min_workers}, "
-            f"max_workers={self.max_workers}"
+            f"ProcessPoolManager starting (max_workers={self.max_workers})"
         )
 
         self._started = True
@@ -480,10 +467,6 @@ class ProcessPoolManager:
 
         # Start template process (loads deps, ready to fork)
         await self._start_template()
-
-        # Spawn initial pool
-        for _ in range(self.min_workers):
-            self._fork_process()
 
         # Register in Redis
         await self._register_worker()
@@ -510,9 +493,7 @@ class ProcessPoolManager:
             name="pool-command-listener"
         )
 
-        logger.info(
-            f"ProcessPoolManager started with {len(self.processes)} workers"
-        )
+        logger.info("ProcessPoolManager started")
 
     async def stop(self) -> None:
         """
@@ -608,40 +589,25 @@ class ProcessPoolManager:
                 pass
             handle.process.join(timeout=1)
 
-    def _get_idle_process(self) -> ProcessHandle | None:
+    async def _wait_for_slot(self, timeout: float = 30.0) -> bool:
         """
-        Get an IDLE process from the pool.
+        Wait until `len(self.processes) < self.max_workers`.
 
-        Returns:
-            ProcessHandle with IDLE state, or None if no idle processes
+        Used by route_execution when the pool is saturated. Returns True
+        as soon as a slot opens (a worker exited and notified the
+        condition), or False if `timeout` seconds elapse first.
         """
-        for handle in self.processes.values():
-            # Skip processes that are pending recycle - they're about to be terminated
-            if handle.pending_recycle:
-                continue
-            if handle.state == ProcessState.IDLE and handle.is_alive:
-                return handle
-        return None
-
-    async def _wait_for_idle_process(self, timeout: float = 30.0) -> ProcessHandle | None:
-        """
-        Wait for an idle process to become available.
-
-        Args:
-            timeout: Maximum seconds to wait
-
-        Returns:
-            ProcessHandle with IDLE state, or None if timeout
-        """
-        async with self._idle_condition:
+        async with self._slot_condition:
             try:
                 await asyncio.wait_for(
-                    self._idle_condition.wait_for(lambda: self._get_idle_process() is not None),
-                    timeout=timeout
+                    self._slot_condition.wait_for(
+                        lambda: len(self.processes) < self.max_workers
+                    ),
+                    timeout=timeout,
                 )
-                return self._get_idle_process()
+                return True
             except asyncio.TimeoutError:
-                return None
+                return False
 
     async def route_execution(
         self,
@@ -649,10 +615,11 @@ class ProcessPoolManager:
         context: dict[str, Any],
     ) -> None:
         """
-        Route an execution to an idle process.
+        Fork a one-shot worker for this execution.
 
-        The context is written to Redis, and the execution_id is sent
-        to the process via the work queue.
+        Waits for a free slot under the `max_workers` cap if the pool is
+        saturated. The context is written to Redis, and the execution_id
+        is sent to the forked child via the work queue.
 
         Args:
             execution_id: Unique identifier for the execution
@@ -678,35 +645,30 @@ class ProcessPoolManager:
                 f"exceeds {settings.memory_pressure_threshold:.0%} threshold"
             )
 
-        # Find or create idle process
-        idle = self._get_idle_process()
-        if idle is None:
-            # Scale up if possible
-            if len(self.processes) < self.max_workers:
-                idle = self._fork_process()
-            else:
-                # Wait for a process to become idle
-                idle = await self._wait_for_idle_process()
-                if idle is None:
-                    raise RuntimeError("No idle process available after timeout")
+        # Wait for a slot under the max_workers cap. Worker exits notify
+        # _slot_condition, so this wakes immediately once a slot frees.
+        if len(self.processes) >= self.max_workers:
+            if not await self._wait_for_slot():
+                raise RuntimeError("No worker slot available after timeout")
+
+        # Fork the worker. _fork_process returns a handle already in BUSY.
+        handle = self._fork_process()
 
         # Get timeout from context or use default
         timeout = context.get("timeout_seconds", self.execution_timeout_seconds)
 
-        # Assign work
-        idle.state = ProcessState.BUSY
-        idle.current_execution = ExecutionInfo(
+        handle.current_execution = ExecutionInfo(
             execution_id=execution_id,
             started_at=datetime.now(timezone.utc),
             timeout_seconds=timeout,
         )
-        idle.result_reported = False
+        handle.result_reported = False
 
-        # Send to process
-        idle.work_queue.put_nowait(execution_id)
+        # Send execution_id to the child
+        handle.work_queue.put_nowait(execution_id)
 
         logger.info(
-            f"Routed {execution_id[:8]}... to {idle.id} "
+            f"Routed {execution_id[:8]}... to {handle.id} "
             f"(timeout={timeout}s)"
         )
 
@@ -760,7 +722,6 @@ class ProcessPoolManager:
 
                 await self._check_timeouts()
                 await self._check_process_health()
-                await self._maybe_scale_down()
 
                 # Periodic stale queue cleanup
                 now = _time.monotonic()
@@ -806,12 +767,10 @@ class ProcessPoolManager:
                 # Report timeout
                 await self._report_timeout(handle)
 
-                # Remove from pool
+                # Remove from pool — one-shot workers don't get replaced;
+                # the next execution's route_execution will fork on demand.
                 del self.processes[handle.id]
-
-                # Spawn replacement if below min_workers
-                if len(self.processes) < self.min_workers:
-                    self._fork_process()
+                await self._notify_slot_free()
 
     async def _kill_process(self, handle: ProcessHandle) -> None:
         """
@@ -981,77 +940,63 @@ class ProcessPoolManager:
 
     async def _handle_recycle_process_command(self, command: dict[str, Any]) -> None:
         """
-        Handle recycle_process command - recycle a specific process by PID.
+        Handle recycle_process command.
 
-        Args:
-            command: Command dict with 'pid' field
+        Workers are one-shot in this pool, so "recycle this specific PID"
+        has no per-PID meaning — by the time the command lands the child
+        may already have exited. We delegate to the same drain+restart
+        path used by recycle_all so the operator-visible behavior is
+        consistent: in-flight executions are allowed to finish, then the
+        template is restarted so subsequent forks see fresh sys.modules.
         """
         pid = command.get("pid")
         reason = command.get("reason", "API request")
-
-        if pid is None:
-            logger.warning("recycle_process command missing 'pid' field")
-            return
-
-        logger.info(f"Processing recycle_process command for PID={pid} (reason: {reason})")
-
-        success = await self.recycle_process(pid=pid)
-        if success:
-            logger.info(f"Successfully recycled process PID={pid}")
-        else:
-            logger.warning(f"Failed to recycle process PID={pid} (not found or busy)")
+        logger.info(
+            f"Processing recycle_process command for PID={pid} (reason: {reason}) "
+            f"— delegating to drain+restart"
+        )
+        await self._recycle_via_drain(reason=reason)
 
     async def _handle_recycle_all_command(self, command: dict[str, Any]) -> None:
         """
-        Handle recycle_all command - mark all processes for recycling.
-
-        Idle processes are recycled immediately with progress updates.
-        Busy processes are marked for recycling after their current execution.
+        Handle recycle_all command: drain in-flight executions and
+        restart the template so future forks see fresh sys.modules.
 
         Args:
             command: Command dict with optional 'reason' field
         """
         reason = command.get("reason", "API request")
         logger.info(f"Processing recycle_all command (reason: {reason})")
+        await self._recycle_via_drain(reason=reason)
 
-        # Install requirements before spawning replacement processes
-        # (recycle_all is typically triggered after a package install on the API container;
-        # the worker container needs to pip install from requirements.txt)
+    async def _recycle_via_drain(self, reason: str) -> None:
+        """
+        Shared recycle path: pip-install requirements, then drain
+        in-flight executions and restart the template process.
+
+        Used by both `recycle_process` and `recycle_all` RPC commands as
+        well as by the post-pip-install consumer.
+        """
+        # Pick up any requirements changes published to S3/Redis since
+        # last start (recycle is typically triggered after a package
+        # install on the API container).
         await asyncio.to_thread(install_requirements)
         self._update_requirements_status()
 
-        count, idle_handles = self.mark_for_recycle()
-        logger.info(f"Marked {count} processes for recycling ({len(idle_handles)} idle)")
+        in_flight = len(self.processes)
+        try:
+            from src.core.pubsub import publish_pool_scaling
 
-        # Publish initial scaling event for UI feedback
-        if count > 0:
-            try:
-                from src.core.pubsub import publish_pool_scaling
+            await publish_pool_scaling(
+                worker_id=self.worker_id,
+                action="recycle_all",
+                processes_affected=in_flight,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to publish recycle scaling event: {e}")
 
-                await publish_pool_scaling(
-                    worker_id=self.worker_id,
-                    action="recycle_all",
-                    processes_affected=count,
-                )
-            except Exception as e:
-                logger.warning(f"Failed to publish recycle_all event: {e}")
-
-        # Recycle idle processes with progress updates
-        for i, handle in enumerate(idle_handles):
-            try:
-                from src.core.pubsub import publish_pool_progress
-                await publish_pool_progress(
-                    worker_id=self.worker_id,
-                    action="recycle_all",
-                    current=i + 1,
-                    total=count,
-                    message=f"Recycling process {i + 1} of {count}...",
-                )
-            except Exception as e:
-                logger.warning(f"Failed to publish progress: {e}")
-
-            # Recycle this idle process
-            await self._recycle_idle_process(handle)
+        await self.drain_and_restart_template()
+        logger.info(f"recycle_via_drain complete (reason: {reason}, drained {in_flight} processes)")
 
     async def _handle_cancel_request(self, execution_id: str) -> None:
         """
@@ -1076,10 +1021,9 @@ class ProcessPoolManager:
                 # Report cancellation
                 await self._report_cancellation(handle)
 
-                # Remove from pool and replace
+                # Remove from pool — one-shot worker, no replacement
                 del self.processes[handle.id]
-                if len(self.processes) < self.min_workers:
-                    self._fork_process()
+                await self._notify_slot_free()
 
                 return
 
@@ -1158,13 +1102,12 @@ class ProcessPoolManager:
                     await self._report_orphan(handle)
                 to_remove.append(process_id)
 
-        # Remove crashed/orphaned processes
-        for process_id in to_remove:
-            del self.processes[process_id]
-
-        # Spawn replacements to maintain min_workers
-        while len(self.processes) < self.min_workers:
-            self._fork_process()
+        # Remove crashed/orphaned processes. One-shot workers don't get
+        # replaced — the next execution's route_execution will fork.
+        if to_remove:
+            for process_id in to_remove:
+                del self.processes[process_id]
+            await self._notify_slot_free()
 
     async def _report_orphan(self, handle: ProcessHandle) -> None:
         """
@@ -1220,59 +1163,6 @@ class ProcessPoolManager:
         except Exception as e:
             logger.exception(f"Error reporting crash: {e}")
 
-    async def _maybe_scale_down(self) -> None:
-        """
-        Remove excess idle processes if above min_workers.
-
-        Removes the oldest idle processes first to maintain min_workers.
-        """
-        idle_processes = [
-            p for p in self.processes.values()
-            if p.state == ProcessState.IDLE and p.is_alive
-        ]
-
-        excess = len(self.processes) - self.min_workers
-        if excess <= 0:
-            return
-
-        # Sort by age (oldest first)
-        idle_processes.sort(key=lambda p: p.started_at)
-
-        # Remove oldest idle processes up to excess count
-        to_remove = idle_processes[:excess]
-
-        if not to_remove:
-            return
-
-        # Publish scaling event
-        try:
-            from src.core.pubsub import publish_pool_scaling
-            await publish_pool_scaling(
-                worker_id=self.worker_id,
-                action="scale_down",
-                processes_affected=len(to_remove),
-            )
-        except Exception as e:
-            logger.warning(f"Failed to publish scale_down event: {e}")
-
-        for i, handle in enumerate(to_remove):
-            # Publish progress
-            try:
-                from src.core.pubsub import publish_pool_progress
-                await publish_pool_progress(
-                    worker_id=self.worker_id,
-                    action="scale_down",
-                    current=i + 1,
-                    total=len(to_remove),
-                    message=f"Terminating process {i + 1} of {len(to_remove)}...",
-                )
-            except Exception as e:
-                logger.warning(f"Failed to publish progress: {e}")
-
-            logger.info(f"Scaling down: removing idle process {handle.id}")
-            await self._terminate_process(handle)
-            del self.processes[handle.id]
-
     async def _result_loop(self) -> None:
         """
         Collect results from all process result queues.
@@ -1307,7 +1197,10 @@ class ProcessPoolManager:
         result: dict[str, Any],
     ) -> None:
         """
-        Handle a result from a worker process.
+        Handle a result from a one-shot worker process.
+
+        The child has already exited (or is about to); remove the handle,
+        wake any waiters blocked on a free slot, then fire the callback.
 
         Args:
             handle: ProcessHandle that produced the result
@@ -1321,52 +1214,11 @@ class ProcessPoolManager:
         handle.current_execution = None
         handle.executions_completed += 1
 
-        # On-demand mode: child exits after one execution, just clean up
-        if self.min_workers == 0:
-            if handle.id in self.processes:
-                del self.processes[handle.id]
-            # Forward result to callback
-            if self.on_result:
-                try:
-                    await self.on_result(result)
-                except Exception as e:
-                    logger.exception(f"Error in result callback: {e}")
-            return
-
-        # Check if should recycle (pending flag or execution count threshold)
-        if handle.pending_recycle:
-            logger.info(f"Recycling process {handle.id} (pending recycle flag)")
-            await self._recycle_process(handle)
-            return
-
-        if self.recycle_after_executions > 0:
-            if handle.executions_completed >= self.recycle_after_executions:
-                logger.info(
-                    f"Recycling process {handle.id} after "
-                    f"{handle.executions_completed} executions"
-                )
-                await self._recycle_process(handle)
-                return
-
-        # Memory-based recycling (safety net for Python arena fragmentation)
-        if self.recycle_memory_mb > 0:
-            rss_bytes = result.get("process_rss_bytes", 0)
-            if rss_bytes > 0:
-                rss_mb = rss_bytes / (1024 * 1024)
-                if rss_mb > self.recycle_memory_mb:
-                    logger.info(
-                        f"Recycling {handle.id}: RSS {rss_mb:.0f}MB > "
-                        f"threshold {self.recycle_memory_mb}MB"
-                    )
-                    await self._recycle_process(handle)
-                    return
-
-        # Return to IDLE state
-        handle.state = ProcessState.IDLE
-
-        # Notify any waiters that an idle process is available
-        async with self._idle_condition:
-            self._idle_condition.notify_all()
+        # Remove the handle (frees a slot under max_workers) and wake any
+        # waiters in route_execution that were blocked on a free slot.
+        if handle.id in self.processes:
+            del self.processes[handle.id]
+        await self._notify_slot_free()
 
         # Forward result to callback
         if self.on_result:
@@ -1375,137 +1227,10 @@ class ProcessPoolManager:
             except Exception as e:
                 logger.exception(f"Error in result callback: {e}")
 
-    async def _recycle_process(self, handle: ProcessHandle) -> None:
-        """
-        Recycle a process by terminating and spawning replacement.
-
-        Args:
-            handle: ProcessHandle to recycle
-        """
-        # Check if already removed (race condition with multiple recycle paths)
-        if handle.id not in self.processes:
-            return
-
-        logger.info(
-            f"Recycling process {handle.id} after "
-            f"{handle.executions_completed} executions"
-        )
-
-        # Remove from processes dict FIRST to prevent routing to dying process
-        # A new process will be spawned with a fresh work queue
-        del self.processes[handle.id]
-
-        # Spawn replacement immediately so we maintain worker count
-        self._fork_process()
-
-        # Then terminate the old process (this includes grace period wait)
-        await self._terminate_process(handle)
-
-    async def recycle_process(self, pid: int | None = None) -> bool:
-        """
-        Manually recycle a process.
-
-        If pid is provided, recycles that specific process.
-        If pid is None, recycles any idle process.
-
-        Args:
-            pid: Process ID to recycle, or None for any idle
-
-        Returns:
-            True if recycle was triggered, False if not found
-        """
-        target: ProcessHandle | None = None
-
-        if pid is not None:
-            for p in self.processes.values():
-                if p.pid == pid:
-                    target = p
-                    break
-        else:
-            # Find any idle process
-            target = self._get_idle_process()
-
-        if target is None:
-            return False
-
-        if target.state == ProcessState.BUSY:
-            logger.warning(f"Cannot recycle busy process {target.id}")
-            return False
-
-        await self._terminate_process(target)
-        # The process might have been removed by the monitor loop during the
-        # graceful shutdown wait. Only delete if still present.
-        if target.id in self.processes:
-            del self.processes[target.id]
-        self._fork_process()
-
-        return True
-
-    async def _scale_down_process(self, handle: ProcessHandle) -> None:
-        """
-        Terminate a process as part of scale-down operation.
-
-        Only terminates idle processes. If the process becomes busy
-        before we can terminate it, skip it.
-
-        Args:
-            handle: ProcessHandle to terminate
-        """
-        if handle.state != ProcessState.IDLE:
-            logger.debug(f"Skipping scale-down of {handle.id} - no longer idle")
-            return
-
-        if handle.id not in self.processes:
-            return  # Already removed
-
-        logger.info(f"Scale-down: terminating process {handle.id}")
-
-        # Remove from processes dict
-        del self.processes[handle.id]
-
-        # Terminate the process
-        await self._terminate_process(handle)
-
-    def mark_for_recycle(self) -> tuple[int, list[ProcessHandle]]:
-        """
-        Mark all worker processes for recycling after their current execution.
-
-        Called after package installation so workers pick up newly installed
-        packages. Each process will be recycled (terminated + respawned) after
-        completing its current execution. Returns list of idle processes to
-        be recycled so caller can publish progress.
-
-        Returns:
-            Tuple of (total count, list of idle handles to recycle immediately)
-        """
-        idle_handles: list[ProcessHandle] = []
-        marked_for_later = 0
-
-        for handle in list(self.processes.values()):
-            if handle.state == ProcessState.IDLE:
-                # Idle process - mark for immediate recycle
-                handle.pending_recycle = True
-                idle_handles.append(handle)
-            else:
-                # Busy process - mark for recycle after current execution
-                handle.pending_recycle = True
-                marked_for_later += 1
-
-        logger.info(
-            f"Marked {len(self.processes)} processes for recycle "
-            f"({len(idle_handles)} immediate, {marked_for_later} after execution)"
-        )
-        return len(self.processes), idle_handles
-
-    async def _recycle_idle_process(self, handle: ProcessHandle) -> None:
-        """Recycle an idle process immediately."""
-        if handle.id not in self.processes:
-            return  # Already removed
-        if handle.state != ProcessState.IDLE:
-            return  # No longer idle, will be recycled after execution
-
-        logger.info(f"Recycling idle process {handle.id} (package install)")
-        await self._recycle_process(handle)
+    async def _notify_slot_free(self) -> None:
+        """Wake any tasks blocked in `_wait_for_slot`."""
+        async with self._slot_condition:
+            self._slot_condition.notify_all()
 
     async def _heartbeat_loop(self) -> None:
         """
@@ -1675,7 +1400,6 @@ class ProcessPoolManager:
                 "private_dirty_kb": private_dirty_kb,
                 "uptime_seconds": p.uptime_seconds,
                 "executions_completed": p.executions_completed,
-                "pending_recycle": p.pending_recycle,
             }
             if p.current_execution:
                 info["execution"] = {
@@ -1685,7 +1409,9 @@ class ProcessPoolManager:
                 }
             processes.append(info)
 
-        idle_count = len([p for p in self.processes.values() if p.state == ProcessState.IDLE])
+        # In on-demand mode every handle is BUSY or KILLED — no idle pool.
+        # Keep `idle_count` in the heartbeat shape for back-compat (always 0).
+        idle_count = 0
         busy_count = len([p for p in self.processes.values() if p.state == ProcessState.BUSY])
 
         memory_current, memory_max = get_cgroup_memory()
@@ -1780,12 +1506,9 @@ def get_process_pool() -> ProcessPoolManager:
     if _pool is None:
         settings = get_settings()
         _pool = ProcessPoolManager(
-            min_workers=0,  # On-demand (JIT) mode — no warm pool
             max_workers=settings.max_workers,
             execution_timeout_seconds=settings.execution_timeout_seconds,
             graceful_shutdown_seconds=settings.graceful_shutdown_seconds,
-            recycle_after_executions=settings.recycle_after_executions,
-            recycle_memory_mb=settings.recycle_memory_mb,
             heartbeat_interval_seconds=settings.worker_heartbeat_interval_seconds,
             registration_ttl_seconds=settings.worker_registration_ttl_seconds,
         )

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -1,15 +1,9 @@
 """
-Unit tests for ProcessPoolManager.
+Unit tests for ProcessPoolManager (on-demand / one-shot workers).
 
-Tests the process pool management functionality including:
-- Pool starts with min_workers
-- Route to idle process
-- Scale up when all busy
-- Scale down when excess idle
-- Timeout kills process
-- Crash detection replaces process
-- Recycle idle process
-- Cannot recycle busy process
+Each route_execution call forks a fresh worker; the worker exits after
+returning its single result. The pool's only throttles are
+`max_workers` (concurrency cap) and the cgroup memory-pressure check.
 
 NOTE: These tests use mocks to avoid spawning real processes.
 """
@@ -169,11 +163,9 @@ class TestProcessPoolManagerInit:
         """Should initialize with default values."""
         pool = ProcessPoolManager()
 
-        assert pool.min_workers == 2
         assert pool.max_workers == 10
         assert pool.execution_timeout_seconds == 300
         assert pool.graceful_shutdown_seconds == 5
-        assert pool.recycle_after_executions == 0
         assert pool.heartbeat_interval_seconds == 10
         assert pool.registration_ttl_seconds == 30
         assert pool.on_result is None
@@ -186,21 +178,17 @@ class TestProcessPoolManagerInit:
         callback = AsyncMock()
 
         pool = ProcessPoolManager(
-            min_workers=5,
             max_workers=20,
             execution_timeout_seconds=600,
             graceful_shutdown_seconds=10,
-            recycle_after_executions=100,
             heartbeat_interval_seconds=30,
             registration_ttl_seconds=60,
             on_result=callback,
         )
 
-        assert pool.min_workers == 5
         assert pool.max_workers == 20
         assert pool.execution_timeout_seconds == 600
         assert pool.graceful_shutdown_seconds == 10
-        assert pool.recycle_after_executions == 100
         assert pool.heartbeat_interval_seconds == 30
         assert pool.registration_ttl_seconds == 60
         assert pool.on_result is callback
@@ -210,53 +198,38 @@ class TestProcessPoolManagerStart:
     """Tests for pool startup."""
 
     @pytest.mark.asyncio
-    async def test_pool_starts_with_min_workers(self):
-        """Should spawn min_workers processes on start."""
-        pool = ProcessPoolManager(min_workers=3, max_workers=10)
+    async def test_pool_starts_with_no_workers(self):
+        """Start should boot the template but not pre-spawn any workers."""
+        pool = ProcessPoolManager(max_workers=10)
 
-        # Mock process spawning
-        spawn_count = 0
+        spawned: list[None] = []
 
         def mock_spawn():
-            nonlocal spawn_count
-            spawn_count += 1
-            mock_process = MagicMock()
-            mock_process.is_alive.return_value = True
-            mock_process.pid = 10000 + spawn_count
-            mock_process.start = MagicMock()
-
-            handle = ProcessHandle(
-                id=f"process-{spawn_count}",
-                process=mock_process,
-                pid=10000 + spawn_count,
-                state=ProcessState.IDLE,
-                work_queue=MagicMock(),
-                result_queue=MagicMock(),
-                started_at=datetime.now(timezone.utc),
-            )
-            pool.processes[handle.id] = handle
-            return handle
+            spawned.append(None)
+            return MagicMock()
 
         pool._fork_process = mock_spawn
 
-        # Mock Redis and background tasks
         with patch.object(pool, "_get_redis", new_callable=AsyncMock) as mock_redis:
-            mock_redis_client = AsyncMock()
-            mock_redis.return_value = mock_redis_client
+            mock_redis.return_value = AsyncMock()
+            with patch.object(pool, "_start_template", new_callable=AsyncMock), \
+                 patch.object(pool, "_register_worker", new_callable=AsyncMock), \
+                 patch.object(pool, "_monitor_loop", new_callable=AsyncMock), \
+                 patch.object(pool, "_result_loop", new_callable=AsyncMock), \
+                 patch.object(pool, "_heartbeat_loop", new_callable=AsyncMock), \
+                 patch.object(pool, "_cancel_listener_loop", new_callable=AsyncMock), \
+                 patch.object(pool, "_command_listener_loop", new_callable=AsyncMock), \
+                 patch("src.services.execution.process_pool.install_requirements"):
+                await pool.start()
 
-            with patch.object(pool, "_register_worker", new_callable=AsyncMock):
-                with patch.object(pool, "_monitor_loop", new_callable=AsyncMock):
-                    with patch.object(pool, "_result_loop", new_callable=AsyncMock):
-                        with patch.object(pool, "_heartbeat_loop", new_callable=AsyncMock):
-                            await pool.start()
-
-        assert spawn_count == 3
-        assert len(pool.processes) == 3
+        assert spawned == [], "start() must not pre-spawn workers in on-demand mode"
+        assert len(pool.processes) == 0
         assert pool._started is True
 
         # Cleanup
         pool._shutdown = True
-        for task in [pool._monitor_task, pool._result_task, pool._heartbeat_task]:
+        for task in [pool._monitor_task, pool._result_task, pool._heartbeat_task,
+                     pool._cancel_task, pool._command_task]:
             if task:
                 task.cancel()
                 try:
@@ -270,46 +243,52 @@ class TestProcessPoolManagerRouting:
     """Tests for execution routing."""
 
     @pytest.mark.asyncio
-    async def test_route_to_idle_process(self):
-        """Should route execution to an idle process."""
-        pool = ProcessPoolManager()
+    async def test_route_forks_fresh_worker(self):
+        """Every route_execution call should fork a fresh one-shot worker."""
+        pool = ProcessPoolManager(max_workers=5)
 
-        # Create a mock idle process
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = True
-        mock_work_queue = MagicMock()
+        forked: list[ProcessHandle] = []
 
-        handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.IDLE,
-            work_queue=mock_work_queue,
-            result_queue=MagicMock(),
-            started_at=datetime.now(timezone.utc),
-        )
-        pool.processes["process-1"] = handle
+        def mock_spawn():
+            new_process = MagicMock()
+            new_process.is_alive.return_value = True
+            new_process.pid = 12346 + len(forked)
+            new_work_queue = MagicMock()
+            new_handle = ProcessHandle(
+                id=f"process-{len(forked) + 1}",
+                process=new_process,
+                pid=new_process.pid,
+                state=ProcessState.BUSY,
+                work_queue=new_work_queue,
+                result_queue=MagicMock(),
+                started_at=datetime.now(timezone.utc),
+            )
+            pool.processes[new_handle.id] = new_handle
+            forked.append(new_handle)
+            return new_handle
 
-        # Mock Redis
-        with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock):
+        pool._fork_process = mock_spawn
+
+        with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock), \
+             patch("src.services.execution.process_pool.has_sufficient_memory_cgroup", return_value=True):
             await pool.route_execution("exec-123", {"timeout_seconds": 300})
 
-        # Verify routing
-        assert handle.state == ProcessState.BUSY
-        assert handle.current_execution is not None
-        assert handle.current_execution.execution_id == "exec-123"
-        mock_work_queue.put_nowait.assert_called_once_with("exec-123")
+        assert len(forked) == 1
+        h = forked[0]
+        assert h.state == ProcessState.BUSY
+        assert h.current_execution is not None
+        assert h.current_execution.execution_id == "exec-123"
+        h.work_queue.put_nowait.assert_called_once_with("exec-123")
 
     @pytest.mark.asyncio
-    async def test_scale_up_when_all_busy(self):
-        """Should spawn new process when all are busy."""
-        pool = ProcessPoolManager(min_workers=1, max_workers=5)
+    async def test_route_waits_for_slot_when_saturated(self):
+        """When at max_workers, route_execution should wait on the slot condition."""
+        pool = ProcessPoolManager(max_workers=1)
 
-        # Create a mock busy process
+        # Fill the pool with one busy handle (NOT via _fork_process)
         mock_process = MagicMock()
         mock_process.is_alive.return_value = True
-
-        busy_handle = ProcessHandle(
+        existing = ProcessHandle(
             id="process-1",
             process=mock_process,
             pid=12345,
@@ -318,82 +297,48 @@ class TestProcessPoolManagerRouting:
             result_queue=MagicMock(),
             started_at=datetime.now(timezone.utc),
         )
-        pool.processes["process-1"] = busy_handle
+        pool.processes["process-1"] = existing
 
-        # Track spawning
-        spawned = False
+        # Track fork
+        forked: list[ProcessHandle] = []
 
         def mock_spawn():
-            nonlocal spawned
-            spawned = True
             new_process = MagicMock()
             new_process.is_alive.return_value = True
-            new_process.pid = 12346
-
             new_handle = ProcessHandle(
                 id="process-2",
                 process=new_process,
                 pid=12346,
-                state=ProcessState.IDLE,
+                state=ProcessState.BUSY,
                 work_queue=MagicMock(),
                 result_queue=MagicMock(),
                 started_at=datetime.now(timezone.utc),
             )
-            pool.processes["process-2"] = new_handle
+            pool.processes[new_handle.id] = new_handle
+            forked.append(new_handle)
             return new_handle
 
         pool._fork_process = mock_spawn
 
-        # Mock Redis
-        with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock):
-            await pool.route_execution("exec-123", {"timeout_seconds": 300})
-
-        assert spawned is True
-        assert len(pool.processes) == 2
-        assert pool.processes["process-2"].state == ProcessState.BUSY
-
-
-class TestProcessPoolManagerScaling:
-    """Tests for pool scaling."""
-
-    @pytest.mark.asyncio
-    async def test_scale_down_when_excess_idle(self):
-        """Should remove excess idle processes."""
-        pool = ProcessPoolManager(min_workers=2, max_workers=10)
-
-        # Create 4 idle processes
-        for i in range(4):
-            mock_process = MagicMock()
-            mock_process.is_alive.return_value = True
-
-            handle = ProcessHandle(
-                id=f"process-{i+1}",
-                process=mock_process,
-                pid=12345 + i,
-                state=ProcessState.IDLE,
-                work_queue=MagicMock(),
-                result_queue=MagicMock(),
-                started_at=datetime.now(timezone.utc) - timedelta(seconds=i * 10),
+        with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock), \
+             patch("src.services.execution.process_pool.has_sufficient_memory_cgroup", return_value=True):
+            # Kick off the route — it should park on _slot_condition.
+            route_task = asyncio.create_task(
+                pool.route_execution("exec-456", {"timeout_seconds": 300})
             )
-            pool.processes[handle.id] = handle
+            await asyncio.sleep(0.1)
+            assert not route_task.done(), "route should be parked while pool full"
+            assert not forked, "no fork until a slot opens"
 
-        # Mock termination
-        terminated_ids: list[str] = []
+            # Free a slot
+            del pool.processes["process-1"]
+            await pool._notify_slot_free()
 
-        async def mock_terminate(handle: ProcessHandle) -> None:
-            terminated_ids.append(handle.id)
-            handle.state = ProcessState.KILLED
+            await asyncio.wait_for(route_task, timeout=2.0)
 
-        pool._terminate_process = mock_terminate
-
-        # Scale down
-        await pool._maybe_scale_down()
-
-        # Should have removed 2 processes (4 - 2 = 2 excess)
-        assert len(terminated_ids) == 2
-        # Note: _maybe_scale_down removes from dict, so we check terminations
-        # Verify min_workers setting is still correct
-        assert pool.min_workers == 2
+        assert len(forked) == 1
+        assert forked[0].current_execution is not None
+        assert forked[0].current_execution.execution_id == "exec-456"
 
 
 class TestProcessPoolManagerTimeouts:
@@ -402,7 +347,7 @@ class TestProcessPoolManagerTimeouts:
     @pytest.mark.asyncio
     async def test_timeout_kills_process(self):
         """Should kill process when execution times out."""
-        pool = ProcessPoolManager(min_workers=1, max_workers=10)
+        pool = ProcessPoolManager(max_workers=10)
 
         # Create a busy process with timed-out execution
         mock_process = MagicMock()
@@ -436,26 +381,14 @@ class TestProcessPoolManagerTimeouts:
             killed = True
             h.state = ProcessState.KILLED
 
-        async def mock_report_timeout(handle: ProcessHandle) -> None:
+        async def mock_report_timeout(h: ProcessHandle) -> None:
             nonlocal timeout_reported
             timeout_reported = True
 
         def mock_spawn() -> ProcessHandle:
             nonlocal spawned
             spawned = True
-            new_process = MagicMock()
-            new_process.is_alive.return_value = True
-            new_handle = ProcessHandle(
-                id="process-2",
-                process=new_process,
-                pid=12346,
-                state=ProcessState.IDLE,
-                work_queue=MagicMock(),
-                result_queue=MagicMock(),
-                started_at=datetime.now(timezone.utc),
-            )
-            pool.processes["process-2"] = new_handle
-            return new_handle
+            raise AssertionError("timeout must not spawn replacements in on-demand mode")
 
         pool._kill_process = mock_kill
         pool._report_timeout = mock_report_timeout
@@ -466,16 +399,22 @@ class TestProcessPoolManagerTimeouts:
         assert killed is True
         assert timeout_reported is True
         assert "process-1" not in pool.processes
-        assert spawned is True  # Should spawn replacement
+        # One-shot mode: timeout cleanup does not spawn a replacement;
+        # the next route_execution will fork a fresh worker on demand.
+        assert spawned is False
 
 
 class TestProcessPoolManagerCrashDetection:
     """Tests for crash detection."""
 
     @pytest.mark.asyncio
-    async def test_crash_detection_replaces_process(self):
-        """Should detect crashed process and spawn replacement."""
-        pool = ProcessPoolManager(min_workers=2, max_workers=10)
+    async def test_crash_detection_removes_handle(self):
+        """Should detect a crashed process, fire the crash callback, and remove the handle.
+
+        One-shot workers are not replaced here — the next execution's
+        route_execution will fork on demand.
+        """
+        pool = ProcessPoolManager(max_workers=10)
 
         # Create a crashed process
         mock_process = MagicMock()
@@ -492,7 +431,7 @@ class TestProcessPoolManagerCrashDetection:
             id="process-1",
             process=mock_process,
             pid=12345,
-            state=ProcessState.BUSY,  # Was busy when crashed
+            state=ProcessState.BUSY,
             work_queue=MagicMock(),
             result_queue=MagicMock(),
             started_at=datetime.now(timezone.utc),
@@ -500,30 +439,17 @@ class TestProcessPoolManagerCrashDetection:
         )
         pool.processes["process-1"] = handle
 
-        # Track callbacks
         crash_reported = False
         spawn_count = 0
 
-        async def mock_report_crash(handle: ProcessHandle) -> None:
+        async def mock_report_crash(h: ProcessHandle) -> None:
             nonlocal crash_reported
             crash_reported = True
 
         def mock_spawn() -> ProcessHandle:
             nonlocal spawn_count
             spawn_count += 1
-            new_process = MagicMock()
-            new_process.is_alive.return_value = True
-            new_handle = ProcessHandle(
-                id=f"process-{spawn_count + 1}",
-                process=new_process,
-                pid=12346 + spawn_count,
-                state=ProcessState.IDLE,
-                work_queue=MagicMock(),
-                result_queue=MagicMock(),
-                started_at=datetime.now(timezone.utc),
-            )
-            pool.processes[new_handle.id] = new_handle
-            return new_handle
+            raise AssertionError("crash detection must not spawn replacements")
 
         pool._report_crash = mock_report_crash
         pool._fork_process = mock_spawn
@@ -532,108 +458,7 @@ class TestProcessPoolManagerCrashDetection:
 
         assert crash_reported is True
         assert "process-1" not in pool.processes
-        # Should spawn 2 replacements to maintain min_workers=2
-        assert spawn_count == 2
-
-
-class TestProcessPoolManagerRecycle:
-    """Tests for process recycling."""
-
-    @pytest.mark.asyncio
-    async def test_recycle_idle_process(self):
-        """Should recycle an idle process."""
-        pool = ProcessPoolManager(min_workers=2, max_workers=10)
-
-        # Create an idle process
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = True
-
-        handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.IDLE,
-            work_queue=MagicMock(),
-            result_queue=MagicMock(),
-            started_at=datetime.now(timezone.utc),
-        )
-        pool.processes["process-1"] = handle
-
-        # Track callbacks
-        terminated = False
-        spawned = False
-
-        async def mock_terminate(h: ProcessHandle) -> None:
-            nonlocal terminated
-            terminated = True
-            h.state = ProcessState.KILLED
-
-        def mock_spawn() -> ProcessHandle:
-            nonlocal spawned
-            spawned = True
-            new_process = MagicMock()
-            new_process.is_alive.return_value = True
-            new_handle = ProcessHandle(
-                id="process-2",
-                process=new_process,
-                pid=12346,
-                state=ProcessState.IDLE,
-                work_queue=MagicMock(),
-                result_queue=MagicMock(),
-                started_at=datetime.now(timezone.utc),
-            )
-            pool.processes["process-2"] = new_handle
-            return new_handle
-
-        pool._terminate_process = mock_terminate
-        pool._fork_process = mock_spawn
-
-        result = await pool.recycle_process(12345)
-
-        assert result is True
-        assert terminated is True
-        assert spawned is True
-        assert "process-1" not in pool.processes
-        assert "process-2" in pool.processes
-
-    @pytest.mark.asyncio
-    async def test_cannot_recycle_busy_process(self):
-        """Should not recycle a busy process."""
-        pool = ProcessPoolManager()
-
-        # Create a busy process
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = True
-
-        handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.BUSY,
-            work_queue=MagicMock(),
-            result_queue=MagicMock(),
-            started_at=datetime.now(timezone.utc),
-            current_execution=ExecutionInfo(
-                execution_id="exec-123",
-                started_at=datetime.now(timezone.utc),
-                timeout_seconds=300,
-            ),
-        )
-        pool.processes["process-1"] = handle
-
-        result = await pool.recycle_process(12345)
-
-        assert result is False
-        assert "process-1" in pool.processes  # Should still be there
-
-    @pytest.mark.asyncio
-    async def test_recycle_not_found(self):
-        """Should return False when process not found."""
-        pool = ProcessPoolManager()
-
-        result = await pool.recycle_process(99999)
-
-        assert result is False
+        assert spawn_count == 0
 
 
 class TestProcessPoolManagerHeartbeat:
@@ -683,7 +508,10 @@ class TestProcessPoolManagerHeartbeat:
         assert heartbeat["type"] == "worker_heartbeat"
         assert heartbeat["worker_id"] == "test-worker-123"
         assert heartbeat["pool_size"] == 2
-        assert heartbeat["idle_count"] == 1
+        # In on-demand mode every running handle is BUSY (the IDLE-marked
+        # handle above is for test-shape parity with persistent-pool
+        # heartbeats; idle_count is reported as 0 in this mode).
+        assert heartbeat["idle_count"] == 0
         assert heartbeat["busy_count"] == 1
         assert len(heartbeat["processes"]) == 2
 
@@ -698,8 +526,8 @@ class TestProcessPoolManagerResultHandling:
     """Tests for result handling."""
 
     @pytest.mark.asyncio
-    async def test_handle_result_returns_to_idle(self):
-        """Should return process to IDLE after result."""
+    async def test_handle_result_removes_handle(self):
+        """Should remove the handle (one-shot worker) after result."""
         pool = ProcessPoolManager()
 
         mock_process = MagicMock()
@@ -730,14 +558,15 @@ class TestProcessPoolManagerResultHandling:
 
         await pool._handle_result(handle, result_data)
 
-        assert handle.state == ProcessState.IDLE
+        assert "process-1" not in pool.processes
         assert handle.current_execution is None
         assert handle.executions_completed == 1
+        assert handle.result_reported is True
 
     @pytest.mark.asyncio
-    async def test_handle_result_triggers_recycle(self):
-        """Should recycle after max executions."""
-        pool = ProcessPoolManager(recycle_after_executions=5)
+    async def test_handle_result_notifies_slot_waiters(self):
+        """Removing a handle should wake any tasks waiting on a slot."""
+        pool = ProcessPoolManager(max_workers=1)
 
         mock_process = MagicMock()
         mock_process.is_alive.return_value = True
@@ -755,27 +584,18 @@ class TestProcessPoolManagerResultHandling:
                 started_at=datetime.now(timezone.utc),
                 timeout_seconds=300,
             ),
-            executions_completed=4,  # Will be 5 after this
         )
         pool.processes["process-1"] = handle
 
-        recycled = False
+        # Spawn a waiter — pool is full so it parks on _slot_condition.
+        waiter = asyncio.create_task(pool._wait_for_slot(timeout=5.0))
+        await asyncio.sleep(0.1)
+        assert not waiter.done(), "waiter should be parked"
 
-        async def mock_recycle(h: ProcessHandle) -> None:
-            nonlocal recycled
-            recycled = True
-
-        pool._recycle_process = mock_recycle
-
-        result_data = {
-            "type": "result",
-            "execution_id": "exec-123",
-            "success": True,
-        }
-
-        await pool._handle_result(handle, result_data)
-
-        assert recycled is True
+        # Result handling deletes the handle and notifies — waiter should wake.
+        await pool._handle_result(handle, {"success": True})
+        got_slot = await asyncio.wait_for(waiter, timeout=1.0)
+        assert got_slot is True
 
     @pytest.mark.asyncio
     async def test_handle_result_calls_callback(self):
@@ -819,7 +639,7 @@ class TestProcessPoolManagerStatus:
 
     def test_get_status(self):
         """Should return current pool status."""
-        pool = ProcessPoolManager(min_workers=2, max_workers=10)
+        pool = ProcessPoolManager(max_workers=10)
         pool._started = True
         pool.worker_id = "test-worker"
 
@@ -848,110 +668,43 @@ class TestProcessPoolManagerStatus:
         assert status["processes"][0]["state"] == "idle"
 
 
-class TestProcessPoolManagerIdleProcess:
-    """Tests for idle process retrieval."""
-
-    def test_get_idle_process_returns_idle(self):
-        """Should return an IDLE process."""
-        pool = ProcessPoolManager()
-
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = True
-
-        handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.IDLE,
-            work_queue=MagicMock(),
-            result_queue=MagicMock(),
-            started_at=datetime.now(timezone.utc),
-        )
-        pool.processes["process-1"] = handle
-
-        result = pool._get_idle_process()
-
-        assert result is handle
-
-    def test_get_idle_process_skips_busy(self):
-        """Should skip BUSY processes."""
-        pool = ProcessPoolManager()
-
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = True
-
-        busy_handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.BUSY,
-            work_queue=MagicMock(),
-            result_queue=MagicMock(),
-            started_at=datetime.now(timezone.utc),
-        )
-        pool.processes["process-1"] = busy_handle
-
-        result = pool._get_idle_process()
-
-        assert result is None
-
-    def test_get_idle_process_skips_dead(self):
-        """Should skip dead processes."""
-        pool = ProcessPoolManager()
-
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = False
-
-        handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.IDLE,
-            work_queue=MagicMock(),
-            result_queue=MagicMock(),
-            started_at=datetime.now(timezone.utc),
-        )
-        pool.processes["process-1"] = handle
-
-        result = pool._get_idle_process()
-
-        assert result is None
-
-
 class TestProcessPoolManagerIntegration:
     """Integration tests for full workflows."""
 
     @pytest.mark.asyncio
     async def test_full_execution_cycle(self):
-        """Test routing and completing an execution."""
+        """Test routing and completing an execution (one-shot fork → result)."""
         callback = AsyncMock()
-        pool = ProcessPoolManager(min_workers=1, on_result=callback)
+        pool = ProcessPoolManager(on_result=callback)
 
-        # Create mock idle process
-        mock_process = MagicMock()
-        mock_process.is_alive.return_value = True
+        # Mock the fork — route_execution will create a fresh BUSY handle.
         mock_work_queue = MagicMock()
-        mock_result_queue = MagicMock()
 
-        handle = ProcessHandle(
-            id="process-1",
-            process=mock_process,
-            pid=12345,
-            state=ProcessState.IDLE,
-            work_queue=mock_work_queue,
-            result_queue=mock_result_queue,
-            started_at=datetime.now(timezone.utc),
-        )
-        pool.processes["process-1"] = handle
+        def mock_spawn() -> ProcessHandle:
+            mock_process = MagicMock()
+            mock_process.is_alive.return_value = True
+            new_handle = ProcessHandle(
+                id="process-1",
+                process=mock_process,
+                pid=12345,
+                state=ProcessState.BUSY,
+                work_queue=mock_work_queue,
+                result_queue=MagicMock(),
+                started_at=datetime.now(timezone.utc),
+            )
+            pool.processes[new_handle.id] = new_handle
+            return new_handle
 
-        # Route execution
-        with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock):
+        pool._fork_process = mock_spawn
+
+        with patch.object(pool, "_write_context_to_redis", new_callable=AsyncMock), \
+             patch("src.services.execution.process_pool.has_sufficient_memory_cgroup", return_value=True):
             await pool.route_execution("exec-123", {"timeout_seconds": 300})
 
+        handle = pool.processes["process-1"]
         assert handle.state == ProcessState.BUSY
         mock_work_queue.put_nowait.assert_called_once_with("exec-123")
 
-        # Simulate result
         result_data = {
             "type": "result",
             "execution_id": "exec-123",
@@ -961,36 +714,9 @@ class TestProcessPoolManagerIntegration:
 
         await pool._handle_result(handle, result_data)
 
-        assert handle.state == ProcessState.IDLE
+        # One-shot worker: handle is removed after completion.
+        assert "process-1" not in pool.processes
         callback.assert_called_once_with(result_data)
-
-
-class TestMinWorkersZero:
-    """Tests for on-demand mode (min_workers=0)."""
-
-    @pytest.fixture
-    def pool_zero(self):
-        """Create a pool with min_workers=0."""
-        pool = ProcessPoolManager(
-            min_workers=0,
-            max_workers=5,
-        )
-        return pool
-
-    def test_min_workers_zero_is_valid(self, pool_zero):
-        """Should accept min_workers=0 without raising."""
-        assert pool_zero.min_workers == 0
-
-    @pytest.mark.asyncio
-    async def test_start_with_zero_workers_spawns_none(self, pool_zero):
-        """Pool with min_workers=0 should have no processes after start."""
-        with patch.object(pool_zero, '_fork_process') as mock_spawn:
-            with patch.object(pool_zero, '_register_worker', new_callable=AsyncMock):
-                with patch.object(pool_zero, '_start_template', new_callable=AsyncMock):
-                    pool_zero._started = True
-                    # Simulate start without background tasks
-                    assert len(pool_zero.processes) == 0
-                    mock_spawn.assert_not_called()
 
 
 class TestAdmissionControl:
@@ -999,7 +725,7 @@ class TestAdmissionControl:
     @pytest.mark.asyncio
     async def test_route_execution_checks_memory_pressure(self):
         """Should reject execution when memory pressure is too high."""
-        pool = ProcessPoolManager(min_workers=0, max_workers=5)
+        pool = ProcessPoolManager(max_workers=5)
         pool._started = True
 
         with patch(
@@ -1013,28 +739,33 @@ class TestAdmissionControl:
     @pytest.mark.asyncio
     async def test_route_execution_allows_when_memory_ok(self):
         """Should allow execution when memory is within threshold."""
-        pool = ProcessPoolManager(min_workers=0, max_workers=5)
+        pool = ProcessPoolManager(max_workers=5)
         pool._started = True
 
         mock_handle = ProcessHandle(
             id="process-1",
             process=MagicMock(is_alive=MagicMock(return_value=True)),
             pid=12345,
-            state=ProcessState.IDLE,
+            state=ProcessState.BUSY,
             work_queue=MagicMock(),
             result_queue=MagicMock(),
             started_at=datetime.now(timezone.utc),
         )
+
+        def mock_spawn():
+            pool.processes[mock_handle.id] = mock_handle
+            return mock_handle
 
         with patch(
             "src.services.execution.process_pool.has_sufficient_memory_cgroup",
             return_value=True,
         ):
             with patch.object(pool, '_write_context_to_redis', new_callable=AsyncMock):
-                with patch.object(pool, '_fork_process', return_value=mock_handle):
-                    pool.processes["process-1"] = mock_handle
+                with patch.object(pool, '_fork_process', side_effect=mock_spawn):
                     await pool.route_execution("exec-123", {"timeout_seconds": 300})
                     assert mock_handle.state == ProcessState.BUSY
+                    assert mock_handle.current_execution is not None
+                    assert mock_handle.current_execution.execution_id == "exec-123"
 
 
 class TestOrphanedKilledHandleSweep:
@@ -1045,7 +776,7 @@ class TestOrphanedKilledHandleSweep:
         """A handle whose state is KILLED but result_reported=False should
         have a synthetic orphan callback fired so the DB doesn't sit orphaned."""
         callback = AsyncMock()
-        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
+        pool = ProcessPoolManager(max_workers=5, on_result=callback)
 
         mock_process = MagicMock()
         mock_process.is_alive.return_value = False
@@ -1088,7 +819,7 @@ class TestOrphanedKilledHandleSweep:
         """If result_reported is already True, the orphan callback must NOT fire
         even when state is KILLED."""
         callback = AsyncMock()
-        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
+        pool = ProcessPoolManager(max_workers=5, on_result=callback)
 
         mock_process = MagicMock()
         mock_process.is_alive.return_value = False
@@ -1132,7 +863,7 @@ class TestOrphanedKilledHandleSweep:
         """
         callback = AsyncMock()
         pool = ProcessPoolManager(
-            min_workers=0, max_workers=1, graceful_shutdown_seconds=5,
+            max_workers=1, graceful_shutdown_seconds=5,
             on_result=callback,
         )
         mock_process = MagicMock()
@@ -1163,15 +894,6 @@ class TestOrphanedKilledHandleSweep:
         assert "proc-1" in pool.processes
 
 
-class TestOnDemandMode:
-    """Tests for on-demand mode (min_workers is always 0 now)."""
-
-    def test_pool_starts_with_zero_min_workers(self):
-        """Pool should always have min_workers=0 for on-demand mode."""
-        pool = ProcessPoolManager(min_workers=0, max_workers=5)
-        assert pool.min_workers == 0
-
-
 class TestCrashedProcessReport:
     """Tests that a SIGKILLed worker with an in-flight execution gets reported immediately.
 
@@ -1191,7 +913,7 @@ class TestCrashedProcessReport:
         have on_result called with success=False and error_type='ProcessCrashError'
         synchronously within _check_process_health — no reaper wait needed."""
         callback = AsyncMock()
-        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
+        pool = ProcessPoolManager(max_workers=5, on_result=callback)
 
         mock_process = MagicMock()
         mock_process.is_alive.return_value = False  # process is dead
@@ -1237,7 +959,7 @@ class TestCrashedProcessReport:
         where the result came back on the queue before the health check ran),
         the crash callback must NOT fire again."""
         callback = AsyncMock()
-        pool = ProcessPoolManager(min_workers=0, max_workers=5, on_result=callback)
+        pool = ProcessPoolManager(max_workers=5, on_result=callback)
 
         mock_process = MagicMock()
         mock_process.is_alive.return_value = False

--- a/api/tests/unit/test_worker_metrics.py
+++ b/api/tests/unit/test_worker_metrics.py
@@ -14,7 +14,6 @@ class TestHeartbeatCgroupData:
         pool = ProcessPoolManager.__new__(ProcessPoolManager)
         pool.worker_id = "test-worker"
         pool.processes = {}
-        pool.min_workers = 0
         pool.max_workers = 10
         pool._started_at = datetime.now(timezone.utc)
         pool._requirements_installed = 0
@@ -37,7 +36,6 @@ class TestHeartbeatCgroupData:
         pool = ProcessPoolManager.__new__(ProcessPoolManager)
         pool.worker_id = "test-worker"
         pool.processes = {}
-        pool.min_workers = 0
         pool.max_workers = 10
         pool._started_at = datetime.now(timezone.utc)
         pool._requirements_installed = 0
@@ -60,7 +58,6 @@ class TestHeartbeatCgroupData:
         pool = ProcessPoolManager.__new__(ProcessPoolManager)
         pool.worker_id = "test-worker"
         pool.processes = {}
-        pool.min_workers = 0
         pool.max_workers = 10
         pool._started_at = datetime.now(timezone.utc)
         pool._requirements_installed = 0
@@ -96,7 +93,6 @@ class TestHeartbeatCgroupData:
                 "state": ProcessState.IDLE,
                 "uptime_seconds": 1.0,
                 "executions_completed": 0,
-                "pending_recycle": False,
                 "current_execution": None,
             },
         )()
@@ -137,7 +133,6 @@ class TestHeartbeatCgroupData:
                 "state": ProcessState.IDLE,
                 "uptime_seconds": 1.0,
                 "executions_completed": 0,
-                "pending_recycle": False,
                 "current_execution": None,
             },
         )()


### PR DESCRIPTION
## Summary

Production has hard-coded `min_workers=0` (on-demand-only mode) for a while, but the `process_pool.py` file still carried all the persistent-pool machinery — warm pool, scale-down, recycle-after-N-executions, recycle-by-memory, IDLE-process selection, `_wait_for_idle_process`. None of it was reachable, and the half-baked on-demand path it papered over was broken: workers exited without notifying queue waiters, so any burst beyond `max_workers` parked the 11th+ request on a condition variable that nobody ever fired, until the 30s timeout.

## Why the 30s timeout was happening

`_handle_result` for on-demand workers did `del self.processes[id]` (freeing a slot under `max_workers`) but never notified the queue waiters. The waiter predicate was `_get_idle_process() is not None`, but on-demand workers never go IDLE — they exit. So waiters slept forever on a condition that could not become true. The unlucky requests that arrived while the pool was at `max_workers` timed out at 30s; lucky ones happened to enter `route_execution` at the exact millisecond a slot was free and forked directly.

The new shape:

- `route_execution` waits on `_slot_condition` for `len(self.processes) < max_workers`
- `_handle_result`, timeout, cancel, and crash paths all call `_notify_slot_free()` after removing a handle
- `drain_and_restart_template` notifies too (in case waiters were parked when the drain started)

## What got removed

- `min_workers` field + ctor arg + `settings.min_workers` config field
- `recycle_after_executions`, `recycle_memory_mb` config fields
- `_get_idle_process`, `_wait_for_idle_process` (replaced with `_wait_for_slot`)
- `_maybe_scale_down`, `_scale_down_process`, `_recycle_idle_process`
- `_recycle_process`, `recycle_process(pid)`, `mark_for_recycle`
- `pending_recycle` field on `ProcessHandle` (was only consulted by removed code paths)
- The persistent-mode branch of `_handle_result` (recycle gates, IDLE return, notify on the old condition)
- \"Spawn replacement\" tails on timeout / cancel / crash paths — one-shot workers are not replaced; the next route forks fresh
- `persistent` parameter on `_fork_process` (always False)

## What's preserved

- **Memory-pressure throttle** in `route_execution` (cgroup working-set check before forking) — the one throttle you asked to keep
- `drain_and_restart_template` — still called automatically from the package-install consumer, now also the body of both manual recycle RPCs (`recycle_process` per-PID and `recycle_all`)
- Cancel / timeout / crash detection and reporting
- Heartbeat, Redis registration, command/cancel listeners
- `ProcessState.IDLE` enum value (deprecated, never emitted) — kept to preserve the heartbeat shape for external consumers

## Verification

| Test | Before revert | After revert | After this cleanup |
|---|---|---|---|
| 30-burst `crash_repro` workflow | 19 ✓ / 3 crashed / 9 timeout | 20 ✓ / 0 crashed / 10 timeout | **30 ✓ / 0 failed** |
| 60-burst `crash_repro` workflow | — | — | **60 ✓ / 0 failed** |
| Success duration | — | — | min 0ms / median 2ms / **max 11ms** |
| `./test.sh tests/unit/execution/test_process_pool.py` | — | — | 29 passed |
| `./test.sh tests/unit/test_worker_metrics.py` | — | — | 6 passed |
| `./test.sh unit` (full) | — | — | **3923 passed, 0 failed** |

## Diff shape

```
api/src/config.py                             |  17 +-
api/src/services/execution/process_pool.py    | 577 +++++-----
api/tests/unit/execution/test_process_pool.py | 596 +++++-----
api/tests/unit/test_worker_metrics.py         |   5 -
4 files changed, 312 insertions(+), 883 deletions(-)
```

Net **−571 LoC**.

## Test plan

- [x] Unit tests: `./test.sh unit` — 3923 passed
- [x] 30-burst stress test against debug stack — 30/30 succeed
- [x] 60-burst stress test against debug stack — 60/60 succeed
- [ ] Backend E2E in CI
- [ ] Browser-verify the Diagnostics UI recycle buttons still work end-to-end (both per-PID and \"Recycle All\")

## Out of scope

The README at `api/src/services/execution/README.md` still describes the old persistent-pool architecture. Worth a follow-up but I left it alone here so this PR stays focused on code.