### PR TITLE
Rank Config search results by field weight

### DIFF
--- a/client/src/pages/Config.tsx
+++ b/client/src/pages/Config.tsx
@@ -35,7 +35,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { SearchBox } from "@/components/search/SearchBox";
-import { useSearch } from "@/hooks/useSearch";
+import { useWeightedSearch } from "@/hooks/useSearch";
 import { toast } from "sonner";
 
 import { useConfigs, useDeleteConfig } from "@/hooks/useConfig";
@@ -91,13 +91,15 @@ export function Config() {
 		return org?.name || orgId;
 	};
 
-	// Apply search filter
-	const filteredConfigs = useSearch(configs || [], searchTerm, [
-		"key",
-		"value",
-		"type",
-		"description",
-		"integration_name",
+	// Apply weighted search — key matches dominate, integration_name/value/type
+	// still match but rank lower so a specific key search isn't drowned out by
+	// every config tied to a matching integration.
+	const filteredConfigs = useWeightedSearch(configs || [], searchTerm, [
+		{ field: "key", weight: 10 },
+		{ field: "description", weight: 5 },
+		{ field: "integration_name", weight: 3 },
+		{ field: "value", weight: 1 },
+		{ field: "type", weight: 1 },
 	]);
 
 	// React Query automatically refetches when scope changes (via orgId in query key)


### PR DESCRIPTION
## Summary
- Config list search was treating `key`, `value`, `type`, `description`, and `integration_name` as equal OR-matches. Typing a specific key (e.g. "buildfrost") returned every config tied to an integration whose name contained the same substring, drowning out the actual key match.
- Switches `Config.tsx` to `useWeightedSearch` (already in the codebase, previously unused) with per-field weights: key 10, description 5, integration_name 3, value/type 1.
- Result: exact/prefix key matches float to the top; integration_name matches still appear but no longer dominate.

## Test plan
- [ ] Seed configs with "buildfrost" in key, description, and integration_name; confirm ranking order on the Config page
- [ ] Verify clearing the search restores the full list
- [ ] `npm run tsc` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)