### PR TITLE
fix(process-pool): race-safe dict mutation across awaits in cleanup paths

### DIFF
--- a/api/src/services/execution/process_pool.py
+++ b/api/src/services/execution/process_pool.py
@@ -823,7 +823,9 @@ class ProcessPoolManager:
 
                 # Remove from pool — one-shot workers don't get replaced;
                 # the next execution's route_execution will fork on demand.
-                del self.processes[handle.id]
+                # pop() not del: a peer (_handle_result) may have removed it
+                # during the _kill_process / _report_timeout awaits above.
+                self.processes.pop(handle.id, None)
                 await self._notify_slot_free()
 
     async def _kill_process(self, handle: ProcessHandle) -> None:
@@ -1076,8 +1078,10 @@ class ProcessPoolManager:
                 # Report cancellation
                 await self._report_cancellation(handle)
 
-                # Remove from pool — one-shot worker, no replacement
-                del self.processes[handle.id]
+                # Remove from pool — one-shot worker, no replacement.
+                # pop() not del: a peer (_handle_result) may have removed it
+                # during the _kill_process / _report_cancellation awaits.
+                self.processes.pop(handle.id, None)
                 await self._notify_slot_free()
 
                 return
@@ -1125,7 +1129,12 @@ class ProcessPoolManager:
         """
         to_remove: list[str] = []
 
-        for process_id, handle in self.processes.items():
+        # Snapshot to a list — items() iterator is unsafe across the awaits
+        # below (peer coroutines like _handle_result mutate self.processes).
+        for process_id, handle in list(self.processes.items()):
+            # Peer may have already cleaned this id during a prior await.
+            if process_id not in self.processes:
+                continue
             if not handle.is_alive and handle.state != ProcessState.KILLED:
                 # Case A: unexpected crash
                 logger.warning(
@@ -1159,10 +1168,17 @@ class ProcessPoolManager:
 
         # Remove crashed/orphaned processes. One-shot workers don't get
         # replaced — the next execution's route_execution will fork.
+        # Use pop() not del because a peer (e.g. _handle_result) may have
+        # already removed the id during one of the awaits above. We still
+        # notify slot waiters if anything was removed here, since the
+        # peer-delete path also notifies and double-notify is harmless.
         if to_remove:
+            removed_any = False
             for process_id in to_remove:
-                del self.processes[process_id]
-            await self._notify_slot_free()
+                if self.processes.pop(process_id, None) is not None:
+                    removed_any = True
+            if removed_any:
+                await self._notify_slot_free()
 
     async def _report_orphan(self, handle: ProcessHandle) -> None:
         """
@@ -1271,8 +1287,8 @@ class ProcessPoolManager:
 
         # Remove the handle (frees a slot under max_workers) and wake any
         # waiters in route_execution that were blocked on a free slot.
-        if handle.id in self.processes:
-            del self.processes[handle.id]
+        # pop() not check-then-del: race-safe against concurrent cleaners.
+        self.processes.pop(handle.id, None)
         await self._notify_slot_free()
 
         # Forward result to callback

--- a/api/tests/unit/execution/test_process_pool.py
+++ b/api/tests/unit/execution/test_process_pool.py
@@ -1061,3 +1061,141 @@ async def test_successful_install_does_not_notify():
         await _notify_requirements_failures(result)
 
     get_svc.assert_not_called()
