### PR TITLE
Hide workflow retry controls for regular users

### DIFF
--- a/client/src/pages/ExecutionDetails.test.tsx
+++ b/client/src/pages/ExecutionDetails.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Tests for admin-only controls in ExecutionDetails.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+
+const mockUseExecution = vi.fn();
+vi.mock("@/hooks/useExecutions", () => ({
+	useExecution: (...args: unknown[]) => mockUseExecution(...args),
+	cancelExecution: vi.fn(),
+}));
+
+const mockUseWorkflowsMetadata = vi.fn();
+vi.mock("@/hooks/useWorkflows", () => ({
+	useWorkflowsMetadata: (...args: unknown[]) => mockUseWorkflowsMetadata(...args),
+	executeWorkflowWithContext: vi.fn(),
+}));
+
+const mockAuth = vi.fn();
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => mockAuth(),
+}));
+
+vi.mock("@/hooks/useExecutionStream", () => ({
+	useExecutionStream: () => ({ isConnected: false }),
+}));
+
+vi.mock("@/stores/executionStreamStore", () => ({
+	useExecutionStreamStore: () => undefined,
+}));
+
+vi.mock("@/stores/editorStore", () => ({
+	useEditorStore: (selector: (state: Record<string, unknown>) => unknown) =>
+		selector({
+			openFileInTab: vi.fn(),
+			openEditor: vi.fn(),
+			setSidebarPanel: vi.fn(),
+			minimizeEditor: vi.fn(),
+		}),
+}));
+
+vi.mock("@/services/fileService", () => ({
+	fileService: { getFileMetadata: vi.fn() },
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/components/PageLoader", () => ({
+	PageLoader: () => <div>Loading...</div>,
+}));
+
+vi.mock("@/components/execution", () => ({
+	ExecutionResultPanel: () => <div>Result</div>,
+	ExecutionLogsPanel: () => <div>Logs</div>,
+	ExecutionSidebar: () => <aside>Sidebar</aside>,
+	ExecutionCancelDialog: () => null,
+	ExecutionRerunDialog: ({ open }: { open: boolean }) =>
+		open ? <div role="dialog">Rerun dialog</div> : null,
+	ExecutionMetadataBar: ({ workflowName }: { workflowName: string }) => (
+		<div>{workflowName}</div>
+	),
+	ExecutionStatusBadge: ({ status }: { status: string }) => (
+		<span>{status}</span>
+	),
+	PrettyInputDisplay: () => <div>Input</div>,
+}));
+
+const execution = {
+	execution_id: "11111111-1111-1111-1111-111111111111",
+	workflow_id: "22222222-2222-2222-2222-222222222222",
+	workflow_name: "test-workflow",
+	status: "Success",
+	executed_by: "user-1",
+	executed_by_name: "Test User",
+	org_id: "org-1",
+	org_name: "Test Org",
+	form_id: null,
+	input_data: {},
+	result: { ok: true },
+	result_type: "json",
+	logs: [],
+	variables: null,
+	execution_context: null,
+	ai_usage: [],
+	ai_totals: null,
+	started_at: "2026-04-23T10:00:00Z",
+	completed_at: "2026-04-23T10:00:05Z",
+	scheduled_at: null,
+	duration_ms: 5000,
+	peak_memory_bytes: null,
+	cpu_total_seconds: null,
+	error_message: null,
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockAuth.mockReturnValue({
+		isPlatformAdmin: false,
+		hasRole: () => false,
+	});
+	mockUseExecution.mockReturnValue({
+		data: execution,
+		isLoading: false,
+		error: null,
+	});
+	mockUseWorkflowsMetadata.mockReturnValue({
+		data: { workflows: [] },
+		isLoading: false,
+	});
+});
+
+async function renderPage() {
+	const { ExecutionDetails } = await import("./ExecutionDetails");
+	return renderWithProviders(
+		<ExecutionDetails executionId={execution.execution_id} />,
+	);
+}
+
+describe("ExecutionDetails — rerun visibility", () => {
+	it("hides rerun and does not fetch workflow metadata for regular users", async () => {
+		await renderPage();
+
+		expect(
+			screen.queryByRole("button", { name: /rerun/i }),
+		).not.toBeInTheDocument();
+		expect(mockUseWorkflowsMetadata).toHaveBeenCalledWith({
+			enabled: false,
+		});
+	});
+
+	it("shows rerun and fetches workflow metadata for platform admins", async () => {
+		mockAuth.mockReturnValue({
+			isPlatformAdmin: true,
+			hasRole: () => false,
+		});
+
+		await renderPage();
+
+		expect(screen.getByRole("button", { name: /rerun/i })).toBeInTheDocument();
+		expect(mockUseWorkflowsMetadata).toHaveBeenCalledWith({
+			enabled: true,
+		});
+	});
+});

