### PR TITLE
Add built-in event topics and reference help

### DIFF
--- a/api/src/core/pubsub.py
+++ b/api/src/core/pubsub.py
@@ -19,10 +19,10 @@ from uuid import UUID
 if TYPE_CHECKING:
     from src.models.orm.agent_runs import AgentRun
 
-import redis.asyncio as redis
 from fastapi import WebSocket
 
 from src.config import get_settings
+from src.core.cache.redis_client import get_redis
 from src.core.log_safety import log_safe
 from src.core.redis_reconnect import ResilientPubSubListener
 
@@ -42,8 +42,6 @@ class ConnectionManager:
 
     # Active WebSocket connections per channel
     connections: dict[str, set[WebSocket]] = field(default_factory=dict)
-    # Redis connection for publishing
-    _redis: redis.Redis | None = None
     # Resilient pub/sub listener for receiving messages
     _pubsub_listener: ResilientPubSubListener | None = None
 
@@ -60,7 +58,7 @@ class ConnectionManager:
         # Ensure Redis listener is running for cross-container messages
         # This fixes a race condition where the scheduler publishes progress
         # before the API's Redis listener is started
-        if not self._redis:
+        if not self._pubsub_listener or not self._pubsub_listener.is_healthy():
             await self._init_redis()
 
         for channel in channels:
