### PR TITLE
Set app tab title + favicon from the open app

### DIFF
--- a/client/src/lib/useDocumentChrome.test.ts
+++ b/client/src/lib/useDocumentChrome.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDocumentChrome } from "./useDocumentChrome";
+
+const SVG_DATA_URL =
+	"data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+const PNG_DATA_URL =
+	"data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==";
+
+function faviconLink(): HTMLLinkElement {
+	const link = document.querySelector<HTMLLinkElement>("link[rel='icon']");
+	if (!link) throw new Error("favicon link missing from test DOM");
+	return link;
+}
+
+describe("useDocumentChrome", () => {
+	beforeEach(() => {
+		// Rebuild <head> first — clearing innerHTML drops the <title> element
+		// that document.title writes through, so set the title afterward.
+		document.head.innerHTML = "";
+		const link = document.createElement("link");
+		link.setAttribute("rel", "icon");
+		link.setAttribute("type", "image/svg+xml");
+		link.setAttribute("href", "/logo.svg");
+		document.head.appendChild(link);
+		document.title = "Bifrost Integrations";
+	});
+
+	afterEach(() => {
+		document.head.innerHTML = "";
+	});
+
+	describe("title", () => {
+		it("sets the document title and restores it on unmount", () => {
+			const { unmount } = renderHook(() =>
+				useDocumentChrome({ title: "My App | Bifrost", logo: null }),
+			);
+			expect(document.title).toBe("My App | Bifrost");
+			unmount();
+			expect(document.title).toBe("Bifrost Integrations");
+		});
+
+		it("updates the title when the input changes", () => {
+			const { rerender } = renderHook(
+				({ title }) => useDocumentChrome({ title, logo: null }),
+				{ initialProps: { title: "First | Bifrost" } },
+			);
+			expect(document.title).toBe("First | Bifrost");
+			rerender({ title: "Second | Bifrost" });
+			expect(document.title).toBe("Second | Bifrost");
+		});
+
+		it("leaves the title untouched when title is falsy", () => {
+			renderHook(() =>
+				useDocumentChrome({ title: undefined, logo: null }),
+			);
+			expect(document.title).toBe("Bifrost Integrations");
+		});
+	});
+
+	describe("favicon", () => {
+		it("sets the favicon href from a logo data URL and restores on unmount", () => {
+			const { unmount } = renderHook(() =>
+				useDocumentChrome({ title: null, logo: SVG_DATA_URL }),
+			);
+			expect(faviconLink().getAttribute("href")).toBe(SVG_DATA_URL);
+			unmount();
+			expect(faviconLink().getAttribute("href")).toBe("/logo.svg");
+		});
+
+		it("drops the hardcoded type so a non-SVG logo is not mislabeled, and restores it", () => {
+			const { unmount } = renderHook(() =>
+				useDocumentChrome({ title: null, logo: PNG_DATA_URL }),
+			);
+			expect(faviconLink().getAttribute("href")).toBe(PNG_DATA_URL);
+			expect(faviconLink().getAttribute("type")).toBeNull();
+			unmount();
+			expect(faviconLink().getAttribute("type")).toBe("image/svg+xml");
+			expect(faviconLink().getAttribute("href")).toBe("/logo.svg");
+		});
+
+		it("leaves the favicon untouched when logo is falsy", () => {
+			renderHook(() =>
+				useDocumentChrome({ title: "X | Bifrost", logo: null }),
+			);
+			expect(faviconLink().getAttribute("href")).toBe("/logo.svg");
+			expect(faviconLink().getAttribute("type")).toBe("image/svg+xml");
+		});
+	});
+
+	describe("enabled flag (embed mode)", () => {
+		it("is a no-op for both title and favicon when disabled", () => {
+			renderHook(() =>
+				useDocumentChrome({
+					title: "Embedded | Bifrost",
+					logo: SVG_DATA_URL,
+					enabled: false,
+				}),
+			);
+			expect(document.title).toBe("Bifrost Integrations");
+			expect(faviconLink().getAttribute("href")).toBe("/logo.svg");
+			expect(faviconLink().getAttribute("type")).toBe("image/svg+xml");
+		});
+	});
+});

