### PR TITLE
fix(rabbitmq): reset connection pool across event loops in scheduling E2E

### DIFF
--- a/api/src/jobs/rabbitmq.py
+++ b/api/src/jobs/rabbitmq.py
@@ -82,6 +82,22 @@ class RabbitMQConnection:
             await self._connection_pool.close()
         logger.info("RabbitMQ connections closed")
 
+    def reset_pools(self) -> None:
+        """Drop the cached pools without awaiting (for testing).
+
+        The pools bind their connections to whichever asyncio loop first
+        touched them (via ``init_pools``). When a test runs on a fresh
+        function-scoped loop, the next ``init_pools`` short-circuits on the
+        stale pool and hands back a connection pinned to the dead loop,
+        surfacing as ``RuntimeError: Event loop is closed`` on the first
+        channel open. Nulling the references forces ``init_pools`` to rebuild
+        on the current loop. We do NOT ``await close()`` here precisely
+        because the old loop is already gone — awaiting it would raise the
+        same error we are clearing. Mirrors ``reset_db_state``.
+        """
+        self._connection_pool = None
+        self._channel_pool = None
+
 
 # Global connection manager
 rabbitmq = RabbitMQConnection()

--- a/api/tests/e2e/api/test_workflow_scheduling_flow.py
+++ b/api/tests/e2e/api/test_workflow_scheduling_flow.py
@@ -99,14 +99,19 @@ async def test_schedule_promote_run_terminal(
 ):
     """Schedule → wait for maturity → promoter → worker → Success."""
     from src.core.database import reset_db_state
+    from src.jobs.rabbitmq import rabbitmq
     import src.core.redis_client as redis_module
 
-    # The app-side DB engine and Redis singleton are cached in module
-    # globals and pin their connections to whichever asyncio loop first
-    # touched them. Resetting both forces fresh clients on this loop —
-    # the promoter below uses both when publishing the matured row.
+    # The app-side DB engine, Redis singleton, and RabbitMQ connection pool
+    # are cached in module globals and pin their connections to whichever
+    # asyncio loop first touched them. Resetting all three forces fresh
+    # clients on this loop — the promoter below uses the DB and Redis when
+    # reading the matured row, and RabbitMQ when publishing it. Without the
+    # pool reset, init_pools() short-circuits on a pool bound to a dead loop
+    # and the publish fails with RuntimeError: Event loop is closed.
     reset_db_state()
     redis_module._redis_client = None
+    rabbitmq.reset_pools()
 
     resp = _schedule(
         e2e_client, platform_admin, runnable_workflow["id"], delay_seconds=2

--- a/api/tests/unit/jobs/test_rabbitmq_reset_pools.py
+++ b/api/tests/unit/jobs/test_rabbitmq_reset_pools.py
@@ -1,0 +1,62 @@
+"""
+Unit tests for RabbitMQConnection.reset_pools().
+
+Regression coverage for the event-loop-pinning flake: the connection and
+channel pools bind to whichever asyncio loop first touched them, so a test
+running on a fresh function-scoped loop would reuse a pool pinned to a dead
+loop and fail with ``RuntimeError: Event loop is closed`` on the next channel
+open. ``reset_pools`` drops the references (without awaiting the dead loop) so
+``init_pools`` rebuilds on the current loop.
+"""
+
+import pytest
+
+from src.jobs.rabbitmq import RabbitMQConnection
+
+
+@pytest.fixture
+def conn():
+    """The shared singleton, with its pools restored after each test.
+
+    RabbitMQConnection is a singleton, so mutating its pools would leak into
+    other tests in the same process; save and restore them.
+    """
+    c = RabbitMQConnection()
+    saved = (c._connection_pool, c._channel_pool)
+    try:
+        yield c
+    finally:
+        c._connection_pool, c._channel_pool = saved
+
+
+def test_reset_pools_clears_both_pools(conn):
+    sentinel = object()
+    conn._connection_pool = sentinel  # type: ignore[assignment]
+    conn._channel_pool = sentinel  # type: ignore[assignment]
+
+    conn.reset_pools()
+
+    assert conn._connection_pool is None
+    assert conn._channel_pool is None
+
+
+def test_reset_pools_does_not_touch_stale_pool(conn):
+    """reset_pools must be synchronous and must not call close().
+
+    The whole point is to clear pools bound to an already-closed loop;
+    awaiting close() on them would re-raise the very error we are clearing.
+    A pool object that explodes on close() proves we never touch it.
+    """
+
+    class _Boom:
+        def close(self):
+            raise AssertionError("reset_pools must not call close() on the pool")
+
+    conn._connection_pool = _Boom()  # type: ignore[assignment]
+    conn._channel_pool = _Boom()  # type: ignore[assignment]
+
+    # Synchronous call, no exception.
+    conn.reset_pools()
+
+    assert conn._connection_pool is None
+    assert conn._channel_pool is None


### PR DESCRIPTION
## Problem

`tests/e2e/api/test_workflow_scheduling_flow.py::test_schedule_promote_run_terminal` fails intermittently in CI:

```
AssertionError: expected 0 publish failures, got 1
  → RuntimeError: Event loop is closed   (aio_pika channel open, via deferred_execution_promoter)
```

It surfaced on **all four** open Dependabot PRs (#303/#304/#305/#307) in the same CI minute while `main` was green — an order-dependent flake, not a regression in those diffs (base-image digest bumps can't touch the async path).

## Root cause

`RabbitMQConnection` caches its pools as singleton state and `init_pools()` short-circuits when a pool already exists (`api/src/jobs/rabbitmq.py:54`). The connections bind to whichever asyncio loop first touched them. Under pytest-asyncio's function-scoped loops, a later test reusing the singleton gets a connection pinned to an already-closed loop → `connection.channel()` → `RuntimeError: Event loop is closed`. The test already resets the DB engine and Redis singleton for this exact reason (see its own comment) but missed the RabbitMQ pool.

## Fix

- `RabbitMQConnection.reset_pools()` — synchronously drops both pool references. No `await close()`, because the dead loop would re-raise the very error we're clearing. Mirrors `reset_db_state()`.
- Call `rabbitmq.reset_pools()` in the test alongside the existing DB/Redis resets.

## Verification

Deterministic loop-level repro (pool init on loop A, used from loop B):

| | result |
|---|---|
| without `reset_pools()` | `RuntimeError: Event loop is closed` |
| with `reset_pools()` | publish OK |

- New unit test: `tests/unit/jobs/test_rabbitmq_reset_pools.py` (2 cases)
- Previously-failing E2E now green: `test_workflow_scheduling_flow.py` (4 passed)
- `ruff` clean, `pyright` clean on `rabbitmq.py`

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)