@@ -135,27 +133,23 @@ class ConnectionManager:
         Returns:
             bool: True if successfully published, False otherwise
         """
-        if not self._redis:
-            await self._init_redis()
-
-        if self._redis:
-            try:
-                await self._redis.publish(
+        try:
+            async with get_redis() as r:
+                await r.publish(
                     f"bifrost:{channel}",
-                    json.dumps(message)
+                    json.dumps(message),
                 )
-                return True
-            except Exception as e:
-                logger.warning(f"Failed to publish to Redis: {e}")
-                return False
-        return False
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to publish to Redis: {e}")
+            return False
 
     async def _init_redis(self) -> None:
-        """Initialize Redis connection and start listener."""
+        """Initialize the Redis listener."""
         settings = get_settings()
         try:
-            # Create Redis connection for publishing
-            self._redis = redis.from_url(settings.redis_url)
+            if self._pubsub_listener:
+                await self._pubsub_listener.stop()
 
             # Create resilient listener for receiving messages
             async def on_message(channel: str, data: dict) -> None:
@@ -172,15 +166,12 @@ class ConnectionManager:
             logger.info("Redis pub/sub initialized (with auto-reconnect)")
         except Exception as e:
             logger.warning(f"Failed to connect to Redis: {e}")
-            self._redis = None
+            self._pubsub_listener = None
 
     async def close(self) -> None:
         """Clean up connections."""
         if self._pubsub_listener:
             await self._pubsub_listener.stop()
-
-        if self._redis:
-            await self._redis.close()
 
 
 # Global connection manager instance

--- a/api/src/jobs/consumers/workflow_execution.py
+++ b/api/src/jobs/consumers/workflow_execution.py
@@ -305,6 +305,7 @@ class WorkflowExecutionConsumer(BaseConsumer):
         workflow_name = pending.get("workflow_name", "unknown")
         org_id = pending.get("org_id")
         user_id = pending.get("user_id")
+        user_email = pending.get("user_email")
         user_name = pending.get("user_name")
         is_sync = pending.get("sync", False)
 
@@ -408,6 +409,22 @@ class WorkflowExecutionConsumer(BaseConsumer):
                 "duration_ms": duration_ms,
                 "execution_model": "process",
             },
+        )
+
+        from src.services.events.builtins import emit_workflow_failure_events
+
+        await emit_workflow_failure_events(
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            execution_id=execution_id,
+            organization_id=org_id,
+            user_id=user_id,
+            user_email=user_email,
+            user_name=user_name,
+            error_type=error_type,
+            error_message=error,
+            status=status.value,
+            trigger_event=pending.get("event"),
         )
 
     async def process_message(self, message_data: dict[str, Any]) -> None:

--- a/api/src/jobs/schedulers/oauth_token_refresh.py
+++ b/api/src/jobs/schedulers/oauth_token_refresh.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import selectinload
 
 from src.core.database import get_db_context
 from src.models import OAuthToken, OAuthProvider
+from src.models.orm.integrations import Integration, IntegrationMapping
 from src.services.oauth_provider import (
     build_token_refresh_context,
     refresh_oauth_token_http,
@@ -189,6 +190,22 @@ async def run_refresh_job(
                     if not token or not provider:
                         continue
 
+                    prior_status = token.status
+                    previous_success_at = (
+                        token.last_refresh_at if prior_status == "completed" else None
+                    )
+                    mapping_result = await db.execute(
+                        select(IntegrationMapping).where(
+                            IntegrationMapping.oauth_token_id == token.id
+                        )
+                    )
+                    mapping = mapping_result.scalar_one_or_none()
+                    integration = (
+                        await db.get(Integration, provider.integration_id)
+                        if provider.integration_id
+                        else None
+                    )
+
                     # Per-token status always gets written
                     if outcome["success"]:
                         token.encrypted_access_token = outcome["encrypted_access_token"]
@@ -200,10 +217,64 @@ async def run_refresh_job(
                         token.status = "completed"
                         token.status_message = None
                         token.last_refresh_at = datetime.now(timezone.utc)
+                        if prior_status == "failed":
+                            try:
+                                from src.services.events.builtins import emit_integration_refresh_recovered
+
+                                await emit_integration_refresh_recovered(
+                                    integration_id=provider.integration_id,
+                                    integration_name=(
+                                        integration.name if integration else provider.display_name
+                                    ),
+                                    organization_id=token.organization_id,
+                                    organization_name=(
+                                        mapping.organization.name
+                                        if mapping and mapping.organization
+                                        else None
+                                    ),
+                                    connection_id=mapping.id if mapping else token.id,
+                                    external_account_id=mapping.entity_id if mapping else None,
+                                    external_account_name=mapping.entity_name if mapping else None,
+                                    attempt=1,
+                                    last_success_at=token.last_refresh_at,
+                                )
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to emit integration.refresh_recovered: {e}",
+                                    exc_info=True,
+                                )
                     else:
                         token.status = "failed"
                         token.status_message = (outcome.get("error", "Refresh failed"))[:200]
                         token.last_refresh_at = datetime.now(timezone.utc)
+                        try:
+                            from src.services.events.builtins import emit_integration_refresh_failed
+
+                            await emit_integration_refresh_failed(
+                                integration_id=provider.integration_id,
+                                integration_name=(
+                                    integration.name if integration else provider.display_name
+                                ),
+                                organization_id=token.organization_id,
+                                organization_name=(
+                                    mapping.organization.name
+                                    if mapping and mapping.organization
+                                    else None
+                                ),
+                                connection_id=mapping.id if mapping else token.id,
+                                external_account_id=mapping.entity_id if mapping else None,
+                                external_account_name=mapping.entity_name if mapping else None,
+                                attempt=1,
+                                last_success_at=previous_success_at,
+                                error_message=token.status_message or "Refresh failed",
+                                retryable=False,
+                                reauth_required=True,
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to emit integration.refresh_failed: {e}",
+                                exc_info=True,
+                            )
 
                     # Provider status mirrors the integration-level (fallback) token only.
                     # Per-org tokens (organization_id IS NOT NULL) don't poison provider status.

--- a/api/src/models/contracts/events.py
+++ b/api/src/models/contracts/events.py
@@ -684,6 +684,12 @@ class TopicRegistryEntry(BaseModel):
 
     topic: str
     description: str
+    category: str = Field(..., description="Grouping for this built-in topic.")
+    emitted_by: str = Field(..., description="Platform surface that emits this topic.")
+    example_body: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Representative context.event.data body for this topic.",
+    )
 
 
 class TopicsRegistryResponse(BaseModel):

--- a/api/src/routers/integrations.py
+++ b/api/src/routers/integrations.py
@@ -1323,6 +1323,10 @@ async def disconnect_mapping(
     if not mapping:
         raise HTTPException(status_code=404, detail="Mapping not found")
 
+    integration = mapping.integration
+    organization = mapping.organization
+    external_account_id = mapping.entity_id
+    external_account_name = mapping.entity_name
     token_id = mapping.oauth_token_id
     mapping.oauth_token_id = None
     await ctx.db.flush()
@@ -1332,6 +1336,25 @@ async def disconnect_mapping(
         if token:
             await ctx.db.delete(token)
             await ctx.db.flush()
+
+    if token_id is not None:
+        try:
+            from src.services.events.builtins import emit_integration_disconnected
+
+            await emit_integration_disconnected(
+                integration_id=integration.id if integration else integration_id,
+                integration_name=integration.name if integration else None,
+                organization_id=mapping.organization_id,
+                organization_name=organization.name if organization else None,
+                connection_id=mapping.id,
+                external_account_id=external_account_id,
+                external_account_name=external_account_name,
+                actor_user_id=ctx.user.user_id,
+                actor_email=ctx.user.email,
+                actor_name=ctx.user.name,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to emit integration.disconnected: {e}", exc_info=True)
 
 
 @router.post(
@@ -1395,6 +1418,8 @@ async def refresh_mapping_oauth(
         token=token,
         org_id=mapping.organization_id,
     )
+    was_failed = token.status == "failed"
+    previous_success_at = token.last_refresh_at if token.status == "completed" else None
     outcome = await refresh_oauth_token_http(td)
 
     now = datetime.now(timezone.utc)
@@ -1408,11 +1433,54 @@ async def refresh_mapping_oauth(
         token.status = "completed"
         token.status_message = None
         token.last_refresh_at = now
+        if was_failed:
+            try:
+                from src.services.events.builtins import emit_integration_refresh_recovered
+
+                await emit_integration_refresh_recovered(
+                    integration_id=integration.id,
+                    integration_name=integration.name,
+                    organization_id=mapping.organization_id,
+                    organization_name=mapping.organization.name if mapping.organization else None,
+                    connection_id=mapping.id,
+                    external_account_id=mapping.entity_id,
+                    external_account_name=mapping.entity_name,
+                    attempt=1,
+                    last_success_at=now,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to emit integration.refresh_recovered: {e}",
+                    exc_info=True,
+                )
     else:
         token.status = "failed"
         token.status_message = (outcome.get("error", "Refresh failed"))[:200]
         token.last_refresh_at = now
         await ctx.db.flush()
+        try:
+            from src.services.events.builtins import emit_integration_refresh_failed
+
+            await emit_integration_refresh_failed(
+                integration_id=integration.id,
+                integration_name=integration.name,
+                organization_id=mapping.organization_id,
+                organization_name=mapping.organization.name if mapping.organization else None,
+                connection_id=mapping.id,
+                external_account_id=mapping.entity_id,
+                external_account_name=mapping.entity_name,
+                attempt=1,
+                last_success_at=previous_success_at,
+                error_code=outcome.get("error_code"),
+                error_message=token.status_message or "Refresh failed",
+                retryable=False,
+                reauth_required=True,
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to emit integration.refresh_failed: {e}",
+                exc_info=True,
+            )
         raise HTTPException(
             status_code=502,
             detail=token.status_message or "Refresh failed",

--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -827,6 +827,27 @@ async def _apply_callback_to_mapping(
             captured = extracted
 
     await db.flush()
+
+    try:
+        from src.models.orm import Integration
+        from src.services.events.builtins import emit_integration_connected
+
+        integration = None
+        if provider.integration_id:
+            integration = await db.get(Integration, provider.integration_id)
+
+        await emit_integration_connected(
+            integration_id=provider.integration_id,
+            integration_name=integration.name if integration else provider.display_name,
+            organization_id=mapping.organization_id,
+            organization_name=mapping.organization.name if mapping.organization else None,
+            connection_id=mapping.id,
+            external_account_id=mapping.entity_id,
+            external_account_name=mapping.entity_name,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to emit integration.connected: {e}", exc_info=True)
+
     return captured
 
 
@@ -978,6 +999,24 @@ async def oauth_callback(
     )
 
     logger.info(f"OAuth callback completed for {log_safe(connection_name)}")
+
+    if mapping_id_from_state is None:
+        try:
+            from src.services.events.builtins import emit_integration_connected
+
+            await emit_integration_connected(
+                integration_id=provider.integration_id,
+                integration_name=provider.display_name or provider.provider_name,
+                organization_id=org_id,
+                connection_id=provider.id,
+                external_account_id=None,
+                external_account_name=provider.display_name,
+                actor_user_id=ctx.user.user_id,
+                actor_email=ctx.user.email,
+                actor_name=ctx.user.name,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to emit integration.connected: {e}", exc_info=True)
 
     # Per-mapping flow: link the freshly-stored (org-scoped) token to the mapping
     # and capture entity_id from the provider's configured source. State + org_id

--- a/api/src/services/events/builtins.py
+++ b/api/src/services/events/builtins.py
@@ -1,0 +1,386 @@
+"""Built-in platform event emitters.
+
+These helpers own the canonical body shape for Bifrost-emitted topics. Callers
+pass domain objects or primitive identifiers; this module keeps the common
+payload keys consistent across event families.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from src.core.constants import SYSTEM_USER_ID, SYSTEM_USER_EMAIL
+
+logger = logging.getLogger(__name__)
+
+
+def _iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _organization(organization_id: str | UUID | None, name: str | None = None) -> dict[str, str | None]:
+    return {
+        "id": str(organization_id) if organization_id else None,
+        "name": name,
+    }
+
+
+def _system_actor() -> dict[str, str | None]:
+    return {
+        "type": "system",
+        "id": SYSTEM_USER_ID,
+        "email": SYSTEM_USER_EMAIL,
+        "name": "Bifrost",
+    }
+
+
+def _user_actor(
+    *,
+    user_id: str | UUID | None,
+    email: str | None,
+    name: str | None,
+) -> dict[str, str | None]:
+    return {
+        "type": "user" if user_id or email else "system",
+        "id": str(user_id) if user_id else None,
+        "email": email,
+        "name": name or ("Bifrost" if not user_id and not email else None),
+    }
+
+
+def _base_body(
+    *,
+    organization_id: str | UUID | None,
+    organization_name: str | None = None,
+    actor: dict[str, str | None] | None = None,
+    occurred_at: datetime | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "occurred_at": _iso(occurred_at) or _now(),
+        "organization": _organization(organization_id, organization_name),
+        "actor": actor or _system_actor(),
+    }
+
+
+async def _emit(
+    topic: str,
+    body: dict[str, Any],
+    *,
+    organization_id: str | UUID | None,
+    triggered_by: str | None = None,
+) -> None:
+    try:
+        from src.services.events import emit_event
+
+        await emit_event(
+            topic,
+            body,
+            organization_id=UUID(str(organization_id)) if organization_id else None,
+            triggered_by=triggered_by,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to emit built-in event %s: %s",
+            topic,
+            exc,
+            exc_info=True,
+        )
+
+
+def _trigger_from_event_context(event: dict[str, Any] | None) -> dict[str, Any]:
+    if not event:
+        return {"type": "manual", "event_type": None, "event_id": None}
+
+    return {
+        "type": "event",
+        "event_type": event.get("type"),
+        "event_id": event.get("id"),
+    }
+
+
+async def emit_workflow_failure_events(
+    *,
+    workflow_id: str | UUID | None,
+    workflow_name: str | None,
+    execution_id: str | UUID,
+    organization_id: str | UUID | None,
+    user_id: str | UUID | None,
+    user_email: str | None,
+    user_name: str | None,
+    error_type: str,
+    error_message: str,
+    status: str,
+    trigger_event: dict[str, Any] | None = None,
+    attempt: int = 1,
+    max_attempts: int = 1,
+) -> None:
+    body = {
+        **_base_body(
+            organization_id=organization_id,
+            actor=_user_actor(user_id=user_id, email=user_email, name=user_name),
+        ),
+        "workflow": {
+            "id": str(workflow_id) if workflow_id else None,
+            "name": workflow_name,
+        },
+        "execution": {
+            "id": str(execution_id),
+            "attempt": attempt,
+            "max_attempts": max_attempts,
+            "status": status,
+        },
+        "trigger": _trigger_from_event_context(trigger_event),
+        "error": {
+            "type": error_type,
+            "code": None,
+            "message": error_message,
+            "retryable": attempt < max_attempts,
+        },
+    }
+
+    await _emit(
+        "workflow.failed",
+        body,
+        organization_id=organization_id,
+        triggered_by=str(user_id) if user_id else None,
+    )
+    if attempt >= max_attempts:
+        body = {
+            **body,
+            "error": {
+                **body["error"],
+                "retryable": False,
+            },
+        }
+        await _emit(
+            "workflow.retry_exhausted",
+            body,
+            organization_id=organization_id,
+            triggered_by=str(user_id) if user_id else None,
+        )
+
+
+def _integration_body(
+    *,
+    integration_id: str | UUID | None,
+    integration_name: str | None,
+    organization_id: str | UUID | None,
+    organization_name: str | None,
+    actor: dict[str, str | None] | None = None,
+    connection_id: str | UUID | None = None,
+    external_account_id: str | None = None,
+    external_account_name: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        **_base_body(
+            organization_id=organization_id,
+            organization_name=organization_name,
+            actor=actor,
+        ),
+        "integration": {
+            "id": str(integration_id) if integration_id else None,
+            "name": integration_name,
+        },
+        "connection": {
+            "id": str(connection_id) if connection_id else None,
+            "external_account_id": external_account_id,
+            "external_account_name": external_account_name,
+        },
+        **(extra or {}),
+    }
+
+
+async def emit_integration_connected(
+    *,
+    integration_id: str | UUID | None,
+    integration_name: str | None,
+    organization_id: str | UUID | None,
+    organization_name: str | None = None,
+    connection_id: str | UUID | None = None,
+    external_account_id: str | None = None,
+    external_account_name: str | None = None,
+    actor_user_id: str | UUID | None = None,
+    actor_email: str | None = None,
+    actor_name: str | None = None,
+) -> None:
+    body = _integration_body(
+        integration_id=integration_id,
+        integration_name=integration_name,
+        organization_id=organization_id,
+        organization_name=organization_name,
+        connection_id=connection_id,
+        external_account_id=external_account_id,
+        external_account_name=external_account_name,
+        actor=_user_actor(user_id=actor_user_id, email=actor_email, name=actor_name),
+    )
+    await _emit(
+        "integration.connected",
+        body,
+        organization_id=organization_id,
+        triggered_by=str(actor_user_id) if actor_user_id else None,
+    )
+
+
+async def emit_integration_disconnected(
+    *,
+    integration_id: str | UUID | None,
+    integration_name: str | None,
+    organization_id: str | UUID | None,
+    organization_name: str | None = None,
+    connection_id: str | UUID | None = None,
+    external_account_id: str | None = None,
+    external_account_name: str | None = None,
+    actor_user_id: str | UUID | None = None,
+    actor_email: str | None = None,
+    actor_name: str | None = None,
+) -> None:
+    body = _integration_body(
+        integration_id=integration_id,
+        integration_name=integration_name,
+        organization_id=organization_id,
+        organization_name=organization_name,
+        connection_id=connection_id,
+        external_account_id=external_account_id,
+        external_account_name=external_account_name,
+        actor=_user_actor(user_id=actor_user_id, email=actor_email, name=actor_name),
+    )
+    await _emit(
+        "integration.disconnected",
+        body,
+        organization_id=organization_id,
+        triggered_by=str(actor_user_id) if actor_user_id else None,
+    )
+
+
+async def emit_integration_refresh_failed(
+    *,
+    integration_id: str | UUID | None,
+    integration_name: str | None,
+    organization_id: str | UUID | None,
+    organization_name: str | None = None,
+    connection_id: str | UUID | None = None,
+    external_account_id: str | None = None,
+    external_account_name: str | None = None,
+    attempt: int = 1,
+    last_success_at: datetime | None = None,
+    next_retry_at: datetime | None = None,
+    error_type: str = "OAuthRefreshError",
+    error_code: str | None = None,
+    error_message: str = "Token refresh failed.",
+    retryable: bool = False,
+    reauth_required: bool = False,
+) -> None:
+    body = _integration_body(
+        integration_id=integration_id,
+        integration_name=integration_name,
+        organization_id=organization_id,
+        organization_name=organization_name,
+        connection_id=connection_id,
+        external_account_id=external_account_id,
+        external_account_name=external_account_name,
+        extra={
+            "refresh": {
+                "attempt": attempt,
+                "last_success_at": _iso(last_success_at),
+                "next_retry_at": _iso(next_retry_at),
+            },
+            "error": {
+                "type": error_type,
+                "code": error_code,
+                "message": error_message,
+                "retryable": retryable,
+            },
+        },
+    )
+    await _emit("integration.refresh_failed", body, organization_id=organization_id)
+    if reauth_required:
+        await _emit("integration.reauth_required", body, organization_id=organization_id)
+
+
+async def emit_integration_refresh_recovered(
+    *,
+    integration_id: str | UUID | None,
+    integration_name: str | None,
+    organization_id: str | UUID | None,
+    organization_name: str | None = None,
+    connection_id: str | UUID | None = None,
+    external_account_id: str | None = None,
+    external_account_name: str | None = None,
+    attempt: int = 1,
+    last_success_at: datetime | None = None,
+) -> None:
+    body = _integration_body(
+        integration_id=integration_id,
+        integration_name=integration_name,
+        organization_id=organization_id,
+        organization_name=organization_name,
+        connection_id=connection_id,
+        external_account_id=external_account_id,
+        external_account_name=external_account_name,
+        extra={
+            "refresh": {
+                "attempt": attempt,
+                "last_success_at": _iso(last_success_at),
+                "next_retry_at": None,
+            },
+        },
+    )
+    await _emit("integration.refresh_recovered", body, organization_id=organization_id)
+
+
+async def emit_event_delivery_retry_exhausted(
+    *,
+    event_id: str | UUID,
+    event_type: str | None,
+    source_id: str | UUID | None,
+    organization_id: str | UUID | None,
+    delivery_id: str | UUID,
+    target_type: str,
+    target_id: str | UUID | None,
+    attempt: int,
+    max_attempts: int,
+    error_type: str = "DeliveryError",
+    error_message: str = "Delivery failed after all retry attempts.",
+) -> None:
+    if event_type == "event.delivery_retry_exhausted":
+        return
+
+    body = {
+        **_base_body(organization_id=organization_id),
+        "event": {
+            "id": str(event_id),
+            "type": event_type,
+            "source_id": str(source_id) if source_id else None,
+        },
+        "delivery": {
+            "id": str(delivery_id),
+            "target_type": target_type,
+            "target_id": str(target_id) if target_id else None,
+            "attempt": attempt,
+            "max_attempts": max_attempts,
+        },
+        "error": {
+            "type": error_type,
+            "code": None,
+            "message": error_message,
+            "retryable": False,
+        },
+    }
+    await _emit(
+        "event.delivery_retry_exhausted",
+        body,
+        organization_id=organization_id,
+    )

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -783,6 +783,7 @@ async def update_delivery_from_execution(
                  caller is responsible for commit. If None, creates own session.
     """
     from sqlalchemy import select
+    from sqlalchemy.orm import joinedload
 
     # Map execution status to delivery status
     status_map = {
@@ -797,11 +798,14 @@ async def update_delivery_from_execution(
     async def _do_update(db: AsyncSession) -> None:
         # Find delivery by execution_id
         result = await db.execute(
-            select(EventDelivery).where(
+            select(EventDelivery).options(
+                joinedload(EventDelivery.event),
+                joinedload(EventDelivery.subscription),
+            ).where(
                 EventDelivery.execution_id == uuid.UUID(execution_id)
             )
         )
-        delivery = result.scalar_one_or_none()
+        delivery = result.unique().scalar_one_or_none()
 
         if not delivery:
             # Not an event-triggered execution, nothing to update
@@ -829,6 +833,31 @@ async def update_delivery_from_execution(
                 "status": delivery_status.value,
             },
         )
+
+        if delivery_status == EventDeliveryStatus.FAILED:
+            event_obj = delivery.event or await EventRepository(db).get_by_id(delivery.event_id)
+            subscription = delivery.subscription
+            target_type = getattr(subscription, "target_type", "workflow") or "workflow"
+            target_id = (
+                getattr(subscription, "agent_id", None)
+                if target_type == "agent"
+                else delivery.workflow_id
+            )
+            from src.services.events.builtins import emit_event_delivery_retry_exhausted
+
+            await emit_event_delivery_retry_exhausted(
+                event_id=delivery.event_id,
+                event_type=event_obj.event_type if event_obj else None,
+                source_id=event_obj.event_source_id if event_obj else None,
+                organization_id=event_obj.organization_id if event_obj else None,
+                delivery_id=delivery.id,
+                target_type=target_type,
+                target_id=target_id,
+                attempt=delivery.attempt_count,
+                max_attempts=delivery.attempt_count,
+                error_type="DeliveryError",
+                error_message=error_message or "Delivery failed after all retry attempts.",
+            )
 
         # Broadcast event status update to WebSocket subscribers
         event = await EventRepository(db).get_by_id(delivery.event_id)

--- a/api/src/services/events/registry.py
+++ b/api/src/services/events/registry.py
@@ -1,8 +1,261 @@
 """Curated topic registry for the events system."""
 
+COMMON_EXAMPLE_FIELDS = ("schema_version", "occurred_at", "organization", "actor")
+
+_ORGANIZATION = {
+    "id": "550e8400-e29b-41d4-a716-446655440010",
+    "name": "Acme MSP",
+}
+
+_SYSTEM_ACTOR = {
+    "type": "system",
+    "id": None,
+    "email": None,
+    "name": "Bifrost",
+}
+
+_ADMIN_ACTOR = {
+    "type": "user",
+    "id": "550e8400-e29b-41d4-a716-446655440020",
+    "email": "admin@example.com",
+    "name": "Admin User",
+}
+
+_BASE_BODY = {
+    "schema_version": 1,
+    "occurred_at": "2026-05-28T12:34:56Z",
+    "organization": _ORGANIZATION,
+}
+
+
+def _body(*, actor: dict, **fields: object) -> dict:
+    return {
+        **_BASE_BODY,
+        "actor": actor,
+        **fields,
+    }
+
+
 CURATED_TOPICS = [
     {
         "topic": "user.invited",
-        "description": "Fired when a new user is invited to the platform.",
+        "description": "Fired when a user is invited or an invite is resent.",
+        "category": "Users",
+        "emitted_by": "Bifrost platform",
+        "example_body": _body(
+            actor=_ADMIN_ACTOR,
+            user={
+                "id": "550e8400-e29b-41d4-a716-446655440030",
+                "email": "alice@example.com",
+                "name": "Alice",
+            },
+            invite={
+                "registration_url": "https://app.example.com/accept-invite?token=...",
+                "expires_at": "2026-05-29T12:34:56Z",
+                "reason": "created",
+            },
+        ),
+    },
+    {
+        "topic": "workflow.failed",
+        "description": "Fired when a workflow execution attempt fails.",
+        "category": "Workflows",
+        "emitted_by": "Workflow executor",
+        "example_body": _body(
+            actor=_SYSTEM_ACTOR,
+            workflow={
+                "id": "550e8400-e29b-41d4-a716-446655440040",
+                "name": "sync_tickets",
+            },
+            execution={
+                "id": "550e8400-e29b-41d4-a716-446655440050",
+                "attempt": 1,
+                "max_attempts": 3,
+            },
+            trigger={
+                "type": "event",
+                "event_type": "ticket.created",
+                "event_id": "550e8400-e29b-41d4-a716-446655440060",
+            },
+            error={
+                "type": "ValueError",
+                "code": None,
+                "message": "Workflow raised an exception.",
+                "retryable": True,
+            },
+        ),
+    },
+    {
+        "topic": "workflow.retry_exhausted",
+        "description": "Fired when a workflow has no retry attempts remaining.",
+        "category": "Workflows",
+        "emitted_by": "Workflow executor",
+        "example_body": _body(
+            actor=_SYSTEM_ACTOR,
+            workflow={
+                "id": "550e8400-e29b-41d4-a716-446655440040",
+                "name": "sync_tickets",
+            },
+            execution={
+                "id": "550e8400-e29b-41d4-a716-446655440050",
+                "attempt": 3,
+                "max_attempts": 3,
+            },
+            trigger={
+                "type": "event",
+                "event_type": "ticket.created",
+                "event_id": "550e8400-e29b-41d4-a716-446655440060",
+            },
+            error={
+                "type": "ValueError",
+                "code": None,
+                "message": "Workflow failed after all retry attempts.",
+                "retryable": False,
+            },
+        ),
+    },
+    {
+        "topic": "integration.connected",
+        "description": "Fired when an integration connection is established.",
+        "category": "Integrations",
+        "emitted_by": "Integration service",
+        "example_body": _body(
+            actor=_ADMIN_ACTOR,
+            integration={
+                "id": "550e8400-e29b-41d4-a716-446655440070",
+                "name": "Microsoft Graph",
+            },
+            connection={
+                "id": "550e8400-e29b-41d4-a716-446655440080",
+                "external_account_id": "tenant-123",
+                "external_account_name": "acme.onmicrosoft.com",
+            },
+        ),
+    },
+    {
+        "topic": "integration.disconnected",
+        "description": "Fired when an integration connection is removed.",
+        "category": "Integrations",
+        "emitted_by": "Integration service",
+        "example_body": _body(
+            actor=_ADMIN_ACTOR,
+            integration={
+                "id": "550e8400-e29b-41d4-a716-446655440070",
+                "name": "Microsoft Graph",
+            },
+            connection={
+                "id": "550e8400-e29b-41d4-a716-446655440080",
+                "external_account_id": "tenant-123",
+                "external_account_name": "acme.onmicrosoft.com",
+            },
+        ),
+    },
+    {
+        "topic": "integration.refresh_failed",
+        "description": "Fired when Bifrost cannot refresh integration credentials.",
+        "category": "Integrations",
+        "emitted_by": "OAuth refresh service",
+        "example_body": _body(
+            actor=_SYSTEM_ACTOR,
+            integration={
+                "id": "550e8400-e29b-41d4-a716-446655440070",
+                "name": "Microsoft Graph",
+            },
+            connection={
+                "id": "550e8400-e29b-41d4-a716-446655440080",
+                "external_account_id": "tenant-123",
+                "external_account_name": "acme.onmicrosoft.com",
+            },
+            refresh={
+                "attempt": 3,
+                "last_success_at": "2026-05-28T11:34:56Z",
+                "next_retry_at": "2026-05-28T12:49:56Z",
+            },
+            error={
+                "type": "OAuthRefreshError",
+                "code": "invalid_grant",
+                "message": "Token refresh failed.",
+                "retryable": False,
+            },
+        ),
+    },
+    {
+        "topic": "integration.reauth_required",
+        "description": "Fired when an integration needs a human to reconnect it.",
+        "category": "Integrations",
+        "emitted_by": "OAuth refresh service",
+        "example_body": _body(
+            actor=_SYSTEM_ACTOR,
+            integration={
+                "id": "550e8400-e29b-41d4-a716-446655440070",
+                "name": "Microsoft Graph",
+            },
+            connection={
+                "id": "550e8400-e29b-41d4-a716-446655440080",
+                "external_account_id": "tenant-123",
+                "external_account_name": "acme.onmicrosoft.com",
+            },
+            refresh={
+                "attempt": 3,
+                "last_success_at": "2026-05-28T11:34:56Z",
+                "next_retry_at": None,
+            },
+            error={
+                "type": "OAuthRefreshError",
+                "code": "invalid_grant",
+                "message": "Reconnect the integration to continue.",
+                "retryable": False,
+            },
+        ),
+    },
+    {
+        "topic": "integration.refresh_recovered",
+        "description": "Fired when credential refresh succeeds after a prior failure.",
+        "category": "Integrations",
+        "emitted_by": "OAuth refresh service",
+        "example_body": _body(
+            actor=_SYSTEM_ACTOR,
+            integration={
+                "id": "550e8400-e29b-41d4-a716-446655440070",
+                "name": "Microsoft Graph",
+            },
+            connection={
+                "id": "550e8400-e29b-41d4-a716-446655440080",
+                "external_account_id": "tenant-123",
+                "external_account_name": "acme.onmicrosoft.com",
+            },
+            refresh={
+                "attempt": 1,
+                "last_success_at": "2026-05-28T12:34:56Z",
+                "next_retry_at": None,
+            },
+        ),
+    },
+    {
+        "topic": "event.delivery_retry_exhausted",
+        "description": "Fired when an event delivery cannot be completed after retries.",
+        "category": "Events",
+        "emitted_by": "Event processor",
+        "example_body": _body(
+            actor=_SYSTEM_ACTOR,
+            event={
+                "id": "550e8400-e29b-41d4-a716-446655440090",
+                "type": "ticket.created",
+                "source_id": "550e8400-e29b-41d4-a716-4466554400a0",
+            },
+            delivery={
+                "id": "550e8400-e29b-41d4-a716-4466554400b0",
+                "target_type": "workflow",
+                "target_id": "550e8400-e29b-41d4-a716-446655440040",
+                "attempt": 3,
+                "max_attempts": 3,
+            },
+            error={
+                "type": "DeliveryError",
+                "code": None,
+                "message": "Delivery failed after all retry attempts.",
+                "retryable": False,
+            },
+        ),
     },
 ]

--- a/api/src/services/execution/queue_tracker.py
+++ b/api/src/services/execution/queue_tracker.py
@@ -10,12 +10,31 @@ import json
 import logging
 import time
 
-from src.core.cache.redis_client import get_redis
+import redis.asyncio as aioredis
+
+from src.config import get_settings
 
 logger = logging.getLogger(__name__)
 
 # Redis key for the queue sorted set
 QUEUE_KEY = "bifrost:queue:pending"
+
+
+async def _get_redis() -> aioredis.Redis:
+    """Create a Redis client scoped to the caller's event loop."""
+    settings = get_settings()
+    return aioredis.from_url(
+        settings.redis_url,
+        decode_responses=True,
+        socket_timeout=5.0,
+        socket_connect_timeout=5.0,
+    )
+
+
+async def _close_redis(r: aioredis.Redis) -> None:
+    close = getattr(r, "aclose", None)
+    if close is not None:
+        await close()
 
 
 async def add_to_queue(execution_id: str) -> int:
@@ -28,7 +47,8 @@ async def add_to_queue(execution_id: str) -> int:
     Returns:
         Position in queue (1-based)
     """
-    async with get_redis() as r:
+    r = await _get_redis()
+    try:
         timestamp = time.time()
 
         # Add to sorted set with timestamp as score
@@ -37,6 +57,8 @@ async def add_to_queue(execution_id: str) -> int:
         # Get position (0-based rank + 1 for 1-based position)
         rank = await r.zrank(QUEUE_KEY, execution_id)
         position = (rank + 1) if rank is not None else 1
+    finally:
+        await _close_redis(r)
 
     logger.debug(f"Added execution {execution_id} to queue at position {position}")
 
@@ -55,9 +77,12 @@ async def remove_from_queue(execution_id: str) -> None:
     Args:
         execution_id: Execution ID to remove
     """
-    async with get_redis() as r:
+    r = await _get_redis()
+    try:
         # Remove from sorted set
         removed = await r.zrem(QUEUE_KEY, execution_id)
+    finally:
+        await _close_redis(r)
 
     if removed:
         logger.debug(f"Removed execution {execution_id} from queue")
@@ -75,8 +100,11 @@ async def get_queue_position(execution_id: str) -> int | None:
     Returns:
         Position (1-based) or None if not in queue
     """
-    async with get_redis() as r:
+    r = await _get_redis()
+    try:
         rank = await r.zrank(QUEUE_KEY, execution_id)
+    finally:
+        await _close_redis(r)
 
     if rank is not None:
         return rank + 1  # Convert 0-based to 1-based
@@ -90,8 +118,11 @@ async def get_queue_depth() -> int:
     Returns:
         Queue depth (number of pending executions)
     """
-    async with get_redis() as r:
+    r = await _get_redis()
+    try:
         return await r.zcard(QUEUE_KEY)
+    finally:
+        await _close_redis(r)
 
 
 async def get_all_queue_positions() -> list[tuple[str, int]]:
@@ -101,9 +132,12 @@ async def get_all_queue_positions() -> list[tuple[str, int]]:
     Returns:
         List of (execution_id, position) tuples, ordered by position
     """
-    async with get_redis() as r:
+    r = await _get_redis()
+    try:
         # Get all members in order (lowest score = earliest = position 1)
         members = await r.zrange(QUEUE_KEY, 0, -1)
+    finally:
+        await _close_redis(r)
 
     # Return as list of (execution_id, 1-based position) tuples
     return [(member, idx + 1) for idx, member in enumerate(members)]
@@ -148,11 +182,14 @@ async def cleanup_stale_entries(max_age_seconds: int = 600) -> int:
     Returns:
         Number of entries removed
     """
-    async with get_redis() as r:
+    r = await _get_redis()
+    try:
         cutoff = time.time() - max_age_seconds
 
         # Remove entries with score (timestamp) less than cutoff
         removed = await r.zremrangebyscore(QUEUE_KEY, "-inf", cutoff)
+    finally:
+        await _close_redis(r)
 
     if removed:
         logger.info(f"Cleaned up {removed} stale queue entries")
@@ -169,7 +206,8 @@ async def get_all_pending_executions() -> list[dict]:
         List of dicts with execution_id, workflow_id, workflow_name,
         organization_name, and queued_at for each pending execution.
     """
-    async with get_redis() as r:
+    r = await _get_redis()
+    try:
         # Get execution IDs from sorted set
         exec_ids = await r.zrange(QUEUE_KEY, 0, -1)
 
@@ -207,5 +245,7 @@ async def get_all_pending_executions() -> list[dict]:
                     "organization_name": None,
                     "queued_at": None,
                 })
+    finally:
+        await _close_redis(r)
 
     return items

--- a/api/src/services/execution/queue_tracker.py
+++ b/api/src/services/execution/queue_tracker.py
@@ -10,29 +10,12 @@ import json
 import logging
 import time
 
-import redis.asyncio as aioredis
+from src.core.cache.redis_client import get_redis
 
 logger = logging.getLogger(__name__)
 
 # Redis key for the queue sorted set
 QUEUE_KEY = "bifrost:queue:pending"
-
-# Module-level redis client
-_redis: aioredis.Redis | None = None
-
-
-async def _get_redis() -> aioredis.Redis:
-    """Get Redis client, creating if needed."""
-    global _redis
-    if _redis is None:
-        from src.config import get_settings
-        settings = get_settings()
-        _redis = aioredis.from_url(
-            settings.redis_url,
-            decode_responses=True,
-            socket_timeout=5.0,
-        )
-    return _redis
 
 
 async def add_to_queue(execution_id: str) -> int:
@@ -45,15 +28,15 @@ async def add_to_queue(execution_id: str) -> int:
     Returns:
         Position in queue (1-based)
     """
-    r = await _get_redis()
-    timestamp = time.time()
+    async with get_redis() as r:
+        timestamp = time.time()
 
-    # Add to sorted set with timestamp as score
-    await r.zadd(QUEUE_KEY, {execution_id: timestamp})
+        # Add to sorted set with timestamp as score
+        await r.zadd(QUEUE_KEY, {execution_id: timestamp})
 
-    # Get position (0-based rank + 1 for 1-based position)
-    rank = await r.zrank(QUEUE_KEY, execution_id)
-    position = (rank + 1) if rank is not None else 1
+        # Get position (0-based rank + 1 for 1-based position)
+        rank = await r.zrank(QUEUE_KEY, execution_id)
+        position = (rank + 1) if rank is not None else 1
 
     logger.debug(f"Added execution {execution_id} to queue at position {position}")
 
@@ -72,10 +55,9 @@ async def remove_from_queue(execution_id: str) -> None:
     Args:
         execution_id: Execution ID to remove
     """
-    r = await _get_redis()
-
-    # Remove from sorted set
-    removed = await r.zrem(QUEUE_KEY, execution_id)
+    async with get_redis() as r:
+        # Remove from sorted set
+        removed = await r.zrem(QUEUE_KEY, execution_id)
 
     if removed:
         logger.debug(f"Removed execution {execution_id} from queue")
@@ -93,8 +75,8 @@ async def get_queue_position(execution_id: str) -> int | None:
     Returns:
         Position (1-based) or None if not in queue
     """
-    r = await _get_redis()
-    rank = await r.zrank(QUEUE_KEY, execution_id)
+    async with get_redis() as r:
+        rank = await r.zrank(QUEUE_KEY, execution_id)
 
     if rank is not None:
         return rank + 1  # Convert 0-based to 1-based
@@ -108,8 +90,8 @@ async def get_queue_depth() -> int:
     Returns:
         Queue depth (number of pending executions)
     """
-    r = await _get_redis()
-    return await r.zcard(QUEUE_KEY)
+    async with get_redis() as r:
+        return await r.zcard(QUEUE_KEY)
 
 
 async def get_all_queue_positions() -> list[tuple[str, int]]:
@@ -119,10 +101,9 @@ async def get_all_queue_positions() -> list[tuple[str, int]]:
     Returns:
         List of (execution_id, position) tuples, ordered by position
     """
-    r = await _get_redis()
-
-    # Get all members in order (lowest score = earliest = position 1)
-    members = await r.zrange(QUEUE_KEY, 0, -1)
+    async with get_redis() as r:
+        # Get all members in order (lowest score = earliest = position 1)
+        members = await r.zrange(QUEUE_KEY, 0, -1)
 
     # Return as list of (execution_id, 1-based position) tuples
     return [(member, idx + 1) for idx, member in enumerate(members)]
@@ -167,11 +148,11 @@ async def cleanup_stale_entries(max_age_seconds: int = 600) -> int:
     Returns:
         Number of entries removed
     """
-    r = await _get_redis()
-    cutoff = time.time() - max_age_seconds
+    async with get_redis() as r:
+        cutoff = time.time() - max_age_seconds
 
-    # Remove entries with score (timestamp) less than cutoff
-    removed = await r.zremrangebyscore(QUEUE_KEY, "-inf", cutoff)
+        # Remove entries with score (timestamp) less than cutoff
+        removed = await r.zremrangebyscore(QUEUE_KEY, "-inf", cutoff)
 
     if removed:
         logger.info(f"Cleaned up {removed} stale queue entries")
@@ -188,29 +169,37 @@ async def get_all_pending_executions() -> list[dict]:
         List of dicts with execution_id, workflow_id, workflow_name,
         organization_name, and queued_at for each pending execution.
     """
-    r = await _get_redis()
+    async with get_redis() as r:
+        # Get execution IDs from sorted set
+        exec_ids = await r.zrange(QUEUE_KEY, 0, -1)
 
-    # Get execution IDs from sorted set
-    exec_ids = await r.zrange(QUEUE_KEY, 0, -1)
-
-    items = []
-    for exec_id in exec_ids:
-        # Get execution context from Redis (stored when queued)
-        context = await r.get(f"bifrost:exec:{exec_id}:context")
-        if context:
-            try:
-                data = json.loads(context)
-                items.append({
-                    "execution_id": exec_id,
-                    "workflow_id": data.get("workflow_id"),
-                    "workflow_name": data.get("name"),
-                    "organization_name": data.get("organization", {}).get("name")
-                    if isinstance(data.get("organization"), dict)
-                    else None,
-                    "queued_at": data.get("queued_at"),
-                })
-            except json.JSONDecodeError:
-                # Invalid context, include execution_id only
+        items = []
+        for exec_id in exec_ids:
+            # Get execution context from Redis (stored when queued)
+            context = await r.get(f"bifrost:exec:{exec_id}:context")
+            if context:
+                try:
+                    data = json.loads(context)
+                    items.append({
+                        "execution_id": exec_id,
+                        "workflow_id": data.get("workflow_id"),
+                        "workflow_name": data.get("name"),
+                        "organization_name": data.get("organization", {}).get("name")
+                        if isinstance(data.get("organization"), dict)
+                        else None,
+                        "queued_at": data.get("queued_at"),
+                    })
+                except json.JSONDecodeError:
+                    # Invalid context, include execution_id only
+                    items.append({
+                        "execution_id": exec_id,
+                        "workflow_id": None,
+                        "workflow_name": None,
+                        "organization_name": None,
+                        "queued_at": None,
+                    })
+            else:
+                # No context found, include execution_id only
                 items.append({
                     "execution_id": exec_id,
                     "workflow_id": None,
@@ -218,14 +207,5 @@ async def get_all_pending_executions() -> list[dict]:
                     "organization_name": None,
                     "queued_at": None,
                 })
-        else:
-            # No context found, include execution_id only
-            items.append({
-                "execution_id": exec_id,
-                "workflow_id": None,
-                "workflow_name": None,
-                "organization_name": None,
-                "queued_at": None,
-            })
 
     return items

--- a/api/tests/e2e/api/test_builtin_events.py
+++ b/api/tests/e2e/api/test_builtin_events.py
@@ -1,0 +1,452 @@
+"""E2E coverage for Bifrost built-in topic emitters."""
+
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from src.core.auth import ExecutionContext, UserPrincipal
+from src.core.security import encrypt_secret
+from src.models.orm import OAuthProvider, OAuthToken
+from src.models.orm.integrations import IntegrationMapping
+from tests.e2e.conftest import execute_workflow_sync, poll_until, write_and_register
+
+
+RECORDER_WORKFLOW = '''"""Built-in event recorder workflow."""
+from bifrost import workflow
+
+@workflow(name="e2e_builtin_event_recorder")
+async def e2e_builtin_event_recorder(_event: dict) -> dict:
+    return {
+        "topic": _event.get("type"),
+        "body": _event.get("body"),
+    }
+'''
+
+FAILING_WORKFLOW = '''"""Built-in event failing workflow."""
+from bifrost import workflow
+
+@workflow(name="e2e_builtin_event_fails")
+async def e2e_builtin_event_fails() -> dict:
+    raise RuntimeError("intentional built-in event failure")
+'''
+
+
+@pytest.fixture(scope="module")
+def recorder_workflow(e2e_client, platform_admin):
+    workflow = write_and_register(
+        e2e_client,
+        platform_admin.headers,
+        "e2e_builtin_event_recorder.py",
+        RECORDER_WORKFLOW,
+        "e2e_builtin_event_recorder",
+    )
+    yield workflow
+    e2e_client.delete(
+        "/api/files/editor?path=e2e_builtin_event_recorder.py",
+        headers=platform_admin.headers,
+    )
+
+
+@pytest.fixture(scope="module")
+def failing_workflow(e2e_client, platform_admin):
+    workflow = write_and_register(
+        e2e_client,
+        platform_admin.headers,
+        "e2e_builtin_event_fails.py",
+        FAILING_WORKFLOW,
+        "e2e_builtin_event_fails",
+    )
+    yield workflow
+    e2e_client.delete(
+        "/api/files/editor?path=e2e_builtin_event_fails.py",
+        headers=platform_admin.headers,
+    )
+
+
+def _create_topic_source(e2e_client, headers, topic: str, workflow_id: str) -> dict:
+    response = e2e_client.post(
+        "/api/events/sources",
+        headers=headers,
+        json={
+            "name": f"E2E {topic} {uuid4().hex[:8]}",
+            "source_type": "topic",
+            "event_type": topic,
+        },
+    )
+    assert response.status_code == 201, response.text
+    source = response.json()
+
+    sub_resp = e2e_client.post(
+        f"/api/events/sources/{source['id']}/subscriptions",
+        headers=headers,
+        json={"workflow_id": workflow_id, "event_type": topic},
+    )
+    assert sub_resp.status_code == 201, sub_resp.text
+    return source
+
+
+def _delete_source(e2e_client, headers, source: dict) -> None:
+    e2e_client.delete(f"/api/events/sources/{source['id']}", headers=headers)
+
+
+def _wait_for_successful_delivery(e2e_client, headers, source: dict, predicate):
+    def find_delivery():
+        events_resp = e2e_client.get(
+            f"/api/events/sources/{source['id']}/events",
+            headers=headers,
+        )
+        if events_resp.status_code != 200:
+            return None
+
+        for event in events_resp.json()["items"]:
+            if not predicate(event):
+                continue
+            deliveries_resp = e2e_client.get(
+                f"/api/events/{event['id']}/deliveries",
+                headers=headers,
+            )
+            if deliveries_resp.status_code != 200:
+                return None
+            deliveries = deliveries_resp.json()["items"]
+            successful = [d for d in deliveries if d["status"] == "success"]
+            if successful:
+                return {"event": event, "delivery": successful[0]}
+        return None
+
+    result = poll_until(find_delivery, max_wait=20.0, interval=0.5)
+    assert result is not None, f"No successful delivery for {source['event_type']}"
+    return result
+
+
+def _wait_for_failed_delivery(e2e_client, headers, source: dict, predicate):
+    def find_delivery():
+        events_resp = e2e_client.get(
+            f"/api/events/sources/{source['id']}/events",
+            headers=headers,
+        )
+        if events_resp.status_code != 200:
+            return None
+
+        for event in events_resp.json()["items"]:
+            if not predicate(event):
+                continue
+            deliveries_resp = e2e_client.get(
+                f"/api/events/{event['id']}/deliveries",
+                headers=headers,
+            )
+            if deliveries_resp.status_code != 200:
+                return None
+            deliveries = deliveries_resp.json()["items"]
+            failed = [d for d in deliveries if d["status"] == "failed"]
+            if failed:
+                return {"event": event, "delivery": failed[0]}
+        return None
+
+    result = poll_until(find_delivery, max_wait=20.0, interval=0.5)
+    assert result is not None, f"No failed delivery for {source['event_type']}"
+    return result
+
+
+def _admin_principal(platform_admin) -> UserPrincipal:
+    return UserPrincipal(
+        user_id=platform_admin.user_id,
+        email=platform_admin.email,
+        organization_id=platform_admin.organization_id,
+        name=platform_admin.name,
+        is_superuser=True,
+        is_verified=True,
+    )
+
+
+@pytest.mark.e2e
+class TestBuiltInWorkflowEvents:
+    def test_workflow_failure_and_retry_exhausted_events_run_subscribers(
+        self, e2e_client, platform_admin, recorder_workflow, failing_workflow
+    ):
+        failed_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "workflow.failed",
+            recorder_workflow["id"],
+        )
+        exhausted_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "workflow.retry_exhausted",
+            recorder_workflow["id"],
+        )
+        try:
+            execution = execute_workflow_sync(
+                e2e_client,
+                platform_admin.headers,
+                failing_workflow["id"],
+                max_wait=30.0,
+            )
+            assert execution["status"] == "Failed"
+            execution_id = execution["execution_id"]
+
+            failed = _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                failed_source,
+                lambda event: event["data"]["execution"]["id"] == execution_id,
+            )
+            exhausted = _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                exhausted_source,
+                lambda event: event["data"]["execution"]["id"] == execution_id,
+            )
+
+            assert failed["event"]["data"]["workflow"]["id"] == failing_workflow["id"]
+            assert exhausted["event"]["data"]["error"]["retryable"] is False
+        finally:
+            _delete_source(e2e_client, platform_admin.headers, failed_source)
+            _delete_source(e2e_client, platform_admin.headers, exhausted_source)
+
+    def test_event_delivery_retry_exhausted_event_runs_subscriber(
+        self, e2e_client, platform_admin, recorder_workflow, failing_workflow
+    ):
+        delivery_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "event.delivery_retry_exhausted",
+            recorder_workflow["id"],
+        )
+        trigger_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "test.delivery_failure",
+            failing_workflow["id"],
+        )
+        try:
+            emit_resp = e2e_client.post(
+                "/api/events/emit",
+                headers=platform_admin.headers,
+                json={
+                    "topic": "test.delivery_failure",
+                    "data": {"marker": "delivery-failure"},
+                },
+            )
+            assert emit_resp.status_code == 200, emit_resp.text
+            emitted_id = emit_resp.json()["event_id"]
+
+            _wait_for_failed_delivery(
+                e2e_client,
+                platform_admin.headers,
+                trigger_source,
+                lambda event: event["id"] == emitted_id,
+            )
+
+            result = _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                delivery_source,
+                lambda event: event["data"]["event"]["id"] == emitted_id,
+            )
+            assert result["event"]["data"]["event"]["type"] == "test.delivery_failure"
+            assert result["event"]["data"]["delivery"]["target_id"] == failing_workflow["id"]
+        finally:
+            _delete_source(e2e_client, platform_admin.headers, trigger_source)
+            _delete_source(e2e_client, platform_admin.headers, delivery_source)
+
+
+@pytest.mark.e2e
+class TestBuiltInIntegrationEvents:
+    @pytest.mark.asyncio
+    async def test_integration_events_run_subscribers(
+        self, e2e_client, platform_admin, db_session, org1, recorder_workflow, monkeypatch
+    ):
+        connected_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "integration.connected",
+            recorder_workflow["id"],
+        )
+        disconnected_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "integration.disconnected",
+            recorder_workflow["id"],
+        )
+        failed_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "integration.refresh_failed",
+            recorder_workflow["id"],
+        )
+        reauth_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "integration.reauth_required",
+            recorder_workflow["id"],
+        )
+        recovered_source = _create_topic_source(
+            e2e_client,
+            platform_admin.headers,
+            "integration.refresh_recovered",
+            recorder_workflow["id"],
+        )
+        integration_resp = e2e_client.post(
+            "/api/integrations",
+            headers=platform_admin.headers,
+            json={"name": f"e2e_builtin_connect_{uuid4().hex[:8]}"},
+        )
+        assert integration_resp.status_code == 201, integration_resp.text
+        integration = integration_resp.json()
+        integration_id = UUID(integration["id"])
+
+        provider = OAuthProvider(
+            provider_name=f"builtin_provider_{uuid4().hex[:8]}",
+            display_name=integration["name"],
+            oauth_flow_type="authorization_code",
+            client_id="client",
+            encrypted_client_secret=encrypt_secret("secret").encode(),
+            authorization_url="https://login.example.test/authorize",
+            token_url="https://login.example.test/token",
+            scopes=["read"],
+            integration_id=integration_id,
+        )
+        mapping = IntegrationMapping(
+            integration_id=integration_id,
+            organization_id=UUID(org1["id"]),
+            entity_id="tenant-123",
+            entity_name="Tenant 123",
+        )
+        token = OAuthToken(
+            provider=provider,
+            organization_id=UUID(org1["id"]),
+            encrypted_access_token=encrypt_secret("access").encode(),
+            encrypted_refresh_token=encrypt_secret("refresh").encode(),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scopes=["read"],
+            status="completed",
+        )
+        db_session.add_all([provider, mapping, token])
+        await db_session.commit()
+        await db_session.refresh(provider)
+        await db_session.refresh(mapping)
+        await db_session.refresh(token)
+
+        try:
+            from src.routers.oauth_connections import _apply_callback_to_mapping
+            from src.routers import integrations
+            from src.services import oauth_provider
+
+            await _apply_callback_to_mapping(
+                db_session,
+                mapping.id,
+                token,
+                provider,
+                callback_url_params={},
+                token_response={},
+            )
+            await db_session.commit()
+
+            connected = _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                connected_source,
+                lambda event: event["data"]["connection"]["id"] == str(mapping.id),
+            )
+            assert connected["event"]["data"]["organization"]["id"] == org1["id"]
+
+            async def fail_refresh(_td):
+                return {
+                    "token_id": token.id,
+                    "provider_id": provider.id,
+                    "success": False,
+                    "error": "Token refresh failed: invalid_grant",
+                }
+
+            monkeypatch.setattr(
+                oauth_provider,
+                "refresh_oauth_token_http",
+                fail_refresh,
+            )
+            ctx = ExecutionContext(
+                user=_admin_principal(platform_admin),
+                org_id=platform_admin.organization_id,
+                db=db_session,
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                await integrations.refresh_mapping_oauth(
+                    integration_id,
+                    mapping.id,
+                    ctx,
+                    _admin_principal(platform_admin),
+                )
+            assert exc_info.value.status_code == 502
+            await db_session.commit()
+
+            _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                failed_source,
+                lambda event: event["data"]["connection"]["id"] == str(mapping.id),
+            )
+            _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                reauth_source,
+                lambda event: event["data"]["connection"]["id"] == str(mapping.id),
+            )
+
+            async def recover_refresh(_td):
+                return {
+                    "token_id": token.id,
+                    "provider_id": provider.id,
+                    "success": True,
+                    "access_token": "new-access",
+                    "encrypted_access_token": encrypt_secret("new-access").encode(),
+                    "encrypted_refresh_token": encrypt_secret("refresh").encode(),
+                    "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+                    "scopes": ["read"],
+                }
+
+            monkeypatch.setattr(
+                oauth_provider,
+                "refresh_oauth_token_http",
+                recover_refresh,
+            )
+            await integrations.refresh_mapping_oauth(
+                integration_id,
+                mapping.id,
+                ctx,
+                _admin_principal(platform_admin),
+            )
+            await db_session.commit()
+
+            recovered = _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                recovered_source,
+                lambda event: event["data"]["connection"]["id"] == str(mapping.id),
+            )
+            assert recovered["event"]["data"]["refresh"]["last_success_at"] is not None
+
+            disconnect_resp = e2e_client.post(
+                f"/api/integrations/{integration_id}/mappings/{mapping.id}/oauth/disconnect",
+                headers=platform_admin.headers,
+            )
+            assert disconnect_resp.status_code == 204, disconnect_resp.text
+
+            disconnected = _wait_for_successful_delivery(
+                e2e_client,
+                platform_admin.headers,
+                disconnected_source,
+                lambda event: event["data"]["connection"]["id"] == str(mapping.id),
+            )
+            assert disconnected["event"]["data"]["integration"]["id"] == str(integration_id)
+        finally:
+            _delete_source(e2e_client, platform_admin.headers, connected_source)
+            _delete_source(e2e_client, platform_admin.headers, disconnected_source)
+            _delete_source(e2e_client, platform_admin.headers, failed_source)
+            _delete_source(e2e_client, platform_admin.headers, reauth_source)
+            _delete_source(e2e_client, platform_admin.headers, recovered_source)
+            e2e_client.delete(
+                f"/api/integrations/{integration_id}",
+                headers=platform_admin.headers,
+            )

