### PR TITLE
fix(sdk): plumb timeout through to httpx in agents.run + knowledge.store_many

### DIFF
--- a/api/bifrost/agents.py
+++ b/api/bifrost/agents.py
@@ -60,6 +60,9 @@ class agents:
                 "output_schema": output_schema,
                 "timeout": timeout,
             },
+            # Client read-timeout must outlast the server-side cap, otherwise
+            # httpx tears down the connection before the server can return.
+            timeout=timeout + 10,
         )
         raise_for_status_with_detail(response)
         data = response.json()

--- a/api/bifrost/knowledge.py
+++ b/api/bifrost/knowledge.py
@@ -107,6 +107,7 @@ class knowledge:
         *,
         namespace: str = "default",
         scope: str | None = None,
+        timeout: float | None = 300.0,
     ) -> list[str]:
         """
         Store multiple documents efficiently.
@@ -123,6 +124,9 @@ class knowledge:
                 context org (with automatic global fallback via cascade).
                 Pass an org UUID to target a specific org (provider orgs only).
                 Pass None explicitly for global scope.
+            timeout: HTTP read-timeout in seconds. Default 300s accommodates
+                large batches whose embedding generation exceeds the SDK's
+                default 30s client timeout.
 
         Returns:
             List of document IDs
@@ -141,7 +145,8 @@ class knowledge:
                 "documents": documents,
                 "namespace": namespace,
                 "scope": effective_scope,
-            }
+            },
+            timeout=timeout,
         )
         raise_for_status_with_detail(response)
         return response.json()["ids"]

--- a/api/tests/unit/sdk/test_sdk_timeout_plumbing.py
+++ b/api/tests/unit/sdk/test_sdk_timeout_plumbing.py
@@ -1,0 +1,117 @@
+"""SDK helpers that accept ``timeout`` must forward it to the httpx call.
+
+Without this, the SDK's hardcoded 30s client read-timeout tears the
+connection down before the server can respond — even when the caller
+explicitly asked for longer. Regression coverage for #301.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _agents_module():
+    if "bifrost.agents" not in sys.modules:
+        importlib.import_module("bifrost.agents")
+    return sys.modules["bifrost.agents"]
+
+
+def _knowledge_module():
+    if "bifrost.knowledge" not in sys.modules:
+        importlib.import_module("bifrost.knowledge")
+    return sys.modules["bifrost.knowledge"]
+
+
+@pytest.mark.asyncio
+async def test_agents_run_forwards_timeout_to_httpx_with_buffer(monkeypatch):
+    """``agents.run(timeout=N)`` must pass ``timeout=N+10`` to ``client.post``
+    so httpx waits long enough for the server-side cap to expire first."""
+    mod = _agents_module()
+
+    mock_response = MagicMock()
+    mock_response.is_success = True
+    mock_response.json.return_value = {"output": "ok", "status": "completed"}
+    mock_response.status_code = 200
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr(mod, "get_client", lambda: mock_client)
+
+    await mod.agents.run("Foo", input={}, timeout=300)
+
+    mock_client.post.assert_awaited_once()
+    kwargs = mock_client.post.call_args.kwargs
+    assert kwargs.get("timeout") == 310, (
+        f"expected client.post(timeout=310), got {kwargs.get('timeout')!r}"
+    )
+    assert kwargs["json"]["timeout"] == 300, (
+        "server-side cap must still be sent in the body"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agents_run_default_timeout_forwarded(monkeypatch):
+    """Default ``timeout=1800`` must reach httpx as 1810, not silently 30."""
+    mod = _agents_module()
+
+    mock_response = MagicMock()
+    mock_response.is_success = True
+    mock_response.json.return_value = {"output": "ok"}
+    mock_response.status_code = 200
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr(mod, "get_client", lambda: mock_client)
+
+    await mod.agents.run("Foo")
+
+    kwargs = mock_client.post.call_args.kwargs
+    assert kwargs.get("timeout") == 1810
+
+
+@pytest.mark.asyncio
+async def test_knowledge_store_many_forwards_default_timeout(monkeypatch):
+    """``knowledge.store_many`` must default ``timeout=300`` to httpx."""
+    mod = _knowledge_module()
+
+    mock_response = MagicMock()
+    mock_response.is_success = True
+    mock_response.json.return_value = {"ids": ["a", "b"]}
+    mock_response.status_code = 200
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr(mod, "get_client", lambda: mock_client)
+    monkeypatch.setattr(mod, "resolve_scope", lambda s: s)
+
+    await mod.knowledge.store_many(
+        [{"content": "x"}, {"content": "y"}],
+        namespace="faq",
+    )
+
+    kwargs = mock_client.post.call_args.kwargs
+    assert kwargs.get("timeout") == 300.0
+
+
+@pytest.mark.asyncio
+async def test_knowledge_store_many_respects_explicit_timeout(monkeypatch):
+    """Explicit ``timeout=`` overrides the default."""
+    mod = _knowledge_module()
+
+    mock_response = MagicMock()
+    mock_response.is_success = True
+    mock_response.json.return_value = {"ids": []}
+    mock_response.status_code = 200
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr(mod, "get_client", lambda: mock_client)
+    monkeypatch.setattr(mod, "resolve_scope", lambda s: s)
+
+    await mod.knowledge.store_many([], namespace="faq", timeout=600.0)
+
+    kwargs = mock_client.post.call_args.kwargs
+    assert kwargs.get("timeout") == 600.0


### PR DESCRIPTION
## Summary
- `agents.run(..., timeout=N)` now passes `timeout=N+10` to httpx so the client read-timeout outlives the server-side cap. Previously the 30s hardcoded `httpx.AsyncClient(timeout=30.0)` tore the connection down even though the server-side run completed.
- `knowledge.store_many` gains a `timeout: float | None = 300` kwarg so large batch embeds don't hit the same 30s floor.
- Pattern mirrors `ai.complete`, which was already doing this correctly.

Fixes #301

## Test plan
- [x] `./test.sh tests/unit/sdk/test_sdk_timeout_plumbing.py tests/unit/sdk/test_sdk_agents_paused.py -v` — 6/6 pass
- [x] `ruff check` clean on changed files
- [x] `pyright` clean on changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)