--- a/client/src/lib/useDocumentChrome.ts
+++ b/client/src/lib/useDocumentChrome.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+/**
+ * Drives the browser tab's "chrome" — the document <title> and the favicon —
+ * from the currently-open entity (e.g. a Bifrost app), restoring the prior
+ * values on unmount or when the inputs change.
+ *
+ * The favicon is set from `logo`, which is an inline data URL
+ * (`data:image/...;base64,...`) as served by the API's `logo` field. Because a
+ * data URL carries its own MIME type, this works uniformly for SVG, PNG, and
+ * JPEG logos without any format detection — we just drop the hardcoded `type`
+ * attribute on the <link> so the data URL's own type drives it.
+ *
+ * When `logo` is null/empty the favicon is left untouched (the default Bifrost
+ * favicon stays). When `enabled` is false (e.g. embed mode, where the host page
+ * owns its own chrome) the hook is a no-op.
+ */
+export function useDocumentChrome({
+	title,
+	logo,
+	enabled = true,
+}: {
+	/** Tab title to set. Falsy values leave the title untouched. */
+	title: string | null | undefined;
+	/** Favicon source as a data URL. Falsy values leave the favicon untouched. */
+	logo: string | null | undefined;
+	/** When false, the hook does nothing. */
+	enabled?: boolean;
+}): void {
+	useEffect(() => {
+		if (!enabled || !title) return;
+		const prev = document.title;
+		document.title = title;
+		return () => {
+			document.title = prev;
+		};
+	}, [enabled, title]);
+
+	useEffect(() => {
+		if (!enabled || !logo) return;
+		const link =
+			document.querySelector<HTMLLinkElement>("link[rel='icon']");
+		if (!link) return;
+		const prevHref = link.getAttribute("href");
+		const prevType = link.getAttribute("type");
+		// Let the data URL's own MIME type drive the favicon, so a PNG/JPEG logo
+		// is not mislabeled by the default `type="image/svg+xml"`.
+		link.removeAttribute("type");
+		link.setAttribute("href", logo);
+		return () => {
+			if (prevHref === null) link.removeAttribute("href");
+			else link.setAttribute("href", prevHref);
+			if (prevType === null) link.removeAttribute("type");
+			else link.setAttribute("type", prevType);
+		};
+	}, [enabled, logo]);
+}

--- a/client/src/pages/AppRouter.tsx
+++ b/client/src/pages/AppRouter.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/card";
 import { useApplication } from "@/hooks/useApplications";
 import { useAuth } from "@/contexts/AuthContext";
+import { useDocumentChrome } from "@/lib/useDocumentChrome";
 import { BundledAppShell } from "@/components/jsx-app/BundledAppShell";
 import { AppLayout } from "@/components/layout/AppLayout";
 
@@ -42,6 +43,19 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 		isLoading,
 		error,
 	} = useApplication(slugParam);
+
+	// Drive the browser tab title + favicon from the open app. Skipped in embed
+	// mode, where the host page owns its own chrome. Must run before the early
+	// returns below to satisfy the Rules of Hooks.
+	useDocumentChrome({
+		title: application?.name
+			? preview
+				? `${application.name} (Preview) | Bifrost`
+				: `${application.name} | Bifrost`
+			: undefined,
+		logo: application?.logo,
+		enabled: !isEmbed,
+	});
 
 	// Loading state
 	if (isLoading) {


### PR DESCRIPTION
## Summary

When a Bifrost app is open, the browser tab now shows the app's **name** as the title and the app's **logo** as the favicon — so multiple open app tabs are distinguishable instead of all reading `Bifrost Integrations` with the same icon.

- New `useDocumentChrome` hook (`client/src/lib/useDocumentChrome.ts`) sets `document.title` and the favicon `<link rel="icon">` href, restoring both on unmount/change.
- Favicon comes from the app `logo` field, which the API already serves as a `data:image/...;base64,...` **data URL**. Because a data URL carries its own MIME type, SVG/PNG/JPEG all work with zero format detection — the hook just drops the hardcoded `type="image/svg+xml"` on the link during the swap so a non-SVG logo isn't mislabeled.
- Wired into `AppRouter` (`client/src/pages/AppRouter.tsx`):
  - Skipped in **embed mode** (`EmbedUser` role) — the host page owns its own chrome.
  - `(Preview)` suffix on the title in preview mode.
  - Apps with **no logo** keep the default Bifrost favicon.

## Testing

- `client/src/lib/useDocumentChrome.test.ts` — 7 vitest cases (title set/restore/update, favicon set/restore, type-attribute drop+restore for non-SVG, no-op when logo falsy, no-op in embed mode). All pass.
- Full client vitest suite: 1052 passed.
- `npm run tsc` clean, `npm run lint` 0 errors.
- Confirmed against the API that the app `logo` is served as a `data:image/svg+xml;base64,...` data URL (the favicon source).
- The author confirmed the title + favicon swap working live in the browser. (My own automated browser check was blocked by an unrelated netbird+Vite-HMR issue on the debug stack.)

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)