--- a/api/tests/unit/services/events/test_registry.py
+++ b/api/tests/unit/services/events/test_registry.py
@@ -1,0 +1,36 @@
+from src.services.events.registry import COMMON_EXAMPLE_FIELDS, CURATED_TOPICS
+
+
+def test_curated_topics_include_expected_built_ins():
+    topics = {entry["topic"] for entry in CURATED_TOPICS}
+
+    assert {
+        "user.invited",
+        "workflow.failed",
+        "workflow.retry_exhausted",
+        "integration.connected",
+        "integration.disconnected",
+        "integration.refresh_failed",
+        "integration.reauth_required",
+        "integration.refresh_recovered",
+        "event.delivery_retry_exhausted",
+    } <= topics
+
+
+def test_builtin_event_bodies_share_common_envelope_keys():
+    for entry in CURATED_TOPICS:
+        body = entry["example_body"]
+
+        assert tuple(body.keys())[: len(COMMON_EXAMPLE_FIELDS)] == COMMON_EXAMPLE_FIELDS
+        assert body["schema_version"] == 1
+        assert set(body["organization"].keys()) == {"id", "name"}
+        assert set(body["actor"].keys()) == {"type", "id", "email", "name"}
+
+
+def test_builtin_event_registry_has_reference_metadata():
+    for entry in CURATED_TOPICS:
+        assert entry["topic"]
+        assert entry["description"]
+        assert entry["category"]
+        assert entry["emitted_by"]
+        assert entry["example_body"]