--- a/client/src/pages/ExecutionDetails.tsx
+++ b/client/src/pages/ExecutionDetails.tsx
@@ -153,8 +153,10 @@ export function ExecutionDetails({
 	const setSidebarPanel = useEditorStore((state) => state.setSidebarPanel);
 	const minimizeEditor = useEditorStore((state) => state.minimizeEditor);
 
-	// Fetch workflow metadata to get source file path
-	const { data: metadataData } = useWorkflowsMetadata();
+	// Workflow metadata is only needed for admin-only editor/rerun actions.
+	const { data: metadataData } = useWorkflowsMetadata({
+		enabled: isPlatformAdmin,
+	});
 	const metadata = metadataData as WorkflowsMetadataResponse | undefined;
 
 	// Wrap onComplete in useCallback to prevent infinite loop
@@ -500,7 +502,7 @@ export function ExecutionDetails({
 
 		const actionButtons = (
 			<>
-				{isComplete && (
+				{isPlatformAdmin && isComplete && (
 					<Button
 						variant="ghost"
 						size="icon"
@@ -708,7 +710,7 @@ export function ExecutionDetails({
 										Editor
 									</Button>
 								)}
-								{isComplete && (
+								{isPlatformAdmin && isComplete && (
 									<Button
 										variant="ghost"
 										size="sm"

--- a/client/src/pages/ExecutionHistory.test.tsx
+++ b/client/src/pages/ExecutionHistory.test.tsx
@@ -83,7 +83,7 @@ vi.mock("@/components/agents/AgentRunsPanel", () => ({
 }));
 
 vi.mock("@/components/forms/WorkflowSelector", () => ({
-	WorkflowSelector: () => null,
+	WorkflowSelector: () => <div aria-label="Workflow selector" />,
 }));
 
 vi.mock("@/components/forms/OrganizationSelect", () => ({
@@ -154,9 +154,9 @@ beforeEach(() => {
 	});
 });
 
-async function renderPage() {
+async function renderPage(initialEntries?: string[]) {
 	const { ExecutionHistory } = await import("./ExecutionHistory");
-	return renderWithProviders(<ExecutionHistory />);
+	return renderWithProviders(<ExecutionHistory />, { initialEntries });
 }
 
 // -----------------------------------------------------------------------------
@@ -171,6 +171,32 @@ describe("ExecutionHistory — status filter", () => {
 		expect(
 			screen.getByRole("tab", { name: /^Scheduled$/i }),
 		).toBeInTheDocument();
+	});
+});
+
+describe("ExecutionHistory — workflow filter visibility", () => {
+	it("hides the workflow selector and ignores workflow query params for regular users", async () => {
+		await renderPage(["/history?workflow=workflow-1"]);
+
+		expect(
+			screen.queryByLabelText(/workflow selector/i),
+		).not.toBeInTheDocument();
+		expect(mockUseExecutions).toHaveBeenLastCalledWith(
+			undefined,
+			expect.not.objectContaining({ workflow_id: "workflow-1" }),
+			undefined,
+		);
+	});
+
+	it("shows the workflow selector for platform admins", async () => {
+		mockAuth.mockReturnValue({
+			isPlatformAdmin: true,
+			user: { id: "admin-1", email: "admin@example.com" },
+		});
+
+		await renderPage();
+
+		expect(screen.getByLabelText(/workflow selector/i)).toBeInTheDocument();
 	});
 });
 

--- a/client/src/pages/ExecutionHistory.tsx
+++ b/client/src/pages/ExecutionHistory.tsx
@@ -187,8 +187,8 @@ export function ExecutionHistory() {
 		// Add excludeLocal filter (inverse of showLocal)
 		baseFilters.excludeLocal = !showLocal;
 
-		// Add workflow ID filter
-		if (workflowIdFilter) {
+		// Workflow IDs are implementation details; only admins get this filter.
+		if (isPlatformAdmin && workflowIdFilter) {
 			baseFilters.workflow_id = workflowIdFilter;
 		}
 
@@ -210,7 +210,7 @@ export function ExecutionHistory() {
 		}
 
 		return baseFilters;
-	}, [statusFilter, dateRange, showLocal, workflowIdFilter]);
+	}, [statusFilter, dateRange, showLocal, isPlatformAdmin, workflowIdFilter]);
 
 	// Pass filterOrgId to backend for filtering (undefined = all, null = global only)
 	// For platform admins, undefined means show all. For non-admins, backend handles filtering.
@@ -703,26 +703,28 @@ export function ExecutionHistory() {
 						: "Search by workflow name, user, or execution ID..."}
 					className="flex-1 max-w-2xl"
 				/>
-				<WorkflowSelector
-					value={workflowIdFilter || undefined}
-					onChange={(value) => {
-						const newFilter = value ?? "";
-						setWorkflowIdFilter(newFilter);
-						setSearchParams((prev) => {
-							const next = new URLSearchParams(prev);
-							if (newFilter) {
-								next.set("workflow", newFilter);
-							} else {
-								next.delete("workflow");
-							}
-							return next;
-						}, { replace: true });
-					}}
-					variant="combobox"
-					allowClear={true}
-					placeholder="All workflows"
-					className="w-48"
-				/>
+				{isPlatformAdmin && (
+					<WorkflowSelector
+						value={workflowIdFilter || undefined}
+						onChange={(value) => {
+							const newFilter = value ?? "";
+							setWorkflowIdFilter(newFilter);
+							setSearchParams((prev) => {
+								const next = new URLSearchParams(prev);
+								if (newFilter) {
+									next.set("workflow", newFilter);
+								} else {
+									next.delete("workflow");
+								}
+								return next;
+							}, { replace: true });
+						}}
+						variant="combobox"
+						allowClear={true}
+						placeholder="All workflows"
+						className="w-48"
+					/>
+				)}
 				<DateRangePicker
 					dateRange={dateRange}
 					onDateRangeChange={setDateRange}


### PR DESCRIPTION
## Summary
- hide workflow rerun controls from non-admin execution details views
- stop non-admin execution details from fetching workflow metadata used only by admin actions
- hide workflow filtering from regular users and ignore workflow query params for them

## Verification
- ./test.sh client unit -- ExecutionHistory.test.tsx ExecutionDetails.test.tsx
- Previously before rebase: ./test.sh client unit, npm run tsc, npm run lint
- Previously before rebase: ./test.sh client e2e ran; broad suite had unrelated existing failures, while org-user history and admin rerun checks passed