### PR TITLE
Harden worker requirements install + fleet-aware install progress

### DIFF
--- a/api/src/jobs/consumers/package_install.py
+++ b/api/src/jobs/consumers/package_install.py
@@ -6,21 +6,23 @@ Uses broadcast delivery so all worker instances install the package.
 
 Flow:
 1. API handler updates requirements.txt in S3 + Redis cache (persistence)
-2. API broadcasts message to this consumer on all workers
+2. API broadcasts message to this consumer on all workers (with a shared run_id)
 3. Consumer runs pip install (makes package available on worker filesystem)
 4. Consumer recycles processes (clears Python import cache)
 5. Consumer updates package list in Redis (so /api/packages reflects changes)
 
-Progress is streamed via WebSocket to the shared package:install channel.
+Progress is aggregated via Redis per run_id (see install_progress.py) so that
+each phase is reported once across all workers, not once per worker.
 """
 
 import asyncio
 import logging
+import os
 import sys
 from typing import Any
 
-from src.core.pubsub import manager as pubsub_manager
 from src.jobs.rabbitmq import BroadcastConsumer
+from src.services.execution.install_progress import report_phase
 
 logger = logging.getLogger(__name__)
 
@@ -38,30 +40,26 @@ class PackageInstallConsumer(BroadcastConsumer):
     Message format:
     {
         "type": "recycle_workers",
+        "action": "install" | "uninstall" (optional, default "install"),
         "package": "package-name" (optional),
-        "version": "1.0.0" (optional)
+        "version": "1.0.0" (optional),
+        "is_update": true | false (optional),
+        "run_id": "<uuid>" (shared across workers for phase aggregation),
     }
     """
 
     def __init__(self):
         super().__init__(exchange_name=EXCHANGE_NAME)
 
-    async def _send_log(self, message: str, level: str = "info") -> None:
-        """Send a log message via WebSocket to the shared package:install channel."""
-        await pubsub_manager.broadcast(
-            "package:install",
-            {"type": "log", "level": level, "message": message},
-        )
+    @property
+    def _worker_id(self) -> str:
+        return os.environ.get("HOSTNAME", "unknown")
 
-    async def _send_complete(self, status: str, message: str) -> None:
-        """Send a completion message via WebSocket to the shared package:install channel."""
-        await pubsub_manager.broadcast(
-            "package:install",
-            {"type": "complete", "status": status, "message": message},
-        )
+    async def _pip_uninstall(self, package: str) -> str | None:
+        """Run pip uninstall for a package on this worker.
 
-    async def _pip_uninstall(self, package: str) -> bool:
-        """Run pip uninstall for a package on this worker."""
+        Returns None on success, or the error message on failure.
+        """
         try:
             proc = await asyncio.create_subprocess_exec(
                 sys.executable, "-m", "pip", "uninstall", "-y", package, "--quiet",
@@ -71,30 +69,30 @@ class PackageInstallConsumer(BroadcastConsumer):
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
             if proc.returncode == 0:
                 logger.info(f"Uninstalled {package}")
-                return True
+                return None
             err = stderr.decode()
             # pip exits non-zero when the package isn't installed; that's fine
             # for our purposes — the post-condition (package absent) holds.
             if "not installed" in err.lower() or "skipping" in err.lower():
                 logger.info(f"Package {package} was not installed; nothing to do")
-                return True
+                return None
             logger.warning(f"pip uninstall {package} failed: {err}")
-            return False
+            return err.strip()
         except asyncio.TimeoutError:
             logger.error(f"pip uninstall {package} timed out")
-            return False
+            return f"pip uninstall {package} timed out"
         except Exception as e:
             logger.error(f"pip uninstall {package} error: {e}")
-            return False
+            return f"pip uninstall {package} error: {e}"
 
-    async def _pip_install(self, package: str, version: str | None) -> bool:
+    async def _pip_install(self, package: str, version: str | None) -> str | None:
         """
         Run pip install for a specific package on this worker.
 
         Installs into the worker's Python environment so all child processes
         (which share the same filesystem) can import it after recycle.
 
-        Returns True on success, False on failure.
+        Returns None on success, or the error message on failure.
         """
         package_spec = f"{package}=={version}" if version else package
 
@@ -108,25 +106,26 @@ class PackageInstallConsumer(BroadcastConsumer):
 
             if proc.returncode == 0:
                 logger.info(f"Installed {package_spec}")
-                return True
+                return None
             else:
-                logger.warning(f"pip install {package_spec} failed: {stderr.decode()}")
-                return False
+                err = stderr.decode()
+                logger.warning(f"pip install {package_spec} failed: {err}")
+                return err.strip()
         except asyncio.TimeoutError:
             logger.error(f"pip install {package_spec} timed out")
-            return False
+            return f"pip install {package_spec} timed out"
         except Exception as e:
             logger.error(f"pip install {package_spec} error: {e}")
-            return False
+            return f"pip install {package_spec} error: {e}"
 
-    async def _pip_install_requirements(self) -> bool:
+    async def _pip_install_requirements(self) -> str | None:
         """
         Run pip install from the cached requirements.txt.
 
         Used when no specific package is provided (e.g., "Install from
         requirements.txt" button).
 
-        Returns True on success, False on failure.
+        Returns None on success, or the error message on failure.
         """
         import tempfile
 
@@ -135,7 +134,7 @@ class PackageInstallConsumer(BroadcastConsumer):
         cached = await get_requirements()
         if not cached or not cached["content"].strip():
             logger.info("No cached requirements.txt to install from")
-            return True
+            return None
 
         try:
             with tempfile.NamedTemporaryFile(
@@ -151,7 +150,6 @@ class PackageInstallConsumer(BroadcastConsumer):
             )
             _, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
 
-            import os
             os.unlink(temp_path)
 
             if proc.returncode == 0:
@@ -159,16 +157,17 @@ class PackageInstallConsumer(BroadcastConsumer):
                     line for line in cached["content"].strip().split("\n") if line.strip()
                 ])
                 logger.info(f"Installed {pkg_count} packages from requirements.txt")
-                return True
+                return None
             else:
-                logger.warning(f"pip install -r requirements.txt failed: {stderr.decode()}")
-                return False
+                err = stderr.decode()
+                logger.warning(f"pip install -r requirements.txt failed: {err}")
+                return err.strip()
         except asyncio.TimeoutError:
             logger.error("pip install -r requirements.txt timed out")
-            return False
+            return "pip install -r requirements.txt timed out"
         except Exception as e:
             logger.error(f"pip install -r requirements.txt error: {e}")
-            return False
+            return f"pip install -r requirements.txt error: {e}"
 
     async def _update_pool_packages(self) -> None:
         """Update the pool's packages in Redis after installation."""
@@ -204,40 +203,46 @@ class PackageInstallConsumer(BroadcastConsumer):
 
         `action` is "install" (default) or "uninstall". For "install" with
         `package=None`, runs pip install -r requirements.txt (sync from cache).
