### PR TITLE
Fix scoped OAuth and config fallback lookups

### DIFF
--- a/api/src/core/cache/invalidation.py
+++ b/api/src/core/cache/invalidation.py
@@ -49,6 +49,12 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
+async def _delete_org_config_hashes(r: Any) -> None:
+    """Delete merged org config hashes, which include global fallback values."""
+    async for key in r.scan_iter(match="bifrost:org:*:config"):
+        await r.delete(key)
+
+
 async def upsert_config(
     org_id: str | None,
     key: str,
@@ -70,6 +76,18 @@ async def upsert_config(
         r = await get_shared_redis()
         hash_key = config_hash_key(org_id)
 
+        if org_id:
+            # Org config hashes are merged views (global fallback overlaid with
+            # org values). Updating one field would create a partial hash that
+            # hides the remaining global config values on the next read.
+            await r.delete(hash_key)
+            await r.delete(config_key(org_id, key))
+            logger.debug(
+                f"Invalidated merged org config cache after upsert: "
+                f"org={log_safe(org_id)}, key={log_safe(key)}"
+            )
+            return
+
         # Store as JSON with type info for proper parsing at read time
         cache_value = json.dumps({"value": value, "type": config_type})
 
@@ -80,6 +98,8 @@ async def upsert_config(
         ttl = await r.ttl(hash_key)
         if ttl < 0:  # -1 = no TTL, -2 = key doesn't exist
             await r.expire(hash_key, TTL_CONFIG)
+
+        await _delete_org_config_hashes(r)
 
         logger.debug(f"Upserted config to cache: org={log_safe(org_id)}, key={log_safe(key)}")
     except Exception as e:
@@ -104,6 +124,9 @@ async def invalidate_config(org_id: str | None, key: str | None = None) -> None:
         # Also invalidate specific key if provided
         if key:
             await r.delete(config_key(org_id, key))
+
+        if org_id is None:
+            await _delete_org_config_hashes(r)
 
         logger.debug(f"Invalidated config cache: org={log_safe(org_id)}, key={log_safe(key)}")
     except Exception as e:

--- a/api/src/repositories/integrations.py
+++ b/api/src/repositories/integrations.py
@@ -709,7 +709,9 @@ class IntegrationsRepository(BaseRepository[Integration]):
 
         return config
 
-    async def get_provider_org_token(self, provider_id: UUID) -> Any:
+    async def get_provider_org_token(
+        self, provider_id: UUID, organization_id: UUID | None = None
+    ) -> Any:
         """
         Get org-level OAuth token for a provider (user_id=NULL).
 
@@ -718,15 +720,29 @@ class IntegrationsRepository(BaseRepository[Integration]):
 
         Args:
             provider_id: OAuthProvider UUID
+            organization_id: Optional organization UUID to prefer before global
 
         Returns:
             OAuthToken or None if not found
         """
         from src.models.orm.oauth import OAuthToken
 
+        if organization_id:
+            result = await self.session.execute(
+                select(OAuthToken).where(
+                    OAuthToken.provider_id == provider_id,
+                    OAuthToken.organization_id == organization_id,
+                    OAuthToken.user_id.is_(None),
+                )
+            )
+            token = result.scalars().first()
+            if token:
+                return token
+
         result = await self.session.execute(
             select(OAuthToken).where(
                 OAuthToken.provider_id == provider_id,
+                OAuthToken.organization_id.is_(None),
                 OAuthToken.user_id.is_(None),
             )
         )

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -70,6 +70,7 @@ from src.models.contracts.cli import (
     SDKTableListRequest,
     SDKTableInfo,
 )
+from src.models.orm.oauth import OAuthProvider, OAuthToken
 from src.core.pubsub import publish_cli_session_update, publish_execution_log, publish_execution_update, publish_history_update
 from src.repositories.cli_sessions import CLISessionRepository
 
@@ -118,6 +119,56 @@ def should_auto_refresh_token(
         return True
 
     return False
+
+
+async def _get_oauth_provider_for_scope(
+    db: AsyncSession, connection_name: str, org_uuid: UUID | None
+) -> Any:
+    """Load an org-specific OAuth provider, falling back to the global provider."""
+    if org_uuid:
+        result = await db.execute(
+            select(OAuthProvider).where(
+                OAuthProvider.provider_name == connection_name,
+                OAuthProvider.organization_id == org_uuid,
+            )
+        )
+        provider = result.scalars().first()
+        if provider:
+            return provider
+
+    result = await db.execute(
+        select(OAuthProvider).where(
+            OAuthProvider.provider_name == connection_name,
+            OAuthProvider.organization_id.is_(None),
+        )
+    )
+    return result.scalars().first()
+
+
+async def _get_oauth_token_for_scope(
+    db: AsyncSession, provider_id: UUID, org_uuid: UUID | None
+) -> Any:
+    """Load an org-level OAuth token, falling back to the global provider token."""
+    if org_uuid:
+        result = await db.execute(
+            select(OAuthToken).where(
+                OAuthToken.provider_id == provider_id,
+                OAuthToken.organization_id == org_uuid,
+                OAuthToken.user_id.is_(None),
+            )
+        )
+        token = result.scalars().first()
+        if token:
+            return token
+
+    result = await db.execute(
+        select(OAuthToken).where(
+            OAuthToken.provider_id == provider_id,
+            OAuthToken.organization_id.is_(None),
+            OAuthToken.user_id.is_(None),
+        )
+    )
+    return result.scalars().first()
 
 
 # =============================================================================
@@ -661,7 +712,10 @@ async def sdk_integrations_get(
             if integration and integration.oauth_provider:
                 token = mapping.oauth_token
                 if not token:
-                    token = await repo.get_provider_org_token(integration.oauth_provider.id)
+                    token = await repo.get_provider_org_token(
+                        integration.oauth_provider.id,
+                        org_uuid,
+                    )
                 response_data["oauth"] = await _build_oauth_data(
                     integration.oauth_provider, token, entity_id, resolve_url_template, decrypt_secret,
                     oauth_scope=request.oauth_scope,
@@ -691,7 +745,10 @@ async def sdk_integrations_get(
 
         # Build OAuth data if provider exists
         if integration.oauth_provider:
-            token = await repo.get_provider_org_token(integration.oauth_provider.id)
+            token = await repo.get_provider_org_token(
+                integration.oauth_provider.id,
+                org_uuid,
+            )
             response_data["oauth"] = await _build_oauth_data(
                 integration.oauth_provider, token, entity_id, resolve_url_template, decrypt_secret,
                 oauth_scope=request.oauth_scope,
@@ -1083,7 +1140,6 @@ async def sdk_integrations_refresh_token(
     :func:`src.services.oauth_provider.refresh_oauth_token_http`; this handler
     only owns the provider lookup, context build, and persistence.
     """
-    from src.models.orm.oauth import OAuthProvider, OAuthToken
     from src.services.oauth_provider import (
         build_token_refresh_context,
         refresh_oauth_token_http,
@@ -1093,13 +1149,13 @@ async def sdk_integrations_refresh_token(
     org_uuid = UUID(org_id) if org_id else None
 
     try:
-        # Look up provider by connection_name (== provider_name)
-        result = await db.execute(
-            select(OAuthProvider).where(
-                OAuthProvider.provider_name == request.connection_name
-            )
+        # Look up provider by connection_name (== provider_name), preferring
+        # org-specific rows while allowing global providers for scoped mappings.
+        provider = await _get_oauth_provider_for_scope(
+            db,
+            request.connection_name,
+            org_uuid,
         )
-        provider = result.scalars().first()
 
         if not provider:
             raise HTTPException(
@@ -1111,13 +1167,7 @@ async def sdk_integrations_refresh_token(
         # build_token_refresh_context can carry the encrypted refresh token.
         stored_token = None
         if provider.oauth_flow_type == "authorization_code":
-            token_result = await db.execute(
-                select(OAuthToken).where(
-                    OAuthToken.provider_id == provider.id,
-                    OAuthToken.user_id.is_(None),
-                )
-            )
-            stored_token = token_result.scalars().first()
+            stored_token = await _get_oauth_token_for_scope(db, provider.id, org_uuid)
             if not stored_token or not stored_token.encrypted_refresh_token:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -1166,13 +1216,7 @@ async def sdk_integrations_refresh_token(
         token_obj = stored_token
         if token_obj is None:
             # client_credentials path — fetch (or later create) the user_id=NULL row
-            token_result = await db.execute(
-                select(OAuthToken).where(
-                    OAuthToken.provider_id == provider.id,
-                    OAuthToken.user_id.is_(None),
-                )
-            )
-            token_obj = token_result.scalars().first()
+            token_obj = await _get_oauth_token_for_scope(db, provider.id, org_uuid)
 
         if token_obj:
             token_obj.encrypted_access_token = outcome["encrypted_access_token"]
@@ -2588,4 +2632,3 @@ async def cli_list_tables(
         )
         for t in tables
     ]
-

--- a/api/tests/unit/cache/test_invalidation.py
+++ b/api/tests/unit/cache/test_invalidation.py
@@ -19,6 +19,7 @@ from src.core.cache.invalidation import (
     invalidate_role,
     invalidate_role_forms,
     invalidate_role_users,
+    upsert_config,
 )
 
 
@@ -30,6 +31,14 @@ class TestConfigInvalidation:
         """Create mock async Redis client."""
         mock_r = AsyncMock()
         mock_r.delete = AsyncMock()
+        mock_r.hset = AsyncMock()
+        mock_r.ttl = AsyncMock(return_value=60)
+
+        async def empty_iter():
+            return
+            yield
+
+        mock_r.scan_iter = lambda *args, **kwargs: empty_iter()
         return mock_r
 
     @pytest.mark.asyncio
@@ -74,6 +83,33 @@ class TestConfigInvalidation:
             await invalidate_all_config("org-999")
 
             mock_redis.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_upsert_config_org_scope_invalidates_merged_org_cache(self, mock_redis):
+        """Org config writes must not create partial hashes that hide global fallback."""
+        with patch("src.core.cache.invalidation.get_shared_redis", return_value=mock_redis):
+            await upsert_config("org-123", "api_key", "encrypted", "secret")
+
+            mock_redis.hset.assert_not_called()
+            mock_redis.delete.assert_any_call("bifrost:org:org-123:config")
+            mock_redis.delete.assert_any_call("bifrost:org:org-123:config:api_key")
+
+    @pytest.mark.asyncio
+    async def test_upsert_config_global_scope_invalidates_org_merged_caches(self, mock_redis):
+        """Global config writes should clear org caches that include global fallback."""
+
+        async def org_config_keys():
+            yield "bifrost:org:org-123:config"
+            yield "bifrost:org:org-456:config"
+
+        mock_redis.scan_iter = lambda *args, **kwargs: org_config_keys()
+
+        with patch("src.core.cache.invalidation.get_shared_redis", return_value=mock_redis):
+            await upsert_config(None, "api_key", "encrypted", "secret")
+
+            mock_redis.hset.assert_called_once()
+            mock_redis.delete.assert_any_call("bifrost:org:org-123:config")
+            mock_redis.delete.assert_any_call("bifrost:org:org-456:config")
 
 
 class TestFormInvalidation:

--- a/api/tests/unit/repositories/test_integrations_repository.py
+++ b/api/tests/unit/repositories/test_integrations_repository.py
@@ -153,6 +153,44 @@ class TestIntegrationsRepository:
         assert result is None
         mock_session.execute.assert_called_once()
 
+    async def test_get_provider_org_token_falls_back_to_global_token(
+        self, repository, mock_session
+    ):
+        """Org-scoped lookups should fall back to the provider-level token."""
+        provider_id = uuid4()
+        organization_id = uuid4()
+        global_token = MagicMock()
+        global_token.organization_id = None
+
+        org_result = MagicMock()
+        org_result.scalars.return_value.first.return_value = None
+        global_result = MagicMock()
+        global_result.scalars.return_value.first.return_value = global_token
+        mock_session.execute.side_effect = [org_result, global_result]
+
+        result = await repository.get_provider_org_token(provider_id, organization_id)
+
+        assert result == global_token
+        assert mock_session.execute.call_count == 2
+
+    async def test_get_provider_org_token_prefers_org_specific_token(
+        self, repository, mock_session
+    ):
+        """Org-specific tokens should win over global provider tokens."""
+        provider_id = uuid4()
+        organization_id = uuid4()
+        org_token = MagicMock()
+        org_token.organization_id = organization_id
+
+        org_result = MagicMock()
+        org_result.scalars.return_value.first.return_value = org_token
+        mock_session.execute.return_value = org_result
+
+        result = await repository.get_provider_org_token(provider_id, organization_id)
+
+        assert result == org_token
+        mock_session.execute.assert_called_once()
+
     async def test_get_integration_by_name(self, repository, mock_session, mock_integration):
         """Test getting an integration by name."""
         mock_result = MagicMock()

--- a/api/tests/unit/routers/test_cli_refresh_token.py
+++ b/api/tests/unit/routers/test_cli_refresh_token.py
@@ -154,6 +154,89 @@ class TestRefreshTokenClientCredentials:
         mock_db.add.assert_not_called()
         assert mock_existing_token.expires_at == expires_at
 
+    @pytest.mark.asyncio
+    async def test_scoped_refresh_falls_back_to_global_provider_and_token(self):
+        """Scoped refresh should work when the provider/token are global rows."""
+        from src.routers.cli import sdk_integrations_refresh_token
+        from src.models.contracts.cli import SDKIntegrationsRefreshTokenRequest
+
+        org_id = uuid4()
+        request = SDKIntegrationsRefreshTokenRequest(
+            connection_name="NinjaOne",
+            scope=str(org_id),
+        )
+
+        mock_user = MagicMock()
+        mock_user.user_id = uuid4()
+        mock_user.email = "test@example.com"
+        mock_db = AsyncMock()
+
+        provider_id = uuid4()
+        mock_provider = MagicMock()
+        mock_provider.id = provider_id
+        mock_provider.provider_name = "NinjaOne"
+        mock_provider.client_id = "ninja-client-id"
+        mock_provider.encrypted_client_secret = b"encrypted-secret"
+        mock_provider.token_url = "https://app.ninjarmm.com/ws/oauth/token"
+        mock_provider.token_url_defaults = {}
+        mock_provider.oauth_flow_type = "client_credentials"
+        mock_provider.scopes = ["monitoring"]
+        mock_provider.integration_id = None
+        mock_provider.organization_id = None
+        mock_provider.audience = None
+
+        mock_existing_token = MagicMock()
+        mock_existing_token.organization_id = None
+
+        scoped_provider_result = MagicMock()
+        scoped_provider_result.scalars.return_value.first.return_value = None
+        global_provider_result = MagicMock()
+        global_provider_result.scalars.return_value.first.return_value = mock_provider
+        scoped_token_result = MagicMock()
+        scoped_token_result.scalars.return_value.first.return_value = None
+        global_token_result = MagicMock()
+        global_token_result.scalars.return_value.first.return_value = mock_existing_token
+
+        mock_db.execute = AsyncMock(
+            side_effect=[
+                scoped_provider_result,
+                global_provider_result,
+                scoped_token_result,
+                global_token_result,
+            ]
+        )
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=24)
+        mock_token_response = {
+            "access_token": "new-token",
+            "expires_at": expires_at,
+        }
+
+        with (
+            patch(
+                "src.routers.cli._get_cli_org_id",
+                new_callable=AsyncMock,
+                return_value=str(org_id),
+            ),
+            patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
+            patch("src.services.oauth_provider.decrypt_secret", return_value="decrypted-secret"),
+            patch("src.services.oauth_provider.encrypt_secret", return_value="encrypted-new-token"),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get_client_credentials_token = AsyncMock(
+                return_value=(True, mock_token_response)
+            )
+            mock_client_class.return_value = mock_instance
+
+            result = await sdk_integrations_refresh_token(request, mock_user, mock_db)
+
+        assert result.access_token == "new-token"
+        assert mock_db.execute.call_count == 4
+        mock_db.add.assert_not_called()
+        assert mock_existing_token.expires_at == expires_at
+
 
 class TestRefreshTokenAuthorizationCode:
     """Test refresh_token endpoint for authorization_code flows."""


### PR DESCRIPTION
## Summary
- fall back from org-scoped OAuth provider/token lookups to global provider/token records
- pass org scope into SDK integration config lookups
- invalidate merged org config caches when org/global config values change

## Verification
- pve-t340 VM 101 bifrost-e2e-debian13-01: ./test.sh tests/unit/repositories/test_integrations_repository.py tests/unit/cache/test_invalidation.py tests/unit/routers/test_cli_refresh_token.py -> 60 passed
- pve-t340 VM 103 bifrost-e2e-debian13-02: ./test.sh tests/unit/repositories/test_integrations_repository.py tests/unit/cache/test_invalidation.py tests/unit/routers/test_cli_refresh_token.py -> 60 passed
- git diff --check