--- a/api/tests/unit/test_pubsub_connection_manager.py
+++ b/api/tests/unit/test_pubsub_connection_manager.py
@@ -1,0 +1,31 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.core.pubsub import ConnectionManager
+
+
+@pytest.mark.asyncio
+async def test_publish_to_redis_uses_per_call_connections():
+    manager = ConnectionManager()
+    clients = []
+
+    def fake_get_redis():
+        client = AsyncMock()
+        clients.append(client)
+
+        @asynccontextmanager
+        async def context():
+            yield client
+
+        return context()
+
+    with patch("src.core.pubsub.get_redis", side_effect=fake_get_redis):
+        assert await manager._publish_to_redis("execution:one", {"type": "one"})
+        assert await manager._publish_to_redis("execution:two", {"type": "two"})
+
+    assert len(clients) == 2
+    assert clients[0] is not clients[1]
+    clients[0].publish.assert_awaited_once()
+    clients[1].publish.assert_awaited_once()

--- a/client/src/components/events/CreateEventSourceDialog.test.tsx
+++ b/client/src/components/events/CreateEventSourceDialog.test.tsx
@@ -20,6 +20,22 @@ vi.mock("@/components/forms/OrganizationSelect", () => ({
 	OrganizationSelect: () => <div data-marker="org-select" />,
 }));
 