+
+        Phases are reported via report_phase() to a shared Redis hash keyed by
+        run_id so the frontend sees one aggregate status, not one per worker.
         """
         action = body.get("action", "install")
         package = body.get("package")
         version = body.get("version")
-        package_spec = f"{package}=={version}" if package and version else (package or "requirements.txt")
+        run_id = body.get("run_id", "current")
+        package_spec = (
+            f"{package}=={version}" if package and version else (package or "requirements.txt")
+        )
+        wid = self._worker_id
+        logger.info(f"Processing package {action}: {package_spec} (run={run_id})")
 
-        logger.info(f"Processing package {action}: {package_spec}")
+        await report_phase(run_id, wid, phase="installing", action=action)
 
         if action == "uninstall":
             if not package:
-                await self._send_complete("error", "uninstall requires a package name")
+                await report_phase(
+                    run_id, wid, phase="failed", action=action,
+                    package="(none)", error="uninstall requires a package name",
+                )
                 return
-            await self._send_log(f"Uninstalling {package}...")
-            success = await self._pip_uninstall(package)
+            err = await self._pip_uninstall(package)
         elif package:
-            await self._send_log(f"Installing {package_spec}...")
-            success = await self._pip_install(package, version)
+            err = await self._pip_install(package, version)
         else:
-            await self._send_log("Installing from requirements.txt...")
-            success = await self._pip_install_requirements()
+            err = await self._pip_install_requirements()
 
-        if success:
-            await self._send_log(f"{action.capitalize()}ed {package_spec}")
-        else:
-            await self._send_log(f"Failed to {action} {package_spec}", "error")
-            await self._send_complete("error", f"{action.capitalize()} failed: {package_spec}")
+        if err is not None:
+            await report_phase(
+                run_id, wid, phase="failed", action=action,
+                package=package_spec, error=err or "pip command failed",
+            )
             return
 
         # Worker subprocesses are forked before pip runs; recycle so they pick
         # up the new on-disk state.
-        await self._send_log("Recycling worker processes...")
+        await report_phase(run_id, wid, phase="recycling", action=action)
         await self._recycle_workers()
-
         await self._update_pool_packages()
-
-        await self._send_complete("success", f"{action.capitalize()} complete")
-        logger.info(f"Package {action} completed")
+        await report_phase(run_id, wid, phase="recycled", action=action)
+        logger.info(f"Package {action} completed on {wid}")

--- a/api/src/routers/packages.py
+++ b/api/src/routers/packages.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import json
 from typing import Awaitable, cast
+from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, status
 
@@ -335,15 +336,17 @@ async def install_package(
             is_update = True
             logger.info("Warmed requirements cache from S3 for recycle")
 
-        # Broadcast to all workers — they pip install + recycle processes
+        # Broadcast to all workers — they pip install + recycle processes.
+        # run_id ties all workers' phase reports to the same Redis hash so
+        # the frontend sees one aggregate status instead of N per-worker logs.
         await publish_broadcast(
             exchange_name="package-installations",
             message={
                 "type": "recycle_workers",
                 "package": request.package_name,
                 "version": request.version if request.version else None,
-
                 "is_update": is_update,
+                "run_id": str(uuid4()),
             },
         )
 
@@ -396,6 +399,7 @@ async def uninstall_package(
 
         # Tell workers to pip uninstall and recycle. The "action" field
         # is what distinguishes install from uninstall in the consumer.
+        # run_id ties all workers' phase reports to the same Redis hash.
         await publish_broadcast(
             exchange_name="package-installations",
             message={
@@ -404,6 +408,7 @@ async def uninstall_package(
                 "package": package_name,
                 "version": None,
                 "is_update": True,
+                "run_id": str(uuid4()),
             },
         )
 

--- a/api/src/services/execution/install_progress.py
+++ b/api/src/services/execution/install_progress.py
@@ -1,0 +1,143 @@
+"""Fleet-aware install progress aggregation.
+
+Each worker in the fanout reports its phase for a given install run into a
+per-run Redis hash. After each write the worker computes an aggregate over all
+reporting workers (out of the live worker count) and publishes ONE summary
+message to the shared ``package:install`` WebSocket channel. The frontend
+collapses consecutive identical summaries, so N workers reporting the same
+aggregate render as a single line.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, cast
+
+from src.core.pubsub import manager as pubsub_manager
+from src.core.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+CHANNEL = "package:install"
+_HASH_PREFIX = "bifrost:pkg-install:"
+_HASH_TTL_SECONDS = 120
+_PHASES = ("installing", "installed", "recycling", "recycled", "failed")
+
+
+@dataclass
+class WorkerPhase:
+    phase: str
+    package: str | None = None
+    error: str | None = None
+
+
+async def _raw_redis():  # pragma: no cover - thin accessor, patched in tests
+    client = get_redis_client()
+    return await client._get_redis()
+
+
+async def _live_worker_count(redis: Any) -> int:
+    """Count pool registration keys (exactly bifrost:pool:{id}, 3 parts)."""
+    cursor = 0
+    count = 0
+    while True:
+        cursor, keys = await cast(
+            Awaitable[tuple[int, list[str]]],
+            redis.scan(cursor, match="bifrost:pool:*", count=100),
+        )
+        for key in keys:
+            if key.count(":") == 2:
+                count += 1
+        if cursor == 0:
+            break
+    return count
+
+
+def aggregate_phases(phases: dict[str, WorkerPhase], total: int) -> dict[str, Any]:
+    """Reduce per-worker phases into counts + failure detail."""
+    counts = {p: 0 for p in _PHASES}
+    failures: list[dict[str, Any]] = []
+    for worker_id, wp in phases.items():
+        if wp.phase in counts:
+            counts[wp.phase] += 1
+        if wp.phase == "failed":
+            failures.append(
+                {"worker": worker_id, "package": wp.package, "error": wp.error}
+            )
+    return {
+        "total": max(total, len(phases)),
+        "installing": counts["installing"],
+        "installed": counts["installed"] + counts["recycling"] + counts["recycled"],
+        "recycling": counts["recycling"],
+        "recycled": counts["recycled"],
+        "failed": counts["failed"],
+        "failures": failures,
+    }
+
+
+def summary_line(agg: dict[str, Any], action: str) -> str:
+    """Human-readable single line for the terminal view."""
+    verb = "Installing" if action == "install" else "Uninstalling"
+    total = agg["total"]
+    if agg["installing"]:
+        base = f"{verb} on {agg['installing']}/{total} workers…"
+    else:
+        # 'installed' is the folded count (installed + recycling + recycled):
+        # how many workers have gotten past the install step.
+        done_verb = verb.replace("ing", "ed")
+        base = f"{done_verb} on {agg['installed']}/{total} workers"
+    if agg["failed"]:
+        pkgs = ", ".join(
+            f"{f['worker']}: {f['package']}" for f in agg["failures"] if f.get("package")
+        ) or f"{agg['failed']} worker(s)"
+        base += f" — {agg['failed']} failed ({pkgs})"
+    return base
+
+
+async def report_phase(
+    run_id: str,
+    worker_id: str,
+    phase: str,
+    action: str = "install",
+    package: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Write this worker's phase, then publish one aggregate summary.
+
+    Best-effort: never raises (a progress-reporting failure must not abort the
+    install).
+    """
+    try:
+        redis = await _raw_redis()
+        key = f"{_HASH_PREFIX}{run_id or 'current'}"
+        field_val = json.dumps(
+            {"phase": phase, "package": package, "error": (error or "")[:500]}
+        )
+        await redis.hset(key, worker_id, field_val)  # type: ignore[misc]
+        await redis.expire(key, _HASH_TTL_SECONDS)
+
+        raw = await cast(Awaitable[dict[str, str]], redis.hgetall(key))
+        phases: dict[str, WorkerPhase] = {}
+        for wid, val in raw.items():
+            try:
+                d = json.loads(val)
+                phases[wid] = WorkerPhase(
+                    phase=d.get("phase", ""),
+                    package=d.get("package"),
+                    error=d.get("error"),
+                )
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        total = await _live_worker_count(redis)
+        agg = aggregate_phases(phases, total)
+        message = {
+            "type": "progress",
+            "action": action,
+            "line": summary_line(agg, action),
+            **agg,
+        }
+        await pubsub_manager.broadcast(CHANNEL, message)
+    except Exception as e:  # noqa: BLE001 - progress reporting must never break install
+        logger.warning(f"[pkg-install] progress report failed: {e}")

--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -48,10 +48,63 @@ import redis.asyncio as redis
 
 from src.config import get_settings
 from src.services.execution.memory_monitor import get_cgroup_memory, has_sufficient_memory_cgroup
-from src.services.execution.simple_worker import install_requirements
+from src.models.contracts.notifications import NotificationCategory, NotificationCreate, NotificationStatus
+from src.services.execution.simple_worker import install_requirements, RequirementsInstallResult
+from src.services.notification_service import get_notification_service
 from src.services.execution.template_process import TemplateProcess
 
 logger = logging.getLogger(__name__)
+
+
+async def _notify_requirements_failures(result: RequirementsInstallResult) -> None:
+    """Publish a deduped admin notification when requirements failed to install.
+
+    No-op when the install fully succeeded. Best-effort: notification errors
+    are logged, never raised, so install/recycle is never blocked by it.
+    """
+    if result.ok:
+        return
+
+    names = [f.package for f in result.failed]
+    shown = ", ".join(names[:5])
+    if len(names) > 5:
+        shown += f" and {len(names) - 5} more"
+    title = "Workflow package install failed"
+    description = (
+        f"{len(result.failed)} package(s) failed to install on workers: "
+        f"{shown}. Workflows importing them will fail until fixed."
+    )
+    try:
+        service = get_notification_service()
+        # Dedup is best-effort: concurrent workers can race past this check and
+        # create duplicate notifications. The failure case is rare and duplicates
+        # are cheap to dismiss, so no distributed lock is warranted.
+        existing = await service.find_admin_notification_by_title(
+            title, NotificationCategory.PACKAGE_INSTALL
+        )
+        if existing is not None:
+            logger.info("[pool] requirements-failure notification already exists; skipping")
+            return
+        await service.create_notification(
+            user_id="system",
+            request=NotificationCreate(
+                category=NotificationCategory.PACKAGE_INSTALL,
+                title=title,
+                description=description[:500],
+                metadata={
+                    "failed": [
+                        {"package": f.package, "error": f.error[:500]}
+                        for f in result.failed
+                    ],
+                    "installed": result.installed,
+                },
+            ),
+            for_admins=True,
+            initial_status=NotificationStatus.FAILED,
+        )
+        logger.info(f"[pool] Notified admins of requirements install failures: {shown}")
+    except Exception as e:  # noqa: BLE001 - notification must never block the pool
+        logger.warning(f"[pool] Could not publish requirements-failure notification: {e}")
 
 
 def _get_installed_packages() -> list[dict[str, str]]:
@@ -460,7 +513,8 @@ class ProcessPoolManager:
         self._started_at = datetime.now(timezone.utc)
 
         # Install requirements once (shared filesystem — all child processes inherit)
-        await asyncio.to_thread(install_requirements)
+        install_result = await asyncio.to_thread(install_requirements)
+        await _notify_requirements_failures(install_result)
 
         # Compute requirements status for heartbeat reporting
         self._update_requirements_status()
@@ -980,7 +1034,8 @@ class ProcessPoolManager:
         # Pick up any requirements changes published to S3/Redis since
         # last start (recycle is typically triggered after a package
         # install on the API container).
-        await asyncio.to_thread(install_requirements)
+        install_result = await asyncio.to_thread(install_requirements)
+        await _notify_requirements_failures(install_result)
         self._update_requirements_status()
 
         in_flight = len(self.processes)

--- a/api/src/services/execution/simple_worker.py
+++ b/api/src/services/execution/simple_worker.py
@@ -28,67 +28,156 @@ import json
 import logging
 import os
 import resource
+import subprocess
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-def install_requirements() -> None:
+@dataclass
+class FailedPackage:
+    """One requirements line that failed to install."""
+
+    package: str
+    error: str
+
+
+@dataclass
+class RequirementsInstallResult:
+    """Outcome of a pool requirements install attempt.
+
+    `ok` is True when nothing failed (including the trivial no-requirements
+    case). `installed` + `failed` partition `attempted`.
     """
-    Install packages from requirements.txt.
 
-    Called once at pool startup to ensure user-installed packages persist
-    across container restarts. Reads requirements via get_requirements_sync()
-    which handles Redis → S3 fallback automatically.
+    attempted: list[str] = field(default_factory=list)
+    installed: list[str] = field(default_factory=list)
+    failed: list[FailedPackage] = field(default_factory=list)
 
-    Since all child processes share the same filesystem as the parent,
-    installing once in the parent process is sufficient.
+    @property
+    def ok(self) -> bool:
+        return not self.failed
 
-    This function never raises — failures are logged and execution continues.
+
+def _parse_requirement_lines(content: str) -> list[str]:
+    """Return real package specs (non-comment, non-blank, non-option lines)."""
+    packages, _options = _parse_requirements(content)
+    return packages
+
+
+def _parse_requirements(content: str) -> tuple[list[str], list[str]]:
+    """Split requirements file content into package specs and pip option tokens.
+
+    Lines starting with ``-`` (e.g. ``-i``, ``--index-url``,
+    ``--extra-index-url``, ``-r other.txt``) are pip options, not packages.
+    Their whitespace-split tokens are collected so the per-package fallback can
+    reapply the same index/source configuration to each individual install.
+    Comment and blank lines are ignored.
     """
-    import subprocess
+    packages: list[str] = []
+    options: list[str] = []
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("-"):
+            options.extend(line.split())
+            continue
+        packages.append(line)
+    return packages, options
+
+
+def _pip_install(args: list[str]) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(
+        [sys.executable, "-m", "pip", "install", *args, "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=300,  # 5 minute timeout
+    )
+
+
+def install_requirements() -> RequirementsInstallResult:
+    """
+    Install packages from requirements.txt resiliently.
+
+    Called once at pool startup (and on recycle_all) to ensure user-installed
+    packages persist across container restarts. Reads requirements via
+    get_requirements_sync() (Redis → S3 fallback).
+
+    Strategy: attempt a single batch ``pip install -r`` for speed. If the batch
+    fails (e.g. one package can't build), fall back to installing each
+    requirement individually so a single bad package no longer strips the whole
+    runtime. Returns a structured result; the async caller surfaces failures.
+
+    This function never raises — failures are captured in the returned result.
+    """
     import tempfile
 
     from src.core.requirements_cache import get_requirements_sync
 
+    result = RequirementsInstallResult()
+
     content = get_requirements_sync()
     if not content:
         logger.info("[pool] No requirements.txt found")
-        return
+        return result
 
-    # Write to temp file and install
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-        f.write(content)
-        temp_path = f.name
+    packages, options = _parse_requirements(content)
+    result.attempted = list(packages)
+    if not packages:
+        return result
 
+    # Fast path: one batch install.
+    temp_path: str | None = None
     try:
-        logger.info("[pool] Installing packages from requirements.txt")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(content)
+            temp_path = f.name
 
-        result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-r", temp_path, "--quiet"],
-            capture_output=True,
-            text=True,
-            timeout=300,  # 5 minute timeout
+        logger.info(f"[pool] Installing {len(packages)} packages from requirements.txt")
+        batch = _pip_install(["-r", temp_path])
+        if batch.returncode == 0:
+            logger.info(f"[pool] Installed {len(packages)} packages from requirements.txt")
+            result.installed = list(packages)
+            return result
+
+        logger.warning(
+            "[pool] Batch pip install failed; falling back to per-package install. "
+            f"pip output: {batch.stderr or batch.stdout}"
         )
-
-        if result.returncode == 0:
-            pkg_count = len([line for line in content.strip().split("\n") if line.strip()])
-            logger.info(f"[pool] Installed {pkg_count} packages from requirements.txt")
-        else:
-            logger.warning(f"[pool] pip install failed: {result.stderr or result.stdout}")
-
     except subprocess.TimeoutExpired:
-        logger.warning("[pool] pip install timed out after 5 minutes")
-    except Exception as e:
-        logger.warning(f"[pool] Failed to install requirements: {e}")
+        logger.warning("[pool] Batch pip install timed out; trying per-package install")
+    except Exception as e:  # noqa: BLE001 - batch failure must not abort the fallback path
+        logger.warning(f"[pool] Batch install error ({e}); trying per-package install")
     finally:
+        if temp_path is not None:
+            try:
+                os.unlink(temp_path)
+            except OSError as e:
+                logger.debug(f"[pool] could not remove temp requirements file {temp_path}: {e}")
+
+    # Fallback: install each requirement on its own so one bad package only
+    # fails itself.
+    for pkg in packages:
         try:
-            os.unlink(temp_path)
-        except OSError as e:
-            # Temp file may already be gone — best-effort cleanup
-            logger.debug(f"[pool] could not remove temp requirements file {temp_path}: {e}")
+            single = _pip_install([*options, pkg])
+            if single.returncode == 0:
+                result.installed.append(pkg)
+            else:
+                err = (single.stderr or single.stdout or "").strip()
+                result.failed.append(FailedPackage(package=pkg, error=err[:2000]))
+                logger.warning(f"[pool] Failed to install '{pkg}': {err[:500]}")
+        except subprocess.TimeoutExpired:
+            result.failed.append(FailedPackage(package=pkg, error="pip install timed out (300s)"))
+            logger.warning(f"[pool] Timed out installing '{pkg}'")
+        except Exception as e:  # noqa: BLE001 - per-package install must never abort the loop
+            result.failed.append(FailedPackage(package=pkg, error=str(e)))
+            logger.warning(f"[pool] Error installing '{pkg}': {e}")
+
+    return result
 
 
 def _clear_workspace_modules() -> None:

--- a/api/tests/unit/execution/test_install_progress.py
+++ b/api/tests/unit/execution/test_install_progress.py
@@ -1,0 +1,81 @@
+"""Unit tests for the install-progress aggregator."""
+from __future__ import annotations
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.execution.install_progress import (
+    WorkerPhase,
+    aggregate_phases,
+    summary_line,
+)
+
+
+def test_aggregate_counts_phases_out_of_total():
+    phases = {
+        "w1": WorkerPhase(phase="installed"),
+        "w2": WorkerPhase(phase="installing"),
+        "w3": WorkerPhase(phase="failed", package="xhtml2pdf", error="no cc"),
+    }
+    agg = aggregate_phases(phases, total=4)
+    assert agg["total"] == 4
+    assert agg["installed"] == 1
+    assert agg["installing"] == 1
+    assert agg["failed"] == 1
+    assert agg["failures"] == [{"worker": "w3", "package": "xhtml2pdf", "error": "no cc"}]
+
+
+def test_summary_line_installing():
+    agg = {"total": 6, "installing": 3, "installed": 0, "recycling": 0,
+           "recycled": 0, "failed": 0, "failures": []}
+    assert summary_line(agg, action="install") == "Installing on 3/6 workers…"
+
+
+def test_summary_line_complete_with_failures():
+    agg = {"total": 6, "installing": 0, "installed": 5, "recycling": 0,
+           "recycled": 5, "failed": 1,
+           "failures": [{"worker": "w4", "package": "xhtml2pdf", "error": "no cc"}]}
+    line = summary_line(agg, action="install")
+    assert "5/6" in line
+    assert "xhtml2pdf" in line
+
+
+def test_summary_line_done_uses_folded_installed_count():
+    # 3 done total: but raw recycled=1. Folded installed must win → 3/3.
+    agg = {"total": 3, "installing": 0, "installed": 3, "recycling": 0,
+           "recycled": 1, "failed": 0, "failures": []}
+    assert summary_line(agg, action="install") == "Installed on 3/3 workers"
+
+
+@pytest.mark.asyncio
+async def test_report_phase_writes_hash_and_publishes_once():
+    fake_redis = AsyncMock()
+    fake_redis.hgetall.return_value = {
+        "w1": json.dumps({"phase": "installed"}),
+        "w2": json.dumps({"phase": "installing"}),
+    }
+    fake_redis.scan.side_effect = [(0, ["bifrost:pool:w1", "bifrost:pool:w2"])]
+
+    published: list[dict] = []
+
+    async def fake_broadcast(channel, message):
+        published.append(message)
+
+    from src.services.execution import install_progress as ip
+    with patch.object(ip, "_raw_redis", AsyncMock(return_value=fake_redis)), \
+         patch.object(ip.pubsub_manager, "broadcast", side_effect=fake_broadcast):
+        await ip.report_phase(
+            run_id="run1", worker_id="w1", phase="installed", action="install"
+        )
+
+    fake_redis.hset.assert_awaited_once()
+    call_args = fake_redis.hset.await_args
+    assert call_args.args[0] == "bifrost:pkg-install:run1"
+    assert call_args.args[1] == "w1"
+    assert "installed" in call_args.args[2]
+    assert len(published) == 1
+    assert published[0]["type"] == "progress"
+    assert published[0]["total"] == 2
+    assert published[0]["installed"] == 1
+    assert published[0]["line"] == "Installing on 1/2 workers…"

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -20,6 +20,10 @@ from src.services.execution.process_pool import (
     ProcessPoolManager,
     ProcessState,
 )
+from src.services.execution.simple_worker import (
+    FailedPackage,
+    RequirementsInstallResult,
+)
 
 
 class TestProcessState:
@@ -991,3 +995,69 @@ class TestCrashedProcessReport:
 
         # Handle still removed from pool (cleanup still happens)
         assert "process-sigkill-2" not in pool.processes
+
+
+# ---------------------------------------------------------------------------
+# _notify_requirements_failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_install_notifies_admins():
+    """A result with failed packages creates a deduped admin notification."""
+    from src.services.execution.process_pool import _notify_requirements_failures
+
+    result = RequirementsInstallResult(
+        attempted=["anthropic", "xhtml2pdf"],
+        installed=["anthropic"],
+        failed=[FailedPackage(package="xhtml2pdf", error="Unknown compiler(s): cc")],
+    )
+
+    svc = AsyncMock()
+    svc.find_admin_notification_by_title.return_value = None  # no existing dup
+    with patch(
+        "src.services.execution.process_pool.get_notification_service",
+        return_value=svc,
+    ):
+        await _notify_requirements_failures(result)
+
+    svc.create_notification.assert_awaited_once()
+    kwargs = svc.create_notification.await_args.kwargs
+    assert kwargs["for_admins"] is True
+    assert kwargs["user_id"] == "system"
+    assert "xhtml2pdf" in kwargs["request"].description
+
+
+@pytest.mark.asyncio
+async def test_failed_install_dedups_existing_notification():
+    from src.services.execution.process_pool import _notify_requirements_failures
+
+    result = RequirementsInstallResult(
+        attempted=["xhtml2pdf"],
+        installed=[],
+        failed=[FailedPackage(package="xhtml2pdf", error="boom")],
+    )
+    svc = AsyncMock()
+    svc.find_admin_notification_by_title.return_value = object()  # dup exists
+    with patch(
+        "src.services.execution.process_pool.get_notification_service",
+        return_value=svc,
+    ):
+        await _notify_requirements_failures(result)
+
+    svc.create_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_successful_install_does_not_notify():
+    from src.services.execution.process_pool import _notify_requirements_failures
+
+    result = RequirementsInstallResult(
+        attempted=["anthropic"], installed=["anthropic"], failed=[]
+    )
+    with patch(
+        "src.services.execution.process_pool.get_notification_service",
+    ) as get_svc:
+        await _notify_requirements_failures(result)
+
+    get_svc.assert_not_called()

--- a/api/tests/unit/execution/test_simple_worker_install.py
+++ b/api/tests/unit/execution/test_simple_worker_install.py
@@ -1,0 +1,135 @@
+"""Unit tests for install_requirements resilient install + result reporting."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch, MagicMock
+
+from src.services.execution.simple_worker import (
+    install_requirements,
+    RequirementsInstallResult,
+)
+
+
+def _completed(returncode: int, stderr: str = "", stdout: str = "") -> MagicMock:
+    m = MagicMock(spec=subprocess.CompletedProcess)
+    m.returncode = returncode
+    m.stderr = stderr
+    m.stdout = stdout
+    return m
+
+
+def test_no_requirements_returns_empty_result():
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=None
+    ):
+        result = install_requirements()
+    assert isinstance(result, RequirementsInstallResult)
+    assert result.attempted == []
+    assert result.failed == []
+    assert result.ok is True
+
+
+def test_batch_success_marks_all_installed():
+    content = "anthropic\nlitellm\nreportlab\n"
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch(
+        "src.services.execution.simple_worker.subprocess.run",
+        return_value=_completed(0),
+    ) as run:
+        result = install_requirements()
+    assert run.call_count == 1
+    assert result.ok is True
+    assert set(result.installed) == {"anthropic", "litellm", "reportlab"}
+    assert result.failed == []
+
+
+def test_batch_failure_falls_back_to_per_package_and_isolates_bad_dep():
+    content = "anthropic\nxhtml2pdf\nreportlab\n"
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "-r" in cmd:
+            return _completed(1, stderr="metadata-generation-failed: pycairo")
+        if "xhtml2pdf" in joined:
+            return _completed(1, stderr="ERROR: Unknown compiler(s): cc gcc")
+        return _completed(0)
+
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch(
+        "src.services.execution.simple_worker.subprocess.run", side_effect=fake_run
+    ):
+        result = install_requirements()
+
+    assert result.ok is False
+    assert set(result.installed) == {"anthropic", "reportlab"}
+    assert [f.package for f in result.failed] == ["xhtml2pdf"]
+    assert "Unknown compiler" in result.failed[0].error
+
+
+def test_comments_and_blank_lines_are_ignored():
+    content = "# a comment\n\nanthropic\n  \n# another\nlitellm\n"
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch(
+        "src.services.execution.simple_worker.subprocess.run",
+        return_value=_completed(0),
+    ):
+        result = install_requirements()
+    assert set(result.attempted) == {"anthropic", "litellm"}
+
+
+def test_per_package_fallback_reapplies_pip_options():
+    content = "--extra-index-url https://example.com/simple\nanthropic\nlitellm\n"
+
+    per_package_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        if "-r" in cmd:
+            # Force batch failure so we reach the per-package fallback.
+            return _completed(1, stderr="batch boom")
+        per_package_calls.append(list(cmd))
+        return _completed(0)
+
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch(
+        "src.services.execution.simple_worker.subprocess.run", side_effect=fake_run
+    ):
+        result = install_requirements()
+
+    # Option line is not treated as a package.
+    assert set(result.attempted) == {"anthropic", "litellm"}
+    assert set(result.installed) == {"anthropic", "litellm"}
+    assert result.ok is True
+
+    # Every per-package invocation carries the index config.
+    assert len(per_package_calls) == 2
+    for cmd in per_package_calls:
+        assert "--extra-index-url" in cmd
+        assert "https://example.com/simple" in cmd
+
+
+def test_per_package_timeout_isolates_failed_package():
+    content = "anthropic\nslowpkg\nlitellm\n"
+
+    def fake_run(cmd, **kwargs):
+        if "-r" in cmd:
+            # Force batch failure so we reach the per-package fallback.
+            return _completed(1, stderr="batch boom")
+        if "slowpkg" in cmd:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=300)
+        return _completed(0)
+
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch(
+        "src.services.execution.simple_worker.subprocess.run", side_effect=fake_run
+    ):
+        result = install_requirements()
+
+    assert result.ok is False
+    assert set(result.installed) == {"anthropic", "litellm"}
+    assert [f.package for f in result.failed] == ["slowpkg"]
+    assert result.failed[0].error == "pip install timed out (300s)"