+
+
+class TestBurstRaceRegression:
+    """Regression tests for issue #316 follow-up:
+
+    Under concurrent burst load, _check_process_health, _check_timeouts, and
+    _handle_cancel_request all hold a handle reference across an await
+    (_report_crash / _kill_process / _report_cancellation) and then issue an
+    unconditional `del self.processes[id]`. If a peer coroutine
+    (_handle_result, another health-check pass, a cancellation) removes the
+    same id during that await, the `del` raises KeyError and aborts the
+    cleanup before `_notify_slot_free()` runs — leaving slot waiters parked
+    until the 30s _wait_for_slot timeout.
+    """
+
+    @pytest.mark.asyncio
+    async def test_check_process_health_concurrent_delete_does_not_raise(self):
+        """A concurrent _handle_result for the same id must not break
+        _check_process_health's cleanup loop with KeyError / RuntimeError.
+
+        Reporter symptom on prod (`KeyError: 'process-N'`) matches the post-
+        iteration `del self.processes[process_id]` path at line 1164 when a
+        peer coroutine (result loop, cancel handler) deleted the same id
+        during the `_report_crash` await mid-iteration.
+        """
+        crash_started = asyncio.Event()
+        crash_release = asyncio.Event()
+
+        async def slow_report_crash(_h):
+            crash_started.set()
+            await crash_release.wait()
+
+        pool = ProcessPoolManager(max_workers=5)
+        # Patch _report_crash so we get a deterministic suspension point
+        # without needing on_result (whose await is what trips the race in
+        # prod, but is equivalent to suspending inside _report_crash here).
+        pool._report_crash = slow_report_crash  # type: ignore[method-assign]
+
+        mock_process = MagicMock()
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = -9
+
+        exec_info = ExecutionInfo(
+            execution_id="exec-race",
+            started_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            timeout_seconds=300,
+        )
+        handle = ProcessHandle(
+            id="process-race",
+            process=mock_process,
+            pid=12345,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=MagicMock(),
+            started_at=datetime.now(timezone.utc),
+            current_execution=exec_info,
+            result_reported=False,
+        )
+        pool.processes["process-race"] = handle
+
+        health_task = asyncio.create_task(pool._check_process_health())
+        await crash_started.wait()
+
+        # Simulate _handle_result deleting the id during the await.
+        del pool.processes["process-race"]
+
+        crash_release.set()
+
+        # Must complete without raising. Pre-fix this raises either
+        # `KeyError` (at the post-iteration `del`) or `RuntimeError:
+        # dictionary changed size during iteration` (at the iterator
+        # advance after the await).
+        await asyncio.wait_for(health_task, timeout=2.0)
+
+    @pytest.mark.asyncio
+    async def test_check_process_health_notifies_waiters_even_on_concurrent_delete(self):
+        """If a concurrent delete races the cleanup loop, slot waiters must
+        still be notified — otherwise route_execution parks for 30s.
+
+        Mirrors the reporter's `No worker slot available after timeout` at
+        30s on a 30-burst test: the KeyError aborted cleanup so the
+        `_notify_slot_free()` after the cleanup loop never ran, leaving
+        `_wait_for_slot` parked until its own 30s timeout.
+        """
+        crash_started = asyncio.Event()
+        crash_release = asyncio.Event()
+
+        async def slow_report_crash(_h):
+            crash_started.set()
+            await crash_release.wait()
+
+        pool = ProcessPoolManager(max_workers=1)
+        pool._report_crash = slow_report_crash  # type: ignore[method-assign]
+
+        mock_process = MagicMock()
+        mock_process.is_alive.return_value = False
+        mock_process.exitcode = -9
+
+        exec_info = ExecutionInfo(
+            execution_id="exec-race-2",
+            started_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            timeout_seconds=300,
+        )
+        handle = ProcessHandle(
+            id="process-race-2",
+            process=mock_process,
+            pid=12346,
+            state=ProcessState.BUSY,
+            work_queue=MagicMock(),
+            result_queue=MagicMock(),
+            started_at=datetime.now(timezone.utc),
+            current_execution=exec_info,
+            result_reported=False,
+        )
+        pool.processes["process-race-2"] = handle
+
+        waiter = asyncio.create_task(pool._wait_for_slot(timeout=2.0))
+        await asyncio.sleep(0.05)
+        assert not waiter.done(), "waiter must be parked while pool is full"
+
+        health_task = asyncio.create_task(pool._check_process_health())
+        await crash_started.wait()
+
+        # Race: peer deletes the id during _report_crash's await. In real
+        # code, the peer is _handle_result which ALSO notifies on its own
+        # removal — simulate that complete behavior here. The cleanup loop
+        # must not crash; the waiter must wake from one of the notifies.
+        pool.processes.pop("process-race-2", None)
+        await pool._notify_slot_free()
+
+        crash_release.set()
+        await asyncio.wait_for(health_task, timeout=2.0)
+
+        got_slot = await asyncio.wait_for(waiter, timeout=1.0)
+        assert got_slot is True, (
+            "waiter never woke — _notify_slot_free was skipped because "
+            "cleanup aborted with KeyError"
+        )


### PR DESCRIPTION
## Summary

Fixes #317. Under concurrent burst load, `_check_process_health`, `_check_timeouts`, `_handle_cancel_request`, and `_handle_result` all mutated `self.processes` across `await` boundaries without race protection, producing `RuntimeError: dictionary changed size during iteration` or `KeyError: 'process-N'` depending on the timing — and crucially, aborting cleanup *before* `_notify_slot_free()` could run, which left `_wait_for_slot` callers parked for the full 30s timeout (the reported "No worker slot available after timeout" symptom).

The fix: snapshot iteration up front, use `pop(..., None)` everywhere, and gate the post-loop slot-free notify on whether anything was actually removed.

## Test plan

- [x] Two regression tests (`TestBurstRaceRegression`) reproduce both shapes deterministically without real processes. Both fail on main, pass with this change.
- [x] All 34 `test_process_pool.py` unit tests green.
- [x] `ruff check` clean on changed files.
- [x] In-vivo smoke test: 5×30 stacked burst against debug stack produced no race signals or failures (race not reproducible in-vivo on dev — consistent with what the reporter observed on #316 for #243, which also only reproduced under prod-like load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)