+vi.mock("react-syntax-highlighter", () => ({
+	Prism: ({
+		children,
+	}: {
+		children: string;
+		language?: string;
+		style?: unknown;
+		customStyle?: unknown;
+		codeTagProps?: unknown;
+	}) => <pre>{children}</pre>,
+}));
+
+vi.mock("react-syntax-highlighter/dist/esm/styles/prism", () => ({
+	oneDark: {},
+}));
+
 vi.mock("@/lib/api-client", () => ({
 	authFetch: (...args: unknown[]) => mockAuthFetch(...args),
 	$api: {
@@ -29,9 +45,10 @@ vi.mock("@/lib/api-client", () => ({
 }));
 
 vi.mock("@/services/events", async () => {
-	const actual = await vi.importActual<typeof import("@/services/events")>(
-		"@/services/events",
-	);
+	const actual =
+		await vi.importActual<typeof import("@/services/events")>(
+			"@/services/events",
+		);
 	return {
 		...actual,
 		useCreateEventSource: () => ({
@@ -53,7 +70,28 @@ vi.mock("@/services/events", async () => {
 		useTopics: () => ({
 			data: {
 				curated: [
-					{ topic: "user.invited", description: "Fired when a user is invited." },
+					{
+						topic: "user.invited",
+						description: "Fired when a user is invited.",
+						category: "Users",
+						emitted_by: "Bifrost platform",
+						example_body: {
+							schema_version: 1,
+							occurred_at: "2026-05-28T12:34:56Z",
+							organization: { id: "org-1", name: "Acme" },
+							actor: {
+								type: "user",
+								id: "user-1",
+								email: "admin@example.com",
+								name: "Admin",
+							},
+							user: {
+								id: "user-2",
+								email: "new@example.com",
+								name: "New User",
+							},
+						},
+					},
 				],
 				in_use: ["user.invited"],
 			},
@@ -62,10 +100,9 @@ vi.mock("@/services/events", async () => {
 });
 
 vi.mock("@/services/integrations", async () => {
-	const actual =
-		await vi.importActual<typeof import("@/services/integrations")>(
-			"@/services/integrations",
-		);
+	const actual = await vi.importActual<
+		typeof import("@/services/integrations")
+	>("@/services/integrations");
 	return {
 		...actual,
 		useIntegrations: () => ({ data: { items: [] } }),
@@ -118,8 +155,12 @@ describe("CreateEventSourceDialog — webhook happy path", () => {
 		});
 
 		// Select the adapter
-		await user.click(screen.getByRole("combobox", { name: /webhook adapter/i }));
-		await user.click(screen.getByRole("option", { name: /generic webhook/i }));
+		await user.click(
+			screen.getByRole("combobox", { name: /webhook adapter/i }),
+		);
+		await user.click(
+			screen.getByRole("option", { name: /generic webhook/i }),
+		);
 
 		await user.click(
 			screen.getByRole("button", { name: /create event source/i }),
@@ -143,9 +184,7 @@ describe("CreateEventSourceDialog — webhook rate-limit section", () => {
 			<CreateEventSourceDialog open onOpenChange={() => {}} />,
 		);
 
-		expect(
-			screen.getByLabelText(/^max events$/i),
-		).toBeInTheDocument();
+		expect(screen.getByLabelText(/^max events$/i)).toBeInTheDocument();
 		expect(screen.getByLabelText(/per \(seconds\)/i)).toBeInTheDocument();
 		expect(screen.getByLabelText(/^enabled$/i)).toBeInTheDocument();
 	});
@@ -172,7 +211,9 @@ describe("CreateEventSourceDialog — schedule branch", () => {
 		);
 
 		// Switch to schedule
-		await user.click(screen.getByRole("combobox", { name: /source type/i }));
+		await user.click(
+			screen.getByRole("combobox", { name: /source type/i }),
+		);
 		await user.click(screen.getByRole("option", { name: /schedule/i }));
 
 		expect(screen.getByLabelText(/cron expression/i)).toBeInTheDocument();
@@ -195,13 +236,43 @@ describe("CreateEventSourceDialog — topic branch", () => {
 			<CreateEventSourceDialog open onOpenChange={() => {}} />,
 		);
 
-		await user.click(screen.getByRole("combobox", { name: /source type/i }));
+		await user.click(
+			screen.getByRole("combobox", { name: /source type/i }),
+		);
 		await user.click(screen.getByRole("option", { name: /^topic$/i }));
 
-		expect(screen.getByRole("combobox", { name: /topic/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole("combobox", { name: /topic/i }),
+		).toBeInTheDocument();
 		// Webhook / schedule sections should not be visible
-		expect(screen.queryByLabelText(/webhook adapter/i)).not.toBeInTheDocument();
-		expect(screen.queryByLabelText(/cron expression/i)).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(/webhook adapter/i),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(/cron expression/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("opens event source reference help from the dialog header", async () => {
+		const { user } = renderWithProviders(
+			<CreateEventSourceDialog open onOpenChange={() => {}} />,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: /event source reference/i }),
+		);
+
+		expect(
+			await screen.findByText(/python workflow access/i),
+		).toBeVisible();
+		expect(screen.getAllByText(/from bifrost import workflow, context/i).length).toBeGreaterThan(
+			0,
+		);
+		expect(screen.getByText(/@workflow\(name="handle_builtin_event"\)/i)).toBeVisible();
+		expect(screen.getByText(/user\.invited body/i)).toBeVisible();
+		expect(screen.getAllByText(/schema_version/i).length).toBeGreaterThan(
+			0,
+		);
 	});
 
 	it("submits with source_type topic and event_type from registry", async () => {
@@ -211,12 +282,16 @@ describe("CreateEventSourceDialog — topic branch", () => {
 		);
 
 		// Switch to topic type
-		await user.click(screen.getByRole("combobox", { name: /source type/i }));
+		await user.click(
+			screen.getByRole("combobox", { name: /source type/i }),
+		);
 		await user.click(screen.getByRole("option", { name: /^topic$/i }));
 
 		// Pick from the registry
 		await user.click(screen.getByRole("combobox", { name: /topic/i }));
-		await user.click(screen.getByRole("option", { name: /user\.invited/i }));
+		await user.click(
+			screen.getByRole("option", { name: /user\.invited/i }),
+		);
 
 		await user.click(
 			screen.getByRole("button", { name: /create event source/i }),
@@ -235,7 +310,9 @@ describe("CreateEventSourceDialog — topic branch", () => {
 			<CreateEventSourceDialog open onOpenChange={() => {}} />,
 		);
 
-		await user.click(screen.getByRole("combobox", { name: /source type/i }));
+		await user.click(
+			screen.getByRole("combobox", { name: /source type/i }),
+		);
 		await user.click(screen.getByRole("option", { name: /^topic$/i }));
 
 		// Choose "Custom topic..."

--- a/client/src/components/events/CreateEventSourceDialog.tsx
+++ b/client/src/components/events/CreateEventSourceDialog.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/services/events";
 import { useIntegrations } from "@/services/integrations";
 import { DynamicConfigForm, type ConfigSchema } from "./DynamicConfigForm";
+import { EventTopicReferencePanel } from "./EventTopicReferencePanel";
 import { authFetch } from "@/lib/api-client";
 
 interface CronValidationResult {
@@ -51,9 +52,12 @@ const TOPIC_MAX_LEN = 100;
 
 function validateTopicClient(topic: string): string | null {
 	if (!topic) return "Topic is required";
-	if (topic.length > TOPIC_MAX_LEN) return `Topic must be at most ${TOPIC_MAX_LEN} characters`;
-	if (!TOPIC_REGEX.test(topic)) return "Topic must match ^[a-z0-9_.]+$ (lowercase, digits, dots, underscores)";
-	if (!topic.includes(".")) return "Topic must contain at least one dot (e.g. 'user.invited')";
+	if (topic.length > TOPIC_MAX_LEN)
+		return `Topic must be at most ${TOPIC_MAX_LEN} characters`;
+	if (!TOPIC_REGEX.test(topic))
+		return "Topic must match ^[a-z0-9_.]+$ (lowercase, digits, dots, underscores)";
+	if (!topic.includes("."))
+		return "Topic must contain at least one dot (e.g. 'user.invited')";
 	return null;
 }
 
@@ -125,7 +129,9 @@ function CreateEventSourceDialogContent({
 	];
 
 	const effectiveTopic =
-		topicPickerValue === CUSTOM_TOPIC_VALUE ? customTopic : topicPickerValue;
+		topicPickerValue === CUSTOM_TOPIC_VALUE
+			? customTopic
+			: topicPickerValue;
 
 	// Dynamic config for adapters with config_schema
 	const [webhookConfig, setWebhookConfig] = useState<Record<string, unknown>>(
@@ -133,7 +139,9 @@ function CreateEventSourceDialogContent({
 	);
 
 	// Webhook rate-limit state
-	const [rateLimitPerMinute, setRateLimitPerMinute] = useState<number | null>(60);
+	const [rateLimitPerMinute, setRateLimitPerMinute] = useState<number | null>(
+		60,
+	);
 	const [rateLimitWindowSeconds, setRateLimitWindowSeconds] = useState(60);
 	const [rateLimitEnabled, setRateLimitEnabled] = useState(true);
 
@@ -246,7 +254,9 @@ function CreateEventSourceDialogContent({
 
 		if (sourceType === "schedule") {
 			if (!cronExpression.trim()) {
-				newErrors.push("Cron expression is required for schedule sources");
+				newErrors.push(
+					"Cron expression is required for schedule sources",
+				);
 			} else if (cronValidation && !cronValidation.valid) {
 				newErrors.push(
 					"Cron expression is invalid: " +
@@ -274,7 +284,8 @@ function CreateEventSourceDialogContent({
 					name: resolvedName,
 					source_type: sourceType,
 					organization_id: organizationId || undefined,
-					event_type: sourceType === "topic" ? effectiveTopic : undefined,
+					event_type:
+						sourceType === "topic" ? effectiveTopic : undefined,
 					webhook:
 						sourceType === "webhook"
 							? {
@@ -282,7 +293,8 @@ function CreateEventSourceDialogContent({
 									integration_id: integrationId || undefined,
 									config: webhookConfig,
 									rate_limit_per_minute: rateLimitPerMinute,
-									rate_limit_window_seconds: rateLimitWindowSeconds,
+									rate_limit_window_seconds:
+										rateLimitWindowSeconds,
 									rate_limit_enabled: rateLimitEnabled,
 								}
 							: undefined,
@@ -310,7 +322,10 @@ function CreateEventSourceDialogContent({
 	return (
 		<form onSubmit={handleSubmit}>
 			<DialogHeader>
-				<DialogTitle>Create Event Source</DialogTitle>
+				<div className="flex items-center gap-2">
+					<DialogTitle>Create Event Source</DialogTitle>
+					<EventTopicReferencePanel topics={curatedTopics} />
+				</div>
 				<DialogDescription>
 					Create a new event source to receive webhooks, run on a
 					schedule, or trigger workflows.
@@ -319,7 +334,11 @@ function CreateEventSourceDialogContent({
 
 			<div className="space-y-4 py-4">
 				{errors.length > 0 && (
-					<Alert variant="destructive" role="alert" aria-live="polite">
+					<Alert
+						variant="destructive"
+						role="alert"
+						aria-live="polite"
+					>
 						<AlertCircle className="h-4 w-4" />
 						<AlertDescription>
 							<ul className="list-disc list-inside">
@@ -391,9 +410,11 @@ function CreateEventSourceDialogContent({
 				{sourceType === "topic" && (
 					<>
 						<div className="border-t pt-4">
-							<h4 className="text-sm font-medium mb-3">
-								Topic Configuration
-							</h4>
+							<div className="mb-3">
+								<h4 className="text-sm font-medium">
+									Topic Configuration
+								</h4>
+							</div>
 						</div>
 
 						<div className="space-y-2">
@@ -403,7 +424,10 @@ function CreateEventSourceDialogContent({
 								onValueChange={(value) => {
 									setTopicPickerValue(value);
 									setTopicError(null);
-									if (value !== CUSTOM_TOPIC_VALUE && !name.trim()) {
+									if (
+										value !== CUSTOM_TOPIC_VALUE &&
+										!name.trim()
+									) {
 										setName(topicToName(value));
 									}
 								}}
@@ -415,9 +439,14 @@ function CreateEventSourceDialogContent({
 									{allKnownTopics.length > 0 && (
 										<>
 											<SelectGroup>
-												<SelectLabel>Known Topics</SelectLabel>
+												<SelectLabel>
+													Known Topics
+												</SelectLabel>
 												{allKnownTopics.map((topic) => (
-													<SelectItem key={topic} value={topic}>
+													<SelectItem
+														key={topic}
+														value={topic}
+													>
 														{topic}
 													</SelectItem>
 												))}
@@ -436,7 +465,9 @@ function CreateEventSourceDialogContent({
 									value={customTopic}
 									onChange={(e) => {
 										setCustomTopic(e.target.value);
-										setTopicError(validateTopicClient(e.target.value));
+										setTopicError(
+											validateTopicClient(e.target.value),
+										);
 									}}
 									placeholder="e.g. acme.deal_won"
 									className="font-mono"
@@ -444,10 +475,14 @@ function CreateEventSourceDialogContent({
 								/>
 							)}
 							{topicError && (
-								<p className="text-xs text-destructive">{topicError}</p>
+								<p className="text-xs text-destructive">
+									{topicError}
+								</p>
 							)}
 							<p className="text-xs text-muted-foreground">
-								Lowercase, dot-separated (e.g. <code>user.invited</code>). Must contain at least one dot.
+								Lowercase, dot-separated (e.g.{" "}
+								<code>user.invited</code>). Must contain at
+								least one dot.
 							</p>
 						</div>
 					</>
@@ -545,7 +580,9 @@ function CreateEventSourceDialogContent({
 						</div>
 
 						<div className="space-y-2">
-							<Label htmlFor="rate-limit-per-minute">Max events</Label>
+							<Label htmlFor="rate-limit-per-minute">
+								Max events
+							</Label>
 							<Input
 								id="rate-limit-per-minute"
 								type="number"
@@ -575,12 +612,14 @@ function CreateEventSourceDialogContent({
 								min={1}
 								value={rateLimitWindowSeconds}
 								onChange={(e) =>
-									setRateLimitWindowSeconds(Number(e.target.value))
+									setRateLimitWindowSeconds(
+										Number(e.target.value),
+									)
 								}
 							/>
 							<p className="text-xs text-muted-foreground">
-								Window duration. Default 60 means the limit above
-								applies per minute.
+								Window duration. Default 60 means the limit
+								above applies per minute.
 							</p>
 						</div>
 
@@ -590,7 +629,8 @@ function CreateEventSourceDialogContent({
 									Enabled
 								</Label>
 								<p className="text-xs text-muted-foreground">
-									Disable to bypass rate limiting for this source.
+									Disable to bypass rate limiting for this
+									source.
 								</p>
 							</div>
 							<Switch
@@ -656,7 +696,9 @@ function CreateEventSourceDialogContent({
 									<Alert className="bg-green-50 border-green-200 dark:bg-green-950 dark:border-green-800">
 										<CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
 										<AlertDescription className="text-green-800 dark:text-green-200">
-											{displayCronValidation.human_readable}
+											{
+												displayCronValidation.human_readable
+											}
 										</AlertDescription>
 									</Alert>
 								) : (
@@ -679,7 +721,8 @@ function CreateEventSourceDialogContent({
 								)}
 
 								{displayCronValidation.next_runs &&
-									displayCronValidation.next_runs.length > 0 && (
+									displayCronValidation.next_runs.length >
+										0 && (
 										<div>
 											<h4 className="text-sm font-semibold mb-1">
 												Next runs:
@@ -706,8 +749,7 @@ function CreateEventSourceDialogContent({
 																	{formatDistanceToNow(
 																		date,
 																		{
-																			addSuffix:
-																				true,
+																			addSuffix: true,
 																		},
 																	)}
 																	)

--- a/client/src/components/events/EventTopicReferencePanel.tsx
+++ b/client/src/components/events/EventTopicReferencePanel.tsx
@@ -1,0 +1,165 @@
+import { HelpSlideout } from "@/components/shared/HelpSlideout";
+import type { TopicRegistryEntry } from "@/services/events";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
+
+type EventTopicReferenceTopic = TopicRegistryEntry & {
+	category?: string;
+	emitted_by?: string;
+	example_body?: unknown;
+};
+
+interface EventTopicReferencePanelProps {
+	topics: EventTopicReferenceTopic[];
+}
+
+const WORKFLOW_EXAMPLE = `from bifrost import workflow, context
+
+@workflow(name="handle_builtin_event")
+async def handle_builtin_event():
+    event = context.event
+    if event is None:
+        return {"handled": False}
+
+    event_id = event.id
+    event_type = event.type
+    body = event.data
+    organization_id = event.organization_id
+    received_at = event.received_at
+
+    raw_event = context.parameters["_event"]
+    headers = raw_event.get("headers") or {}
+    source_ip = raw_event.get("source_ip")
+
+    workflow_name = body.get("workflow", {}).get("name")
+    return {"event_id": event_id, "event_type": event_type}`;
+
+const INPUT_MAPPING_EXAMPLE = `workflow_name: "{{ _event.body.workflow.name }}"
+error_message: "{{ _event.body.error.message }}"
+event_type: "{{ _event.type }}"`;
+
+function formatJson(value: unknown) {
+	return JSON.stringify(value, null, 2);
+}
+
+function ExampleBlock({
+	label,
+	language,
+	children,
+}: {
+	label: string;
+	language: string;
+	children: string;
+}) {
+	return (
+		<div className="space-y-2">
+			<div className="text-xs font-medium text-muted-foreground">
+				{label}
+			</div>
+			<SyntaxHighlighter
+				language={language}
+				style={oneDark}
+				customStyle={{
+					margin: 0,
+					borderRadius: "0.375rem",
+					fontSize: "0.75rem",
+					lineHeight: "1.5",
+				}}
+				codeTagProps={{ style: { fontFamily: "inherit" } }}
+			>
+				{children}
+			</SyntaxHighlighter>
+		</div>
+	);
+}
+
+function TopicExample({ topic }: { topic: EventTopicReferenceTopic }) {
+	return (
+		<section className="space-y-3">
+			<div className="space-y-1">
+				<div className="flex items-center gap-2">
+					<code className="rounded border bg-muted px-1.5 py-0.5 text-xs">
+						{topic.topic}
+					</code>
+					<span className="text-xs text-muted-foreground">
+						{topic.category ?? "Built-in"}
+					</span>
+				</div>
+				<p className="text-sm text-muted-foreground">
+					{topic.description}
+				</p>
+				<p className="text-xs text-muted-foreground">
+					Emitted by {topic.emitted_by ?? "Bifrost"}
+				</p>
+			</div>
+			<ExampleBlock label={`${topic.topic} body`} language="json">
+				{formatJson(topic.example_body ?? {})}
+			</ExampleBlock>
+		</section>
+	);
+}
+
+export function EventTopicReferencePanel({
+	topics,
+}: EventTopicReferencePanelProps) {
+	return (
+		<HelpSlideout title="Event source reference">
+			<section className="space-y-3">
+				<p className="text-sm text-muted-foreground">
+					Event-triggered workflows can read a typed envelope from{" "}
+					<code>context.event</code>. The same raw payload is
+					available at{" "}
+					<code>context.parameters["_event"]["body"]</code> for input
+					mappings.
+				</p>
+				<ExampleBlock label="Python workflow access" language="python">
+					{WORKFLOW_EXAMPLE}
+				</ExampleBlock>
+				<ExampleBlock label="Input mapping access" language="yaml">
+					{INPUT_MAPPING_EXAMPLE}
+				</ExampleBlock>
+			</section>
+
+			<section className="space-y-3">
+				<div className="space-y-1">
+					<h3 className="text-sm font-medium">Webhook envelope</h3>
+					<p className="text-sm text-muted-foreground">
+						Webhooks expose adapter output as the event body, plus
+						raw request metadata where available.
+					</p>
+				</div>
+				<ExampleBlock label="_event envelope" language="json">
+					{formatJson({
+						id: "550e8400-e29b-41d4-a716-446655440000",
+						type: "ticket.created",
+						body: {
+							ticket_id: "12345",
+							status: "New",
+						},
+						headers: {
+							"x-vendor-signature": "...",
+						},
+						received_at: "2026-05-28T12:34:56Z",
+						source_ip: "203.0.113.10",
+					})}
+				</ExampleBlock>
+			</section>
+
+			<section className="space-y-5">
+				<div className="space-y-1">
+					<h3 className="text-sm font-medium">
+						Built-in event bodies
+					</h3>
+					<p className="text-sm text-muted-foreground">
+						Built-in bodies use the same common keys:{" "}
+						<code>schema_version</code>, <code>occurred_at</code>,{" "}
+						<code>organization</code>, and <code>actor</code>.
+					</p>
+				</div>
+				{topics.map((topic) => (
+					<TopicExample key={topic.topic} topic={topic} />
+				))}
+			</section>
+		</HelpSlideout>
+	);
+}

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -19949,6 +19949,23 @@ export interface components {
             topic: string;
             /** Description */
             description: string;
+            /**
+             * Category
+             * @description Grouping for this built-in topic.
+             */
+            category: string;
+            /**
+             * Emitted By
+             * @description Platform surface that emits this topic.
+             */
+            emitted_by: string;
+            /**
+             * Example Body
+             * @description Representative context.event.data body for this topic.
+             */
+            example_body?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * TopicsRegistryResponse


### PR DESCRIPTION
## Summary
- add curated built-in event topics with consistent example payloads
- emit workflow failure, integration lifecycle/refresh, and delivery retry exhausted events
- add event source reference help with highlighted workflow/input mapping examples

## Tests
- ./test.sh tests/e2e/api/test_builtin_events.py -v
- ./test.sh tests/unit/services/events/test_registry.py -v
- ./test.sh client unit --run src/components/events/CreateEventSourceDialog.test.tsx
- cd client && npm run tsc
- cd client && npm run lint (passes with existing FormRenderer warning)