--- a/api/tests/unit/jobs/test_package_install_consumer.py
+++ b/api/tests/unit/jobs/test_package_install_consumer.py
@@ -21,28 +21,30 @@ class TestProcessMessage:
 
     @pytest.mark.asyncio
     async def test_specific_package_update_recycles(self, consumer: PackageInstallConsumer):
-        """Test that updating a package (is_update=True) triggers recycle."""
+        """Test that updating a package (is_update=True) triggers recycle with correct phases."""
         with (
+            patch("src.jobs.consumers.package_install.report_phase", new_callable=AsyncMock) as rp,
             patch.object(
-                consumer, "_pip_install", new_callable=AsyncMock, return_value=True
+                consumer, "_pip_install", new_callable=AsyncMock, return_value=None
             ) as mock_pip,
             patch.object(consumer, "_recycle_workers", new_callable=AsyncMock) as mock_recycle,
             patch.object(
                 consumer, "_update_pool_packages", new_callable=AsyncMock
             ) as mock_update,
-            patch.object(consumer, "_send_log", new_callable=AsyncMock),
-            patch.object(consumer, "_send_complete", new_callable=AsyncMock),
         ):
             await consumer.process_message({
                 "type": "recycle_workers",
                 "package": "requests",
                 "version": "2.31.0",
                 "is_update": True,
+                "run_id": "test-run-1",
             })
 
             mock_pip.assert_called_once_with("requests", "2.31.0")
             mock_recycle.assert_called_once()
             mock_update.assert_called_once()
+            phases = [c.kwargs["phase"] for c in rp.await_args_list]
+            assert phases == ["installing", "recycling", "recycled"]
 
     @pytest.mark.asyncio
     async def test_new_package_also_recycles(self, consumer: PackageInstallConsumer):
@@ -52,72 +54,123 @@ class TestProcessMessage:
         recycling to see newly installed packages on the filesystem.
         """
         with (
+            patch("src.jobs.consumers.package_install.report_phase", new_callable=AsyncMock) as rp,
             patch.object(
-                consumer, "_pip_install", new_callable=AsyncMock, return_value=True
+                consumer, "_pip_install", new_callable=AsyncMock, return_value=None
             ) as mock_pip,
             patch.object(consumer, "_recycle_workers", new_callable=AsyncMock) as mock_recycle,
             patch.object(
                 consumer, "_update_pool_packages", new_callable=AsyncMock
             ) as mock_update,
-            patch.object(consumer, "_send_log", new_callable=AsyncMock),
-            patch.object(consumer, "_send_complete", new_callable=AsyncMock),
         ):
             await consumer.process_message({
                 "type": "recycle_workers",
                 "package": "new-package",
                 "version": "1.0.0",
                 "is_update": False,
+                "run_id": "test-run-2",
             })
 
             mock_pip.assert_called_once_with("new-package", "1.0.0")
             mock_recycle.assert_called_once()
             mock_update.assert_called_once()
+            phases = [c.kwargs["phase"] for c in rp.await_args_list]
+            assert phases == ["installing", "recycling", "recycled"]
 
     @pytest.mark.asyncio
     async def test_missing_is_update_defaults_to_recycle(self, consumer: PackageInstallConsumer):
         """Test that missing is_update defaults to True (safe default)."""
         with (
+            patch("src.jobs.consumers.package_install.report_phase", new_callable=AsyncMock) as rp,
             patch.object(
-                consumer, "_pip_install", new_callable=AsyncMock, return_value=True
+                consumer, "_pip_install", new_callable=AsyncMock, return_value=None
             ),
             patch.object(consumer, "_recycle_workers", new_callable=AsyncMock) as mock_recycle,
             patch.object(
                 consumer, "_update_pool_packages", new_callable=AsyncMock
             ),
-            patch.object(consumer, "_send_log", new_callable=AsyncMock),
-            patch.object(consumer, "_send_complete", new_callable=AsyncMock),
         ):
             await consumer.process_message({
                 "type": "recycle_workers",
                 "package": "requests",
                 "version": "2.31.0",
+                "run_id": "test-run-3",
             })
 
             mock_recycle.assert_called_once()
+            phases = [c.kwargs["phase"] for c in rp.await_args_list]
+            assert phases == ["installing", "recycling", "recycled"]
 
     @pytest.mark.asyncio
     async def test_requirements_install(self, consumer: PackageInstallConsumer):
         """Test that no package triggers requirements.txt install + recycle."""
         with (
+            patch("src.jobs.consumers.package_install.report_phase", new_callable=AsyncMock) as rp,
             patch.object(
-                consumer, "_pip_install_requirements", new_callable=AsyncMock, return_value=True
+                consumer, "_pip_install_requirements", new_callable=AsyncMock, return_value=None
             ) as mock_pip_req,
             patch.object(consumer, "_recycle_workers", new_callable=AsyncMock) as mock_recycle,
             patch.object(
                 consumer, "_update_pool_packages", new_callable=AsyncMock
             ) as mock_update,
-            patch.object(consumer, "_send_log", new_callable=AsyncMock),
-            patch.object(consumer, "_send_complete", new_callable=AsyncMock),
         ):
             await consumer.process_message({
                 "type": "recycle_workers",
                 "package": None,
                 "is_update": True,
+                "run_id": "test-run-4",
             })
 
             mock_pip_req.assert_called_once()
             mock_recycle.assert_called_once()
             mock_update.assert_called_once()
+            phases = [c.kwargs["phase"] for c in rp.await_args_list]
+            assert phases == ["installing", "recycling", "recycled"]
+
+    @pytest.mark.asyncio
+    async def test_install_failure_reports_failed_and_skips_recycle(
+        self, consumer: PackageInstallConsumer
+    ):
+        """Test that pip failure reports failed phase with the real error and skips recycle."""
+        with (
+            patch("src.jobs.consumers.package_install.report_phase", new_callable=AsyncMock) as rp,
+            patch.object(
+                consumer, "_pip_install", new_callable=AsyncMock,
+                return_value="ERROR: no C compiler",
+            ),
+            patch.object(consumer, "_recycle_workers", new_callable=AsyncMock) as recycle,
+        ):
+            await consumer.process_message({
+                "action": "install",
+                "package": "badpkg",
+                "run_id": "test-run-fail",
+            })
+
+        phases = [c.kwargs["phase"] for c in rp.await_args_list]
+        assert phases[0] == "installing"
+        assert phases[-1] == "failed"
+        # The real pip error must flow through to the aggregator.
+        assert rp.await_args_list[-1].kwargs["error"] == "ERROR: no C compiler"
+        recycle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_uninstall_without_package_reports_failed_and_skips_recycle(
+        self, consumer: PackageInstallConsumer
+    ):
+        """Test that uninstall with no package name fails before any pip call."""
+        with (
+            patch("src.jobs.consumers.package_install.report_phase", new_callable=AsyncMock) as rp,
+            patch.object(consumer, "_recycle_workers", new_callable=AsyncMock) as recycle,
+        ):
+            await consumer.process_message({
+                "action": "uninstall",
+                "package": None,
+                "run_id": "x",
+            })
+
+        phases = [c.kwargs["phase"] for c in rp.await_args_list]
+        assert phases == ["installing", "failed"]
+        recycle.assert_not_awaited()
 
 
 class TestRecycleWorkers:

--- a/client/src/components/editor/PackagePanel.progress.test.tsx
+++ b/client/src/components/editor/PackagePanel.progress.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the package-install progress collapse + completion logic.
+ *
+ * Tests the handleProgressEvent helper directly — no component rendering
+ * needed, which keeps these fast and dependency-free.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { handleProgressEvent } from "./packageProgress";
+import type { ProgressState, ProgressStore } from "./packageProgress";
+import type { PackageProgress } from "@/services/websocket";
+
+function makeProgress(overrides: Partial<PackageProgress> = {}): PackageProgress {
+	return {
+		action: "install",
+		line: "Installing on 1/6 workers…",
+		total: 6,
+		installing: 1,
+		installed: 0,
+		recycling: 0,
+		recycled: 0,
+		failed: 0,
+		failures: [],
+		...overrides,
+	};
+}
+
+function makeStore(): ProgressStore & {
+	appendLogCalls: Parameters<ProgressStore["appendLog"]>[];
+	completeExecutionCalls: Parameters<ProgressStore["completeExecution"]>[];
+} {
+	const appendLogCalls: Parameters<ProgressStore["appendLog"]>[] = [];
+	const completeExecutionCalls: Parameters<ProgressStore["completeExecution"]>[] = [];
+	return {
+		appendLogCalls,
+		completeExecutionCalls,
+		appendLog: vi.fn((...args: Parameters<ProgressStore["appendLog"]>) => {
+			appendLogCalls.push(args);
+		}),
+		completeExecution: vi.fn(
+			(...args: Parameters<ProgressStore["completeExecution"]>) => {
+				completeExecutionCalls.push(args);
+			},
+		),
+	};
+}
+
+describe("handleProgressEvent — collapse logic", () => {
+	it("two progress events with the same line result in only ONE appended log", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+		const id = "install-1";
+
+		const p = makeProgress({ line: "Installing on 3/6 workers…" });
+
+		handleProgressEvent(p, state, store, id);
+		handleProgressEvent(p, state, store, id);
+
+		expect(store.appendLogCalls).toHaveLength(1);
+		expect(store.appendLogCalls[0][1].message).toBe("Installing on 3/6 workers…");
+	});
+
+	it("a progress event with a different line appends a second log", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+		const id = "install-1";
+
+		handleProgressEvent(
+			makeProgress({ line: "Installing on 3/6 workers…" }),
+			state,
+			store,
+			id,
+		);
+		handleProgressEvent(
+			makeProgress({ line: "Recycling on 3/6 workers…" }),
+			state,
+			store,
+			id,
+		);
+
+		expect(store.appendLogCalls).toHaveLength(2);
+		expect(store.appendLogCalls[0][1].message).toBe("Installing on 3/6 workers…");
+		expect(store.appendLogCalls[1][1].message).toBe("Recycling on 3/6 workers…");
+	});
+});
+
+describe("handleProgressEvent — completion logic", () => {
+	it("marks execution Success when recycled + failed >= total and failed === 0", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+		const id = "install-1";
+
+		const triggered = handleProgressEvent(
+			makeProgress({ total: 6, recycled: 6, failed: 0, line: "Done" }),
+			state,
+			store,
+			id,
+		);
+
+		expect(triggered).toBe(true);
+		expect(store.completeExecutionCalls).toHaveLength(1);
+		expect(store.completeExecutionCalls[0]).toEqual([id, undefined, "Success"]);
+	});
+
+	it("marks execution Failed when failed > 0 and recycled + failed >= total", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+		const id = "install-1";
+
+		const triggered = handleProgressEvent(
+			makeProgress({ total: 6, recycled: 4, failed: 2, line: "Done" }),
+			state,
+			store,
+			id,
+		);
+
+		expect(triggered).toBe(true);
+		expect(store.completeExecutionCalls[0]).toEqual([id, undefined, "Failed"]);
+	});
+
+	it("does NOT complete when recycled + failed < total", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+
+		handleProgressEvent(
+			makeProgress({ total: 6, recycled: 3, failed: 0, line: "In progress" }),
+			state,
+			store,
+			"install-1",
+		);
+
+		expect(store.completeExecutionCalls).toHaveLength(0);
+	});
+
+	it("only completes once even if multiple events satisfy the condition", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+		const id = "install-1";
+
+		// Two terminal events with DIFFERENT lines (so both pass the collapse
+		// guard and append naturally) — the completionHandled guard must still
+		// fire completeExecution exactly once.
+		handleProgressEvent(
+			makeProgress({ total: 6, recycled: 6, failed: 0, line: "All 6 workers recycled" }),
+			state,
+			store,
+			id,
+		);
+		handleProgressEvent(
+			makeProgress({ total: 6, recycled: 6, failed: 0, line: "Installation complete" }),
+			state,
+			store,
+			id,
+		);
+
+		expect(store.appendLogCalls).toHaveLength(2);
+		expect(store.completeExecutionCalls).toHaveLength(1);
+	});
+
+	it("uses WARNING level when failed > 0", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+
+		handleProgressEvent(
+			makeProgress({ failed: 1, line: "1 failure" }),
+			state,
+			store,
+			"install-1",
+		);
+
+		expect(store.appendLogCalls[0][1].level).toBe("WARNING");
+	});
+
+	it("uses INFO level when failed === 0", () => {
+		const state: ProgressState = { lastLine: "", completionHandled: false };
+		const store = makeStore();
+
+		handleProgressEvent(
+			makeProgress({ failed: 0, line: "All good" }),
+			state,
+			store,
+			"install-1",
+		);
+
+		expect(store.appendLogCalls[0][1].level).toBe("INFO");
+	});
+});

--- a/client/src/components/editor/PackagePanel.tsx
+++ b/client/src/components/editor/PackagePanel.tsx
@@ -14,6 +14,8 @@ import {
 import { webSocketService } from "@/services/websocket";
 import { useEditorStore } from "@/stores/editorStore";
 import { useExecutionStreamStore } from "@/stores/executionStreamStore";
+import { handleProgressEvent } from "./packageProgress";
+import type { ProgressState } from "./packageProgress";
 
 /**
  * Package management panel for installing and managing Python packages.
@@ -36,12 +38,16 @@ export function PackagePanel() {
 	>(null);
 
 	// Track whether we've already handled completion for this installation.
-	// Multiple workers send complete events; we only process the first one.
+	// Multiple workers publish progress; we only fire completeExecution once.
 	const completionHandledRef = useRef(false);
 
 	// Ref for installationId so WebSocket callbacks can read it synchronously.
 	// React state updates are batched; the closure would capture stale values.
 	const currentInstallationIdRef = useRef<string | null>(null);
+
+	// Tracks the last progress line we appended so identical consecutive lines
+	// from multiple workers can be collapsed to a single entry.
+	const lastProgressLineRef = useRef<string>("");
 
 	const setCurrentStreamingExecutionId = useEditorStore(
 		(state) => state.setCurrentStreamingExecutionId,
@@ -84,7 +90,7 @@ export function PackagePanel() {
 		}
 	}, []);
 
-	// Subscribe to shared package:install channel for streaming logs
+	// Subscribe to shared package:install channel for streaming progress
 	useEffect(() => {
 		if (!isConnected) {
 			return;
@@ -93,40 +99,29 @@ export function PackagePanel() {
 		const packageChannel = "package:install";
 		webSocketService.subscribe(packageChannel);
 
-		const unsubscribeLog = webSocketService.onPackageLog((log) => {
+		const unsubscribeProgress = webSocketService.onPackageProgress((p) => {
 			const id = currentInstallationIdRef.current;
-			if (id) {
-				const store = useExecutionStreamStore.getState();
-				store.appendLog(id, {
-					level: log.level.toUpperCase(),
-					message: log.message,
-					timestamp: new Date().toISOString(),
-				});
+			if (!id) return;
+
+			const progressState: ProgressState = {
+				lastLine: lastProgressLineRef.current,
+				completionHandled: completionHandledRef.current,
+			};
+
+			const store = useExecutionStreamStore.getState();
+			const triggered = handleProgressEvent(p, progressState, store, id);
+
+			// Sync mutated state back to refs
+			lastProgressLineRef.current = progressState.lastLine;
+			completionHandledRef.current = progressState.completionHandled;
+
+			if (triggered) {
+				loadPackages();
 			}
 		});
 
-		// Handle completion — only process the first complete event
-		const unsubscribeComplete = webSocketService.onPackageComplete(
-			(complete) => {
-				if (completionHandledRef.current) return;
-				completionHandledRef.current = true;
-
-				const id = currentInstallationIdRef.current;
-				if (id) {
-					const store = useExecutionStreamStore.getState();
-					store.completeExecution(
-						id,
-						undefined,
-						complete.status === "success" ? "Success" : "Failed",
-					);
-				}
-				loadPackages();
-			},
-		);
-
 		return () => {
-			unsubscribeLog();
-			unsubscribeComplete();
+			unsubscribeProgress();
 			webSocketService.unsubscribe(packageChannel);
 		};
 	}, [isConnected, loadPackages]);
@@ -234,6 +229,7 @@ export function PackagePanel() {
 		currentInstallationIdRef.current = installationId;
 		setCurrentInstallationId(installationId);
 		completionHandledRef.current = false;
+		lastProgressLineRef.current = "";
 		setIsInstalling(true);
 
 		try {
@@ -279,6 +275,7 @@ export function PackagePanel() {
 		currentInstallationIdRef.current = installationId;
 		setCurrentInstallationId(installationId);
 		completionHandledRef.current = false;
+		lastProgressLineRef.current = "";
 		setIsInstalling(true);
 
 		try {

--- a/client/src/components/editor/packageProgress.ts
+++ b/client/src/components/editor/packageProgress.ts
@@ -1,0 +1,60 @@
+import type { PackageProgress } from "@/services/websocket";
+
+export interface ProgressState {
+	lastLine: string;
+	completionHandled: boolean;
+}
+
+export interface ProgressStore {
+	appendLog: (
+		id: string,
+		log: { level: string; message: string; timestamp: string },
+	) => void;
+	completeExecution: (
+		id: string,
+		variables: Record<string, unknown> | undefined,
+		status: "Success" | "Failed",
+	) => void;
+}
+
+/**
+ * Handle a single aggregated package-install progress event.
+ *
+ * Rules:
+ * - Collapse consecutive identical lines (compare to state.lastLine).
+ * - Derive completion when recycled + failed >= total && total > 0.
+ * - Guard completion with state.completionHandled so only the first
+ *   qualifying event triggers it.
+ *
+ * Mutates `state` in place (mirrors ref semantics in the component).
+ * Returns true if loadPackages should be called (completion was triggered).
+ */
+export function handleProgressEvent(
+	p: PackageProgress,
+	state: ProgressState,
+	store: ProgressStore,
+	id: string,
+): boolean {
+	// Collapse: skip if this line is identical to the last one we appended.
+	if (p.line !== state.lastLine) {
+		state.lastLine = p.line;
+		store.appendLog(id, {
+			level: p.failed > 0 ? "WARNING" : "INFO",
+			message: p.line,
+			timestamp: new Date().toISOString(),
+		});
+	}
+
+	// Derive completion.
+	if (
+		p.total > 0 &&
+		p.recycled + p.failed >= p.total &&
+		!state.completionHandled
+	) {
+		state.completionHandled = true;
+		store.completeExecution(id, undefined, p.failed > 0 ? "Failed" : "Success");
+		return true;
+	}
+
+	return false;
+}

--- a/client/src/services/websocket.ts
+++ b/client/src/services/websocket.ts
@@ -150,6 +150,21 @@ export interface PackageComplete {
 	message: string;
 }
 
+export interface PackageProgress {
+	action: "install" | "uninstall";
+	line: string;
+	total: number;
+	installing: number;
+	// FOLDED count: workers past the install step (installed + recycling +
+	// recycled). recycling/recycled below are raw — don't sum installed with
+	// them or you'll double-count.
+	installed: number;
+	recycling: number;
+	recycled: number;
+	failed: number;
+	failures: { worker: string; package: string | null; error: string | null }[];
+}
+
 export interface LocalRunnerStateUpdate {
 	file_path: string;
 	workflows: Array<{
@@ -438,8 +453,18 @@ type WebSocketMessage =
 	| { type: "notification_created"; notification: NotificationPayload }
 	| { type: "notification_updated"; notification: NotificationPayload }
 	| { type: "notification_dismissed"; notification_id: string }
-	| { type: "log"; level: string; message: string }
-	| { type: "complete"; status: "success" | "error"; message: string }
+	| {
+			type: "progress";
+			action: "install" | "uninstall";
+			line: string;
+			total: number;
+			installing: number;
+			installed: number;
+			recycling: number;
+			recycled: number;
+			failed: number;
+			failures: { worker: string; package: string | null; error: string | null }[];
+	  }
 	| { type: "git_log"; jobId: string; level: string; message: string }
 	| { type: "git_progress"; jobId: string; phase: string; current: number; total: number; path?: string | null }
 	| { type: "git_complete"; jobId: string; status: "success" | "error"; message: string; [key: string]: unknown }
@@ -491,8 +516,7 @@ type ExecutionUpdateCallback = (update: ExecutionUpdate) => void;
 type ExecutionLogCallback = (log: ExecutionLog) => void;
 type NewExecutionCallback = (execution: NewExecution) => void;
 type HistoryUpdateCallback = (update: HistoryUpdate) => void;
-type PackageLogCallback = (log: PackageLog) => void;
-type PackageCompleteCallback = (complete: PackageComplete) => void;
+type PackageProgressCallback = (p: PackageProgress) => void;
 // Git sync progress type
 export interface GitProgress {
 	phase: string;
@@ -560,8 +584,7 @@ class WebSocketService {
 	>();
 	private newExecutionCallbacks = new Set<NewExecutionCallback>();
 	private historyUpdateCallbacks = new Set<HistoryUpdateCallback>();
-	private packageLogCallbacks = new Set<PackageLogCallback>();
-	private packageCompleteCallbacks = new Set<PackageCompleteCallback>();
+	private packageProgressCallbacks = new Set<PackageProgressCallback>();
 	private gitLogCallbacks = new Map<string, Set<GitLogCallback>>();
 	private gitProgressCallbacks = new Map<string, Set<GitProgressCallback>>();
 	private gitCompleteCallbacks = new Map<string, Set<GitCompleteCallback>>();
@@ -822,17 +845,20 @@ class WebSocketService {
 					.removeNotification(message.notification_id);
 				break;
 
-			case "log":
-				// Package installation log message
-				this.packageLogCallbacks.forEach((cb) =>
-					cb({ level: message.level, message: message.message }),
-				);
-				break;
-
-			case "complete":
-				// Package installation complete message
-				this.packageCompleteCallbacks.forEach((cb) =>
-					cb({ status: message.status, message: message.message }),
+			case "progress":
+				// Aggregated package-install progress (one rolling line across workers)
+				this.packageProgressCallbacks.forEach((cb) =>
+					cb({
+						action: message.action,
+						line: message.line,
+						total: message.total,
+						installing: message.installing,
+						installed: message.installed,
+						recycling: message.recycling,
+						recycled: message.recycled,
+						failed: message.failed,
+						failures: message.failures,
+					}),
 				);
 				break;
 
@@ -1285,22 +1311,12 @@ class WebSocketService {
 	}
 
 	/**
-	 * Subscribe to package installation logs
+	 * Subscribe to aggregated package-install progress events
 	 */
-	onPackageLog(callback: PackageLogCallback): () => void {
-		this.packageLogCallbacks.add(callback);
+	onPackageProgress(callback: PackageProgressCallback): () => void {
+		this.packageProgressCallbacks.add(callback);
 		return () => {
-			this.packageLogCallbacks.delete(callback);
-		};
-	}
-
-	/**
-	 * Subscribe to package installation completion
-	 */
-	onPackageComplete(callback: PackageCompleteCallback): () => void {
-		this.packageCompleteCallbacks.add(callback);
-		return () => {
-			this.packageCompleteCallbacks.delete(callback);
+			this.packageProgressCallbacks.delete(callback);
 		};
 	}
 

--- a/docs/superpowers/plans/2026-05-24-harden-pool-requirements-install.md
+++ b/docs/superpowers/plans/2026-05-24-harden-pool-requirements-install.md
@@ -1,0 +1,995 @@
+# Harden Pool Requirements Install Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the worker process-pool requirements install resilient so one unbuildable package can't silently strip the entire workflow runtime, surface install failures to platform admins via a notification, and replace the duplicated-per-worker install stream with a single fleet-aware `(x/y) workers` progress summary.
+
+**Architecture:** Today `install_requirements()` runs `pip install -r requirements.txt` as a single all-or-nothing command and returns `None`, swallowing failures. We change it to (1) attempt the batch install, and on failure (2) fall back to installing each package individually so good packages still land, and (3) return a structured `RequirementsInstallResult` describing what succeeded/failed. The async caller in `process_pool.py` (which already has an event loop + Redis) consumes that result and, when any package failed, publishes a deduplicated admin notification via the existing `NotificationService`.
+
+**Tech Stack:** Python 3.11 (the prod runtime; worker image), `subprocess`/`pip`, existing `NotificationService` (Redis-backed, `for_admins=True`), pytest.
+
+---
+
+## Background (why this change)
+
+Incident 2026-05-24: workers restarted and every workflow importing a runtime dep began failing with `No module named 'openrouter'` / `litellm` / `reportlab`. Root cause: `requirements.txt` contained `xhtml2pdf` (an unused leftover), which pulls `pycairo` transitively; `pycairo` has no wheel for the worker platform and must build from source, but the worker image has **no C compiler** (`cc`/`gcc`). `pip install -r` is all-or-nothing, so the `metadata-generation-failed` on `pycairo` aborted the install of **all 13 packages**. `install_requirements()` logged a `warning` and the pool started anyway — so the failure was invisible until workflows failed.
+
+The data-level fix (removing `xhtml2pdf` from the workspace `requirements.txt`) is being handled separately. **This plan is the code-level hardening** so a future bad package degrades gracefully and is visible.
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|---------------|--------|
+| `api/src/services/execution/simple_worker.py` | `install_requirements()` — batch-then-per-package install, returns structured result | Modify |
+| `api/src/services/execution/process_pool.py` | Two call sites of `install_requirements` — consume result, fire admin notification on failure | Modify (lines ~463, ~983) |
+| `api/tests/unit/execution/test_simple_worker_install.py` | Unit tests for the new install logic (subprocess mocked) | Create |
+| `api/tests/unit/execution/test_process_pool.py` | Test that a failed-package result triggers an admin notification | Modify (existing file) |
+
+## Design notes / constraints
+
+- **Runtime is Python 3.11** in prod workers — but `install_requirements()` imports must stay stdlib + existing project deps. No new third-party deps.
+- `install_requirements()` runs via `await asyncio.to_thread(install_requirements)` from `ProcessPoolManager.start()` and `recycle_all()`. It is therefore **synchronous** and must stay sync (it runs in a thread). It must **not** do async/Redis work itself — it returns data; the async caller notifies.
+- Notification convention (from `api/src/services/file_storage/diagnostics.py:95` and `agent_executor.py:620`): `get_notification_service().create_notification(user_id="system", request=NotificationCreate(category=..., title=..., description=...), for_admins=True)`. Category `NotificationCategory.PACKAGE_INSTALL` already exists for this purpose.
+- **Dedup:** workers recycle and there are 6 of them; use `find_admin_notification_by_title(title, category)` before creating, so we don't spawn 6 identical notifications. Title is stable per failure set.
+- **Per-package fallback** only runs when the batch fails, to keep the happy path fast (one pip invocation). Per-package uses `--no-deps`? No — we DO want deps for good packages; run each line as its own `pip install <line>` so a bad transitive dep only fails that one line.
+
+---
+
+### Task 1: Structured result + resilient install in `simple_worker.py`
+
+**Files:**
+- Modify: `api/src/services/execution/simple_worker.py:38-91`
+- Test: `api/tests/unit/execution/test_simple_worker_install.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/tests/unit/execution/test_simple_worker_install.py`:
+
+```python
+"""Unit tests for install_requirements resilient install + result reporting."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch, MagicMock
+
+from src.services.execution.simple_worker import (
+    install_requirements,
+    RequirementsInstallResult,
+)
+
+
+def _completed(returncode: int, stderr: str = "", stdout: str = "") -> MagicMock:
+    m = MagicMock(spec=subprocess.CompletedProcess)
+    m.returncode = returncode
+    m.stderr = stderr
+    m.stdout = stdout
+    return m
+
+
+def test_no_requirements_returns_empty_result():
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=None
+    ):
+        result = install_requirements()
+    assert isinstance(result, RequirementsInstallResult)
+    assert result.attempted == []
+    assert result.failed == []
+    assert result.ok is True
+
+
+def test_batch_success_marks_all_installed():
+    content = "anthropic\nlitellm\nreportlab\n"
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch("subprocess.run", return_value=_completed(0)) as run:
+        result = install_requirements()
+    # Only the batch invocation runs on success (no per-package fallback)
+    assert run.call_count == 1
+    assert result.ok is True
+    assert set(result.installed) == {"anthropic", "litellm", "reportlab"}
+    assert result.failed == []
+
+
+def test_batch_failure_falls_back_to_per_package_and_isolates_bad_dep():
+    content = "anthropic\nxhtml2pdf\nreportlab\n"
+
+    def fake_run(cmd, **kwargs):
+        # Batch install (cmd contains "-r") fails; per-package: xhtml2pdf fails,
+        # others succeed.
+        joined = " ".join(cmd)
+        if "-r" in cmd:
+            return _completed(1, stderr="metadata-generation-failed: pycairo")
+        if "xhtml2pdf" in joined:
+            return _completed(1, stderr="ERROR: Unknown compiler(s): cc gcc")
+        return _completed(0)
+
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch("subprocess.run", side_effect=fake_run):
+        result = install_requirements()
+
+    assert result.ok is False
+    assert set(result.installed) == {"anthropic", "reportlab"}
+    assert [f.package for f in result.failed] == ["xhtml2pdf"]
+    assert "Unknown compiler" in result.failed[0].error
+
+
+def test_comments_and_blank_lines_are_ignored():
+    content = "# a comment\n\nanthropic\n  \n# another\nlitellm\n"
+    with patch(
+        "src.core.requirements_cache.get_requirements_sync", return_value=content
+    ), patch("subprocess.run", return_value=_completed(0)):
+        result = install_requirements()
+    assert set(result.attempted) == {"anthropic", "litellm"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/execution/test_simple_worker_install.py -v`
+Expected: FAIL — `ImportError: cannot import name 'RequirementsInstallResult'` (and `install_requirements` currently returns `None`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `api/src/services/execution/simple_worker.py`, add the result dataclasses near the top (after the imports, before `install_requirements`):
+
+```python
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FailedPackage:
+    """One requirements line that failed to install."""
+
+    package: str
+    error: str
+
+
+@dataclass
+class RequirementsInstallResult:
+    """Outcome of a pool requirements install attempt.
+
+    `ok` is True when nothing failed (including the trivial no-requirements
+    case). `installed` + `failed` partition `attempted`.
+    """
+
+    attempted: list[str] = field(default_factory=list)
+    installed: list[str] = field(default_factory=list)
+    failed: list[FailedPackage] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.failed
+```
+
+Replace the body of `install_requirements()` (lines 38-91) with:
+
+```python
+def _parse_requirement_lines(content: str) -> list[str]:
+    """Return non-comment, non-blank requirement specifiers from file content."""
+    lines: list[str] = []
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        lines.append(line)
+    return lines
+
+
+def _pip_install(args: list[str]) -> "subprocess.CompletedProcess[str]":
+    import subprocess
+
+    return subprocess.run(
+        [sys.executable, "-m", "pip", "install", *args, "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=300,  # 5 minute timeout
+    )
+
+
+def install_requirements() -> RequirementsInstallResult:
+    """
+    Install packages from requirements.txt resiliently.
+
+    Called once at pool startup (and on recycle_all) to ensure user-installed
+    packages persist across container restarts. Reads requirements via
+    get_requirements_sync() (Redis → S3 fallback).
+
+    Strategy: attempt a single batch ``pip install -r`` for speed. If the batch
+    fails (e.g. one package can't build), fall back to installing each
+    requirement individually so a single bad package no longer strips the whole
+    runtime. Returns a structured result; the async caller surfaces failures.
+
+    This function never raises — failures are captured in the returned result.
+    """
+    import subprocess
+    import tempfile
+
+    from src.core.requirements_cache import get_requirements_sync
+
+    result = RequirementsInstallResult()
+
+    content = get_requirements_sync()
+    if not content:
+        logger.info("[pool] No requirements.txt found")
+        return result
+
+    packages = _parse_requirement_lines(content)
+    result.attempted = list(packages)
+    if not packages:
+        return result
+
+    # Fast path: one batch install.
+    temp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write(content)
+            temp_path = f.name
+
+        logger.info(f"[pool] Installing {len(packages)} packages from requirements.txt")
+        batch = _pip_install(["-r", temp_path])
+        if batch.returncode == 0:
+            logger.info(f"[pool] Installed {len(packages)} packages from requirements.txt")
+            result.installed = list(packages)
+            return result
+
+        logger.warning(
+            "[pool] Batch pip install failed; falling back to per-package install. "
+            f"pip output: {batch.stderr or batch.stdout}"
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("[pool] Batch pip install timed out; trying per-package install")
+    except Exception as e:
+        logger.warning(f"[pool] Batch install error ({e}); trying per-package install")
+    finally:
+        if temp_path is not None:
+            try:
+                os.unlink(temp_path)
+            except OSError as e:
+                logger.debug(f"[pool] could not remove temp requirements file {temp_path}: {e}")
+
+    # Fallback: install each requirement on its own so one bad package only
+    # fails itself.
+    for pkg in packages:
+        try:
+            single = _pip_install([pkg])
+            if single.returncode == 0:
+                result.installed.append(pkg)
+            else:
+                err = (single.stderr or single.stdout or "").strip()
+                result.failed.append(FailedPackage(package=pkg, error=err[:2000]))
+                logger.warning(f"[pool] Failed to install '{pkg}': {err[:500]}")
+        except subprocess.TimeoutExpired:
+            result.failed.append(FailedPackage(package=pkg, error="pip install timed out (300s)"))
+            logger.warning(f"[pool] Timed out installing '{pkg}'")
+        except Exception as e:  # noqa: BLE001 - per-package install must never abort the loop
+            result.failed.append(FailedPackage(package=pkg, error=str(e)))
+            logger.warning(f"[pool] Error installing '{pkg}': {e}")
+
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/unit/execution/test_simple_worker_install.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/services/execution/simple_worker.py api/tests/unit/execution/test_simple_worker_install.py
+git commit -m "feat(pool): resilient per-package requirements install with structured result"
+```
+
+---
+
+### Task 2: Surface install failures as an admin notification
+
+**Files:**
+- Modify: `api/src/services/execution/process_pool.py` (call sites ~463 and ~983; add a helper)
+- Test: `api/tests/unit/execution/test_process_pool.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `api/tests/unit/execution/test_process_pool.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.execution.simple_worker import (
+    RequirementsInstallResult,
+    FailedPackage,
+)
+
+
+@pytest.mark.asyncio
+async def test_failed_install_notifies_admins():
+    """A result with failed packages creates a deduped admin notification."""
+    from src.services.execution.process_pool import _notify_requirements_failures
+
+    result = RequirementsInstallResult(
+        attempted=["anthropic", "xhtml2pdf"],
+        installed=["anthropic"],
+        failed=[FailedPackage(package="xhtml2pdf", error="Unknown compiler(s): cc")],
+    )
+
+    svc = AsyncMock()
+    svc.find_admin_notification_by_title.return_value = None  # no existing dup
+    with patch(
+        "src.services.execution.process_pool.get_notification_service",
+        return_value=svc,
+    ):
+        await _notify_requirements_failures(result)
+
+    svc.create_notification.assert_awaited_once()
+    kwargs = svc.create_notification.await_args.kwargs
+    assert kwargs["for_admins"] is True
+    assert kwargs["user_id"] == "system"
+    assert "xhtml2pdf" in kwargs["request"].description
+
+
+@pytest.mark.asyncio
+async def test_failed_install_dedups_existing_notification():
+    from src.services.execution.process_pool import _notify_requirements_failures
+
+    result = RequirementsInstallResult(
+        attempted=["xhtml2pdf"],
+        installed=[],
+        failed=[FailedPackage(package="xhtml2pdf", error="boom")],
+    )
+    svc = AsyncMock()
+    svc.find_admin_notification_by_title.return_value = object()  # dup exists
+    with patch(
+        "src.services.execution.process_pool.get_notification_service",
+        return_value=svc,
+    ):
+        await _notify_requirements_failures(result)
+
+    svc.create_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_successful_install_does_not_notify():
+    from src.services.execution.process_pool import _notify_requirements_failures
+
+    result = RequirementsInstallResult(
+        attempted=["anthropic"], installed=["anthropic"], failed=[]
+    )
+    svc = AsyncMock()
+    with patch(
+        "src.services.execution.process_pool.get_notification_service",
+        return_value=svc,
+    ):
+        await _notify_requirements_failures(result)
+
+    svc.find_admin_notification_by_title.assert_not_awaited()
+    svc.create_notification.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/execution/test_process_pool.py -k requirements_failures -v`
+Expected: FAIL — `ImportError: cannot import name '_notify_requirements_failures'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `api/src/services/execution/process_pool.py`, add imports near the other `src.` imports at the top:
+
+```python
+from src.models import NotificationCreate
+from src.models.contracts.notifications import NotificationCategory, NotificationStatus
+from src.services.notification_service import get_notification_service
+```
+
+(If `NotificationCreate` is not exported from `src.models`, import it from `src.models.contracts.notifications` instead — verify with `rg "class NotificationCreate" api/src/models`.)
+
+Add the helper function near the other module-level helpers (after the imports, before the class, or as a module function):
+
+```python
+async def _notify_requirements_failures(result: "RequirementsInstallResult") -> None:
+    """Publish a deduped admin notification when requirements failed to install.
+
+    No-op when the install fully succeeded. Best-effort: notification errors
+    are logged, never raised, so install/recycle is never blocked by it.
+    """
+    if result.ok:
+        return
+
+    failed_names = ", ".join(f.package for f in result.failed)
+    title = "Workflow package install failed"
+    description = (
+        f"{len(result.failed)} package(s) failed to install on workers: "
+        f"{failed_names}. Workflows importing them will fail until fixed."
+    )
+    try:
+        service = get_notification_service()
+        existing = await service.find_admin_notification_by_title(
+            title, NotificationCategory.PACKAGE_INSTALL
+        )
+        if existing is not None:
+            logger.info("[pool] requirements-failure notification already exists; skipping")
+            return
+        await service.create_notification(
+            user_id="system",
+            request=NotificationCreate(
+                category=NotificationCategory.PACKAGE_INSTALL,
+                title=title,
+                description=description[:500],
+                metadata={
+                    "failed": [
+                        {"package": f.package, "error": f.error[:500]}
+                        for f in result.failed
+                    ],
+                    "installed": result.installed,
+                },
+            ),
+            for_admins=True,
+            initial_status=NotificationStatus.FAILED,
+        )
+        logger.warning(f"[pool] Notified admins of requirements install failures: {failed_names}")
+    except Exception as e:  # noqa: BLE001 - notification must never block the pool
+        logger.warning(f"[pool] Could not publish requirements-failure notification: {e}")
+```
+
+Add the `RequirementsInstallResult` import to the existing `simple_worker` import line:
+
+```python
+from src.services.execution.simple_worker import install_requirements, RequirementsInstallResult
+```
+
+Update **both** call sites that currently read `await asyncio.to_thread(install_requirements)`:
+
+At `ProcessPoolManager.start()` (~line 463):
+
+```python
+        # Install requirements once (shared filesystem — all child processes inherit)
+        install_result = await asyncio.to_thread(install_requirements)
+        await _notify_requirements_failures(install_result)
+```
+
+At `recycle_all()` (~line 983):
+
+```python
+        install_result = await asyncio.to_thread(install_requirements)
+        await _notify_requirements_failures(install_result)
+        self._update_requirements_status()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/unit/execution/test_process_pool.py -k requirements_failures -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full existing pool test file to check for regressions**
+
+Run: `./test.sh tests/unit/execution/test_process_pool.py -v`
+Expected: PASS (all, including pre-existing tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/services/execution/process_pool.py api/tests/unit/execution/test_process_pool.py
+git commit -m "feat(pool): notify admins when workflow package install fails"
+```
+
+---
+
+### Task 3: Verify quality gates
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Type check**
+
+Run: `cd api && pyright src/services/execution/simple_worker.py src/services/execution/process_pool.py`
+Expected: 0 errors. (If `subprocess.CompletedProcess[str]` subscripting trips pyright on 3.11, use a plain `subprocess.CompletedProcess` annotation.)
+
+- [ ] **Step 2: Lint**
+
+Run: `cd api && ruff check src/services/execution/ tests/unit/execution/`
+Expected: pass. The two `# noqa: BLE001` comments are intentional (broad except must not abort the install loop / block the pool) — keep them with the inline reason per the project's CodeQL/bare-except convention.
+
+- [ ] **Step 3: Run the targeted unit tests once more together**
+
+Run: `./test.sh tests/unit/execution/test_simple_worker_install.py tests/unit/execution/test_process_pool.py -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit (if any gate required a fix)**
+
+```bash
+git add -A && git commit -m "chore(pool): satisfy type/lint gates for install hardening"
+```
+
+---
+
+---
+
+## Part 2 — Fleet-aware install progress (fix the duplicated stream)
+
+**Problem:** `PackageInstallConsumer` is a RabbitMQ **fanout** consumer — every worker (6 in prod) receives the same install message and each independently `pubsub_manager.broadcast(...)`s its raw log lines (`Installing …`, `Recycling …`) to the **shared** `package:install` WebSocket channel. The frontend `appendLog`s every one, so each line appears once per worker. No worker knows the fleet size or the others' progress, so dedup-at-source is impossible without coordination.
+
+**Approach (server-side aggregation via Redis):** Each worker writes its *phase* for the current install run into a per-run Redis hash keyed by `worker_id`. After each write it computes an aggregate (how many workers installed / recycled / failed, out of the live worker count from `bifrost:pool:*`) and publishes **one** `progress` message to `package:install`. The frontend renders the latest aggregate as a single rolling line and collapses consecutive identical summaries — so N workers publishing the same aggregate show as one line. Raw per-worker `log` lines are removed from the consumer's happy path.
+
+**Run identity:** the API handler that broadcasts the install message stamps a `run_id` (uuid) on it; all workers share it → one Redis hash per run. If absent (older message), fall back to the literal `"current"` so behavior degrades to a single shared hash rather than crashing.
+
+### New files / changes (Part 2)
+
+| File | Responsibility | Change |
+|------|---------------|--------|
+| `api/src/services/execution/install_progress.py` | Redis hash read/write + aggregate computation + publish one summary | Create |
+| `api/src/jobs/consumers/package_install.py` | Report phases through the aggregator instead of raw per-worker logs | Modify |
+| `api/src/routers/packages.py` | Stamp `run_id` on the broadcast message | Modify |
+| `client/src/services/websocket.ts` | Add `PackageProgress` type + `onPackageProgress` callback | Modify |
+| `client/src/components/editor/PackagePanel.tsx` | Render aggregate progress as one collapsing line | Modify |
+| `api/tests/unit/execution/test_install_progress.py` | Unit-test aggregate computation + dedup | Create |
+
+---
+
+### Task 4: Redis-backed install-progress aggregator
+
+**Files:**
+- Create: `api/src/services/execution/install_progress.py`
+- Test: `api/tests/unit/execution/test_install_progress.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `api/tests/unit/execution/test_install_progress.py`:
+
+```python
+"""Unit tests for the install-progress aggregator."""
+from __future__ import annotations
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.services.execution.install_progress import (
+    WorkerPhase,
+    aggregate_phases,
+    summary_line,
+)
+
+
+def test_aggregate_counts_phases_out_of_total():
+    phases = {
+        "w1": WorkerPhase(phase="installed"),
+        "w2": WorkerPhase(phase="installing"),
+        "w3": WorkerPhase(phase="failed", package="xhtml2pdf", error="no cc"),
+    }
+    agg = aggregate_phases(phases, total=4)
+    assert agg["total"] == 4
+    assert agg["installed"] == 1
+    assert agg["installing"] == 1
+    assert agg["failed"] == 1
+    assert agg["failures"] == [{"worker": "w3", "package": "xhtml2pdf", "error": "no cc"}]
+
+
+def test_summary_line_installing():
+    agg = {"total": 6, "installing": 3, "installed": 0, "recycling": 0,
+           "recycled": 0, "failed": 0, "failures": []}
+    assert summary_line(agg, action="install") == "Installing on 3/6 workers…"
+
+
+def test_summary_line_complete_with_failures():
+    agg = {"total": 6, "installing": 0, "installed": 5, "recycling": 0,
+           "recycled": 5, "failed": 1,
+           "failures": [{"worker": "w4", "package": "xhtml2pdf", "error": "no cc"}]}
+    line = summary_line(agg, action="install")
+    assert "5/6" in line
+    assert "xhtml2pdf" in line
+
+
+@pytest.mark.asyncio
+async def test_report_phase_writes_hash_and_publishes_once():
+    fake_redis = AsyncMock()
+    # hgetall returns this worker's write plus one peer
+    fake_redis.hgetall.return_value = {
+        "w1": json.dumps({"phase": "installed"}),
+        "w2": json.dumps({"phase": "installing"}),
+    }
+    # scan yields two live pool keys then terminates
+    fake_redis.scan.side_effect = [(0, ["bifrost:pool:w1", "bifrost:pool:w2"])]
+
+    published: list[dict] = []
+
+    async def fake_broadcast(channel, message):
+        published.append(message)
+
+    from src.services.execution import install_progress as ip
+    with patch.object(ip, "_raw_redis", AsyncMock(return_value=fake_redis)), \
+         patch.object(ip.pubsub_manager, "broadcast", side_effect=fake_broadcast):
+        await ip.report_phase(
+            run_id="run1", worker_id="w1", phase="installed", action="install"
+        )
+
+    fake_redis.hset.assert_awaited()  # wrote own field
+    assert len(published) == 1
+    assert published[0]["type"] == "progress"
+    assert published[0]["total"] == 2
+    assert published[0]["installed"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./test.sh tests/unit/execution/test_install_progress.py -v`
+Expected: FAIL — module `install_progress` doesn't exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `api/src/services/execution/install_progress.py`:
+
+```python
+"""Fleet-aware install progress aggregation.
+
+Each worker in the fanout reports its phase for a given install run into a
+per-run Redis hash. After each write the worker computes an aggregate over all
+reporting workers (out of the live worker count) and publishes ONE summary
+message to the shared ``package:install`` WebSocket channel. The frontend
+collapses consecutive identical summaries, so N workers reporting the same
+aggregate render as a single line.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, cast
+
+from src.core.pubsub import manager as pubsub_manager
+from src.core.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+CHANNEL = "package:install"
+_HASH_PREFIX = "bifrost:pkg-install:"
+_HASH_TTL_SECONDS = 120
+# Phases reported by a worker over an install run.
+_PHASES = ("installing", "installed", "recycling", "recycled", "failed")
+
+
+@dataclass
+class WorkerPhase:
+    phase: str
+    package: str | None = None
+    error: str | None = None
+
+
+async def _raw_redis():  # pragma: no cover - thin accessor, patched in tests
+    client = get_redis_client()
+    return await client._get_redis()
+
+
+async def _live_worker_count(redis) -> int:
+    """Count pool registration keys (exactly bifrost:pool:{id}, 3 parts)."""
+    cursor = 0
+    count = 0
+    while True:
+        cursor, keys = await cast(
+            Awaitable[tuple[int, list[str]]],
+            redis.scan(cursor, match="bifrost:pool:*", count=100),
+        )
+        for key in keys:
+            if key.count(":") == 2:
+                count += 1
+        if cursor == 0:
+            break
+    return count
+
+
+def aggregate_phases(phases: dict[str, WorkerPhase], total: int) -> dict[str, Any]:
+    """Reduce per-worker phases into counts + failure detail."""
+    counts = {p: 0 for p in _PHASES}
+    failures: list[dict[str, Any]] = []
+    for worker_id, wp in phases.items():
+        if wp.phase in counts:
+            counts[wp.phase] += 1
+        if wp.phase == "failed":
+            failures.append(
+                {"worker": worker_id, "package": wp.package, "error": wp.error}
+            )
+    # 'recycled' implies install finished on that worker too.
+    return {
+        "total": max(total, len(phases)),
+        "installing": counts["installing"],
+        "installed": counts["installed"] + counts["recycling"] + counts["recycled"],
+        "recycling": counts["recycling"],
+        "recycled": counts["recycled"],
+        "failed": counts["failed"],
+        "failures": failures,
+    }
+
+
+def summary_line(agg: dict[str, Any], action: str) -> str:
+    """Human-readable single line for the terminal view."""
+    verb = "Installing" if action == "install" else "Uninstalling"
+    total = agg["total"]
+    if agg["recycled"] and not agg["installing"]:
+        base = f"{verb.replace('ing', 'ed')} on {agg['recycled']}/{total} workers"
+    elif agg["installed"] and not agg["installing"]:
+        base = f"{verb.replace('ing', 'ed')} on {agg['installed']}/{total} workers"
+    else:
+        base = f"{verb} on {agg['installing']}/{total} workers…"
+    if agg["failed"]:
+        pkgs = ", ".join(
+            f"{f['worker']}: {f['package']}" for f in agg["failures"] if f.get("package")
+        ) or f"{agg['failed']} worker(s)"
+        base += f" — {agg['failed']} failed ({pkgs})"
+    return base
+
+
+async def report_phase(
+    run_id: str,
+    worker_id: str,
+    phase: str,
+    action: str = "install",
+    package: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Write this worker's phase, then publish one aggregate summary.
+
+    Best-effort: never raises (a progress-reporting failure must not abort the
+    install).
+    """
+    try:
+        redis = await _raw_redis()
+        key = f"{_HASH_PREFIX}{run_id or 'current'}"
+        field_val = json.dumps(
+            {"phase": phase, "package": package, "error": (error or "")[:500]}
+        )
+        await redis.hset(key, worker_id, field_val)  # type: ignore[misc]
+        await redis.expire(key, _HASH_TTL_SECONDS)
+
+        raw = await cast(Awaitable[dict[str, str]], redis.hgetall(key))
+        phases: dict[str, WorkerPhase] = {}
+        for wid, val in raw.items():
+            try:
+                d = json.loads(val)
+                phases[wid] = WorkerPhase(
+                    phase=d.get("phase", ""),
+                    package=d.get("package"),
+                    error=d.get("error"),
+                )
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        total = await _live_worker_count(redis)
+        agg = aggregate_phases(phases, total)
+        message = {
+            "type": "progress",
+            "action": action,
+            "line": summary_line(agg, action),
+            **agg,
+        }
+        await pubsub_manager.broadcast(CHANNEL, message)
+    except Exception as e:  # noqa: BLE001 - progress reporting must never break install
+        logger.warning(f"[pkg-install] progress report failed: {e}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./test.sh tests/unit/execution/test_install_progress.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/services/execution/install_progress.py api/tests/unit/execution/test_install_progress.py
+git commit -m "feat(pool): fleet-aware install-progress aggregator"
+```
+
+---
+
+### Task 5: Wire the consumer + handler to report phases (remove duplicated logs)
+
+**Files:**
+- Modify: `api/src/jobs/consumers/package_install.py`
+- Modify: `api/src/routers/packages.py` (stamp `run_id` on broadcast)
+
+- [ ] **Step 1: Stamp `run_id` in the packages router broadcast**
+
+In `api/src/routers/packages.py`, find each `publish_broadcast(...)` to the `package-installations` exchange and add a `run_id`. First confirm the call shape:
+
+Run: `rg -n "publish_broadcast|package-installations|EXCHANGE" api/src/routers/packages.py`
+
+Then for each broadcast message dict, add `"run_id": str(uuid4())` (import `from uuid import uuid4` at top if absent). Example (adapt to the actual dict in the file):
+
+```python
+from uuid import uuid4
+# ...
+await publish_broadcast(
+    "package-installations",
+    {"action": "install", "package": req.name, "version": req.version, "run_id": str(uuid4())},
+)
+```
+
+If a single API request triggers one logical install, generate the `run_id` once and reuse it for that request's broadcast.
+
+- [ ] **Step 2: Replace per-worker raw logs with phase reports in the consumer**
+
+In `api/src/jobs/consumers/package_install.py`, import the aggregator at top:
+
+```python
+from src.services.execution.install_progress import report_phase
+```
+
+Add a `worker_id` accessor on the consumer (mirror the pool's source):
+
+```python
+import os
+# ... in PackageInstallConsumer:
+@property
+def _worker_id(self) -> str:
+    return os.environ.get("HOSTNAME", "unknown")
+```
+
+Rewrite `process_message` so it reports phases instead of broadcasting raw per-worker log lines. Replace the body (lines ~202-243) with:
+
+```python
+    async def process_message(self, body: dict[str, Any]) -> None:
+        action = body.get("action", "install")
+        package = body.get("package")
+        version = body.get("version")
+        run_id = body.get("run_id", "current")
+        package_spec = (
+            f"{package}=={version}" if package and version else (package or "requirements.txt")
+        )
+        wid = self._worker_id
+        logger.info(f"Processing package {action}: {package_spec} (run={run_id})")
+
+        await report_phase(run_id, wid, phase="installing", action=action)
+
+        if action == "uninstall":
+            if not package:
+                await report_phase(run_id, wid, phase="failed", action=action,
+                                   package="(none)", error="uninstall requires a package name")
+                return
+            success = await self._pip_uninstall(package)
+        elif package:
+            success = await self._pip_install(package, version)
+        else:
+            success = await self._pip_install_requirements()
+
+        if not success:
+            await report_phase(run_id, wid, phase="failed", action=action,
+                               package=package_spec, error="pip command failed (see worker logs)")
+            return
+
+        await report_phase(run_id, wid, phase="recycling", action=action)
+        await self._recycle_workers()
+        await self._update_pool_packages()
+        await report_phase(run_id, wid, phase="recycled", action=action)
+        logger.info(f"Package {action} completed on {wid}")
+```
+
+Delete the now-unused `_send_log` and `_send_complete` methods (lines ~49-61) — they were the source of the duplicated stream. (Per the project "no dead code" rule, remove them entirely; verify nothing else calls them with `rg -n "_send_log|_send_complete" api/src`.)
+
+- [ ] **Step 3: Run existing consumer tests**
+
+Run: `./test.sh tests/unit/jobs/test_package_install_consumer.py -v`
+Expected: PASS. If existing tests assert on `_send_log`/`_send_complete`, update them to assert on `report_phase` being awaited with the expected phase sequence (`installing` → `recycling` → `recycled`, or `failed`). Show the updated assertions in the diff.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/src/jobs/consumers/package_install.py api/src/routers/packages.py api/tests/unit/jobs/test_package_install_consumer.py
+git commit -m "feat(pool): report install phases via aggregator instead of per-worker logs"
+```
+
+---
+
+### Task 6: Frontend renders one collapsing progress line
+
+**Files:**
+- Modify: `client/src/services/websocket.ts`
+- Modify: `client/src/components/editor/PackagePanel.tsx`
+- Test: sibling vitest if one exists for PackagePanel; otherwise add `client/src/components/editor/PackagePanel.progress.test.tsx`
+
+- [ ] **Step 1: Add the `PackageProgress` type + callback in `websocket.ts`**
+
+After the `PackageLog`/`PackageComplete` interfaces (line ~151), add:
+
+```typescript
+export interface PackageProgress {
+	action: "install" | "uninstall";
+	line: string;
+	total: number;
+	installing: number;
+	installed: number;
+	recycling: number;
+	recycled: number;
+	failed: number;
+	failures: { worker: string; package: string | null; error: string | null }[];
+}
+```
+
+Add `{ type: "progress"; ... }` to the `package:install` message union (near line ~441-442):
+
+```typescript
+	| {
+			type: "progress";
+			action: "install" | "uninstall";
+			line: string;
+			total: number;
+			installing: number;
+			installed: number;
+			recycling: number;
+			recycled: number;
+			failed: number;
+			failures: { worker: string; package: string | null; error: string | null }[];
+	  }
+```
+
+Add the callback set + register/dispatch, mirroring `onPackageLog` (line ~1290). Add near the other callback sets:
+
+```typescript
+	private packageProgressCallbacks = new Set<(p: PackageProgress) => void>();
+```
+
+Register method:
+
+```typescript
+	onPackageProgress(callback: (p: PackageProgress) => void): () => void {
+		this.packageProgressCallbacks.add(callback);
+		return () => this.packageProgressCallbacks.delete(callback);
+	}
+```
+
+In the `package:install` message dispatch switch (where `type: "log"` / `type: "complete"` are handled), add a `case "progress"` that calls each `packageProgressCallbacks` with the message payload. (Find it with `rg -n '"complete"' client/src/services/websocket.ts`.)
+
+- [ ] **Step 2: Render the collapsing line in `PackagePanel.tsx`**
+
+In the subscribe effect (line ~88-132), replace the raw `onPackageLog` append with an `onPackageProgress` handler that appends a log line **only when it differs from the last one** (collapse duplicates):
+
+```typescript
+		const lastProgressRef = { current: "" }; // module-scope ref or useRef
+
+		const unsubscribeProgress = webSocketService.onPackageProgress((p) => {
+			const id = currentInstallationIdRef.current;
+			if (!id) return;
+			if (p.line === lastProgressRef.current) return; // collapse identical
+			lastProgressRef.current = p.line;
+			const store = useExecutionStreamStore.getState();
+			store.appendLog(id, {
+				level: p.failed > 0 ? "WARNING" : "INFO",
+				message: p.line,
+				timestamp: new Date().toISOString(),
+			});
+		});
+```
+
+Use a real `useRef<string>("")` declared in the component body for `lastProgressRef` (not an inline object). Drive completion off progress instead of the old `complete` event: when `p.recycled + p.failed >= p.total && p.total > 0`, mark the stream complete with status `Failed` if `p.failed > 0` else `Success`, reusing the existing `completionHandledRef` guard. Keep `onPackageComplete` subscription only if other producers (git ops) still use it; otherwise remove the package-install completion path that relied on it. Remove the `unsubscribeLog`/`onPackageLog` wiring for the package channel (it produced the duplicate lines).
+
+- [ ] **Step 3: Add/adjust a vitest**
+
+If a sibling test exists, add a case; else create `client/src/components/editor/PackagePanel.progress.test.tsx` asserting that two `onPackageProgress` events with the same `line` produce a single appended log, and that `recycled === total` flips the stream to complete. Mock `webSocketService` and `useExecutionStreamStore` per the patterns in neighboring `*.test.tsx`.
+
+Run: `./test.sh client unit -- PackagePanel`
+Expected: PASS.
+
+- [ ] **Step 4: Regenerate types + frontend gates**
+
+The progress message is a client-only WS contract (not an OpenAPI schema), so `generate:types` is not required for it. Still run the gates:
+
+Run: `cd client && npm run tsc && npm run lint`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/services/websocket.ts client/src/components/editor/PackagePanel.tsx client/src/components/editor/PackagePanel.progress.test.tsx
+git commit -m "feat(packages): render single fleet-aware install progress line"
+```
+
+---
+
+## Self-Review checklist (completed during planning)
+
+1. **Spec coverage:** (a) resilient install so one bad package can't strip the runtime → Task 1 per-package fallback. (b) admin notification on failure → Task 2. (c) replace duplicated per-worker stream with `(x/y) workers` summary → Tasks 4–6 (aggregator, consumer wiring, frontend collapse). All covered.
+2. **Placeholder scan:** all code steps contain full code; remaining conditionals ("if `NotificationCreate` not exported", "find the dispatch switch", "if a sibling test exists") each give the exact `rg`/command to resolve them against the live code rather than guessing.
+3. **Type consistency:** `RequirementsInstallResult`/`FailedPackage`/`_notify_requirements_failures` consistent across Tasks 1–2. `WorkerPhase` (`phase`/`package`/`error`), `aggregate_phases(phases,total)→dict`, `summary_line(agg,action)`, `report_phase(run_id,worker_id,phase,action,package,error)`, and the `progress` message fields (`action`/`line`/`total`/`installing`/`installed`/`recycling`/`recycled`/`failed`/`failures`) match across Task 4 (backend), Task 5 (producer), and Task 6 (`PackageProgress` TS interface). `run_id` is produced in Task 5 step 1 and consumed in Task 5 step 2 + Task 4.
+
+## Out of scope (do NOT do here)
+
+- Removing `xhtml2pdf` from the workspace `requirements.txt` (data fix, handled separately).
+- Adding a C compiler / Cairo headers to the worker image.
+- Frontend changes to render the failure *notification* (the existing notifications UI already renders `PACKAGE_INSTALL` admin notifications). Note: the install *progress stream* (Task 6) is a different surface (the editor PackagePanel terminal) and IS in scope.
+- Reworking the fanout broadcast mechanism itself — Part 2 keeps fanout, only changing what each worker publishes (phase reports, not raw logs) and stamping a shared `run_id`.


### PR DESCRIPTION
Fixes #298

## Summary
- **Resilient requirements install.** `install_requirements()` now does a batch `pip install -r` then falls back to per-package installs, so one unbuildable package (the `xhtml2pdf`→`pycairo`→no-C-compiler chain that took prod down on 2026-05-24) can no longer strip the entire workflow runtime. Returns a structured `RequirementsInstallResult`; pip option lines (`--extra-index-url` etc.) are reapplied to each per-package install.
- **Visible failures.** A deduplicated admin notification (`PACKAGE_INSTALL` / `FAILED`) fires when packages fail to install, so the failure isn't swallowed silently.
- **Fleet-aware install progress.** Workers report install *phases* into a per-run Redis hash; a single aggregate line ("Installing on 3/6 workers…") is published instead of every worker streaming raw logs to the shared channel (which previously duplicated each line N×). The real pip error now surfaces to the UI, and the frontend collapses identical consecutive lines.

## How it works (Part 2 data flow)
API stamps a `run_id` on the fanout broadcast → each worker `report_phase(run_id, worker_id, phase)` writes a per-run Redis hash and publishes one aggregate summary → frontend collapses duplicates and derives completion from `recycled + failed >= total`.

## Test plan
- [x] `pyright` 0 errors, `ruff` clean on all touched backend files
- [x] 54 backend unit tests pass (`test_simple_worker_install`, `test_process_pool`, `test_install_progress`, `test_package_install_consumer`)
- [x] 8 frontend vitest pass (`PackagePanel.progress.test.tsx`); `tsc` + `lint` clean
- [ ] CI green

## Out of scope (follow-ups)
- Client-side watchdog for a stuck "Installing…" spinner if a live worker never reports.
- Unify the two pip-install paths (the consumer's `-r requirements.txt` path is still all-or-nothing).
- Data fix: remove `xhtml2pdf` from the workspace `requirements.txt`; decide on a C compiler in the worker image.

Plan: `docs/superpowers/plans/2026-05-24-harden-pool-requirements-install.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)