### PR TITLE
docs: clarify workflow hooks and table SDK usage

### DIFF
--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -333,7 +333,7 @@ Before writing any app code, design what you're building.
 
 1. **Every `<PascalCase>` tag and identifier needs an explicit import.** There is no auto-injection. See [import-patterns.md](import-patterns.md) for which name comes from which source.
 2. **Root layout:** `_layout.tsx` uses `<Outlet />` from `"bifrost"` (or `"react-router-dom"`) — NOT `{children}`.
-3. **Workflow hooks:** Always use UUIDs, never names — `useWorkflowQuery("uuid-here")`. Resolve UUIDs with `bifrost workflows list --json` or `bifrost workflows get <ref> --json`.
+3. **Workflow hooks:** Always use UUIDs, never names — `useWorkflowQuery("uuid-here")`. Resolve UUIDs with `bifrost workflows list --json` or `bifrost workflows get <ref> --json`. Use `useWorkflowQuery` for page-load / param-driven data. Use `useWorkflowMutation` for click/submit actions. `execute()` resolves with the final result, not the execution ID; read `executionId` from hook state and react to it in `useEffect` if you need to redirect to `/executions/{executionId}`.
 4. **Fixed-height container:** Your app renders in a fixed-height box — manage your own scrolling (see [app-patterns.md](app-patterns.md) "Custom components" for layout patterns).
 5. **Styling:** Tailwind v4 with the full feature set — arbitrary values (`bg-[color:var(--x)]`, `lg:grid-cols-[1fr_360px]`), `@apply` and `@layer components` in `styles.css`, optional per-app `tailwind.config.{ts,js,mjs,cjs}` for custom theme tokens. Dark mode via `.dark` selector. See [app-patterns.md](app-patterns.md) §10.
 6. **Dependencies:** Declare npm packages with `bifrost apps create --deps`, `bifrost apps update <ref> --deps`, or `bifrost apps set-deps <ref> --deps` (max 20, loaded from esm.sh at runtime — no `package.json` required at runtime, though `--deps @package.json` works for one-shot import).
@@ -347,11 +347,15 @@ These patterns are required for every data-fetching page. Full code examples in 
 - Handle `isLoading` / `isError` on every `useWorkflowQuery`.
 - Null-safe access: `data?.items?.map(...)`, never `data.items.map(...)`.
 - Every `useWorkflowMutation` must handle errors (toast + stay on page).
+- Prefer `errorMessage` over deprecated `error` on workflow hooks.
+- Treat workflow hook `executionId`, `data`, `errorMessage`, and `isLoading` as latest-run state. Do not assume they are per-call state for concurrent `execute()` calls.
 - Verify `useEffect` dep arrays — no stale closures.
 - Custom components go in `components/<Name>.tsx`, imported relatively.
 - Heavy routes: split with `React.lazy(() => import("./pages/heavy"))` + `<Suspense>`.
 
 **Tables:** When you need to read or write structured data from an app, use the `tables.*` SDK + `useTable` hook directly (see [platform-api.md](platform-api.md) → tables). **If you're about to write a workflow just to read/write a table, configure policies and use the SDK directly.** See [app-patterns.md](app-patterns.md) §11 for the CRUD-with-live-updates pattern.
+
+**Workflow progress:** Apps can observe workflow status/logs through `useWorkflowQuery` / `useWorkflowMutation` (`status`, `logs`, `executionId`). There is currently no public workflow SDK method named `execution.publish`, `execution.update`, or `executions.publish` for arbitrary structured progress events. For live structured data, write rows to a table and read them with `useTable`; for textual progress, use workflow logs.
 
 **Drag-and-drop:** Do NOT use `@dnd-kit/*` or `react-beautiful-dnd`. esm.sh's externalization signatures cause the context-providing module to load twice; `useSortable`'s `listeners` come back empty and the drag handle silently never gets an `onPointerDown`. Use native HTML5 drag-and-drop instead — see [app-patterns.md](app-patterns.md) §12 for the handle-armed pattern and reference implementations.
 

--- a/.claude/skills/bifrost-build/app-patterns.md
+++ b/.claude/skills/bifrost-build/app-patterns.md
@@ -13,7 +13,7 @@ import { useWorkflowQuery, Alert, AlertTitle, AlertDescription, Skeleton } from 
 import { Loader2 } from "lucide-react";
 
 export default function ClientsPage() {
-  const { data, isLoading, isError, error } = useWorkflowQuery<{ items: any[] }>("uuid-here");
+  const { data, isLoading, isError, errorMessage } = useWorkflowQuery<{ items: any[] }>("uuid-here");
 
   if (isLoading) {
     return (
@@ -26,7 +26,7 @@ export default function ClientsPage() {
     return (
       <Alert variant="destructive">
         <AlertTitle>Error</AlertTitle>
-        <AlertDescription>{error ?? "Failed to load"}</AlertDescription>
+        <AlertDescription>{errorMessage ?? "Failed to load"}</AlertDescription>
       </Alert>
     );
   }
@@ -104,6 +104,37 @@ export default function SaveButton({ payload }: { payload: any }) {
   return <Button onClick={onClick} disabled={isLoading}>Save</Button>;
 }
 ```
+
+### Execution IDs and redirects
+
+`execute()` resolves with the final workflow result, not the execution ID. Both `useWorkflowMutation` and `useWorkflowQuery` expose `executionId` as reactive state; it becomes non-null after the workflow execution is created and before the final result is available. If you need to navigate to the execution page, react to `executionId` in `useEffect`.
+
+```tsx
+import { useEffect, useState, useWorkflowMutation, useNavigate, Button, toast } from "bifrost";
+
+export default function StartReportButton() {
+  const navigate = useNavigate();
+  const [shouldRedirect, setShouldRedirect] = useState(false);
+  const { execute, executionId, isLoading } = useWorkflowMutation("start-report-uuid");
+
+  useEffect(() => {
+    if (!shouldRedirect || !executionId) return;
+    navigate(`/executions/${executionId}`);
+  }, [shouldRedirect, executionId, navigate]);
+
+  function start() {
+    setShouldRedirect(true);
+    execute({ reportType: "monthly" }).catch((e) => {
+      setShouldRedirect(false);
+      toast.error(e instanceof Error ? e.message : "Could not start report");
+    });
+  }
+
+  return <Button onClick={start} disabled={isLoading}>Start report</Button>;
+}
+```
+
+Use the `shouldRedirect` guard so an old latest `executionId` does not redirect immediately. For concurrent/background runs, remember that the hook's `executionId`, `data`, `errorMessage`, and `isLoading` describe the latest run from that hook, not separate per-run state.
 
 ### Optimistic update reversal
 

--- a/.claude/skills/bifrost-build/import-patterns.md
+++ b/.claude/skills/bifrost-build/import-patterns.md
@@ -85,10 +85,10 @@ const WF_LIST_CLIENTS = "4f262085-f4d1-4b3d-a601-575ba4c9d207";
 export default function ClientsPage() {
   const [q, setQ] = useState("");
   const navigate = useNavigate();
-  const { data, isLoading, isError, error } = useWorkflowQuery(WF_LIST_CLIENTS, { q });
+  const { data, isLoading, isError, errorMessage } = useWorkflowQuery(WF_LIST_CLIENTS, { q });
 
   if (isError) {
-    toast.error(error ?? "Failed to load clients");
+    toast.error(errorMessage ?? "Failed to load clients");
     return null;
   }
 

--- a/.claude/skills/bifrost-build/platform-api.md
+++ b/.claude/skills/bifrost-build/platform-api.md
@@ -451,6 +451,8 @@ useWorkflowMutation<T = unknown>(workflowId: string): {
   execute: (params?: Record<string, unknown>) => Promise<T>;
   isLoading: boolean;
   isError: boolean;
+  errorMessage: string | null;
+  /** @deprecated use errorMessage */
   error: string | null;
   data: T | null;
   logs: StreamingLog[];
@@ -460,7 +462,9 @@ useWorkflowMutation<T = unknown>(workflowId: string): {
 }
 ```
 
-Imperative workflow execution. Does nothing until `execute()` is called. Every call is independent (concurrent calls don't interfere). `execute()` resolves with the workflow result or rejects on failure / timeout (5min).
+Imperative workflow execution. Use it for click/submit actions: save, approve, delete, sync, generate, send. It does nothing until `execute()` is called. `execute()` resolves with the final workflow result or rejects on failure / timeout (5min); it does **not** return the execution ID.
+
+`executionId` is reactive hook state. It becomes non-null as soon as the platform returns `execution_id` from `POST /api/workflows/execute`, before the workflow result resolves. If you need to redirect or show an execution link, watch `executionId` with `useEffect`. The hook state is latest-execution state, not per-call state; avoid concurrent `execute()` calls from one hook if the UI needs separate state for each run.
 
 ```tsx
 import { useWorkflowMutation, Button, toast } from "bifrost";
@@ -481,6 +485,30 @@ export default function SaveButton({ client }: { client: any }) {
 }
 ```
 
+```tsx
+import { useEffect, useState, useWorkflowMutation, useNavigate, Button } from "bifrost";
+
+const WF_START_REPORT = "uuid-here";
+
+export default function StartReportButton() {
+  const navigate = useNavigate();
+  const [shouldRedirect, setShouldRedirect] = useState(false);
+  const { execute, executionId, isLoading } = useWorkflowMutation(WF_START_REPORT);
+
+  useEffect(() => {
+    if (!shouldRedirect || !executionId) return;
+    navigate(`/executions/${executionId}`);
+  }, [shouldRedirect, executionId, navigate]);
+
+  function start() {
+    setShouldRedirect(true);
+    execute({ reportType: "monthly" }).catch(() => setShouldRedirect(false));
+  }
+
+  return <Button onClick={start} disabled={isLoading}>Start report</Button>;
+}
+```
+
 ### useWorkflowQuery
 
 Signature:
@@ -493,6 +521,8 @@ useWorkflowQuery<T = unknown>(
   data: T | null;
   isLoading: boolean;
   isError: boolean;
+  errorMessage: string | null;
+  /** @deprecated use errorMessage */
   error: string | null;
   logs: StreamingLog[];
   refetch: () => Promise<T>;
@@ -501,7 +531,9 @@ useWorkflowQuery<T = unknown>(
 }
 ```
 
-Declarative fetching. Executes on mount and re-executes when `params` change (JSON-stable shallow compare). Pass `{ enabled: false }` to gate execution.
+Declarative workflow execution for page data. Use it when rendering the page should run the workflow: list pages, detail pages, dashboards, and reports. It executes on mount and re-executes when `params` change (`JSON.stringify(params ?? {})`, so object key order matters). Pass `{ enabled: false }` to gate execution.
+
+`useWorkflowQuery` wraps `useWorkflowMutation`, so `executionId`, `status`, and `logs` behave the same way: `executionId` starts as `null`, becomes non-null after the execution is created, and stays as the latest execution ID for this hook. Use `useEffect` if you need to react when it appears.
 
 ```tsx
 import { useWorkflowQuery, Alert, AlertDescription } from "bifrost";
@@ -509,9 +541,9 @@ import { useWorkflowQuery, Alert, AlertDescription } from "bifrost";
 const WF_LIST_CLIENTS = "uuid-here";
 
 export default function Clients() {
-  const { data, isLoading, isError, error, refetch } = useWorkflowQuery<{ items: any[] }>(WF_LIST_CLIENTS);
+  const { data, isLoading, isError, errorMessage, refetch } = useWorkflowQuery<{ items: any[] }>(WF_LIST_CLIENTS);
   if (isLoading) return <div>Loading…</div>;
-  if (isError) return <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>;
+  if (isError) return <Alert variant="destructive"><AlertDescription>{errorMessage}</AlertDescription></Alert>;
   return <ul>{data?.items?.map((c) => <li key={c.id}>{c.name}</li>)}</ul>;
 }
 ```
@@ -1432,7 +1464,7 @@ await tables.insert("clients", [
 
 // Live query — preferred React surface
 const { rows, loading, error } = useTable("clients", {
-  where: { eq: [{ row: "status" }, "active"] },
+  where: { status: "active" },
 });
 ```
 
@@ -1465,12 +1497,18 @@ The `where` filter uses the **dict-shorthand DSL** — same shape the Python SDK
 ```tsx
 useTable("notes",    { where: { client_id: clientId } });
 useTable("invoices", { where: { amount: { gte: 100, lt: 1000 } } });
-useTable("clients",  { where: { name: { contains: "acme" } } });
+useTable("clients",  { where: { name: "Acme" } });
 useTable("tickets",  { where: { status: { in: ["open", "pending"] } } });
 useTable("tasks",    { where: { deleted_at: { is_null: true } } });
 ```
 
-Operators: `eq`, `neq` / `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `is_null`, `has_key`, `contains`, `starts_with`, `ends_with`. The last four are query-only (no policy `Expr` equivalent) — using them in `useTable.where` raises a clear error via `error`. For those, use `tables.query` for one-shot reads or filter client-side.
+Live `useTable.where` supports: equality shorthand, `eq`, `neq` / `ne`, `gt`, `gte`, `lt`, `lte`, `in`, and `is_null`. Query-only operators `contains`, `starts_with`, `ends_with`, and `has_key` work with `tables.query` but cannot be represented as the live subscription policy `Expr`; using them in `useTable.where` raises a clear error via `error`.
+
+```tsx
+const matches = await tables.query("clients", {
+  where: { name: { contains: "acme" } },
+});
+```
 
 ```tsx
 import { useTable } from "bifrost";
@@ -1542,4 +1580,3 @@ The native `WeakSet` constructor (`globalThis.WeakSet`). Re-asserted for symmetr
 ### Date
 
 The native `Date` constructor (`globalThis.Date`). Lucide ships a `Calendar`-adjacent icon set — re-asserted to keep `new Date()` resolving to the constructor.
-

--- a/client/src/lib/app-code-platform.d.ts
+++ b/client/src/lib/app-code-platform.d.ts
@@ -366,13 +366,15 @@ export declare const tables: typeof import("./app-sdk/tables").tables;
  * sees exactly the same row visibility as the snapshot.
  *
  * @param name - Table name (or id) to query and subscribe to
- * @param query - Optional `where` / `limit` / `offset` query parameters
- * @returns `{ rows, loading, error }`
+ * @param query - Optional `where` / `page` / `pageSize` / order / scope query parameters
+ * @returns `{ rows, total, totalPages, loading, error }`
  *
  * @example
  * ```tsx
- * const { rows, loading, error } = useTable("tickets", {
- *   where: { eq: ["status", "open"] },
+ * const { rows, totalPages, loading, error } = useTable("tickets", {
+ *   where: { status: "open" },
+ *   page: 1,
+ *   pageSize: 50,
  * });
  *
  * if (loading) return <Skeleton />;

--- a/docs/llm.txt
+++ b/docs/llm.txt
@@ -113,6 +113,13 @@ Non-obvious semantics:
 - `update` is patch-without-draft — metadata changes apply to the live app, no staging step.
 - `replace <ref> --repo-path <new>` repoints an app's source directory. Validates uniqueness (no other app already owns `<new>`), nesting (no other app's `repo_path` sits above or below `<new>`), and that source files exist under `<new>`. `--force` bypasses all three. Metadata-only: no S3 file moves — caller reconciles files via `bifrost sync`.
 
+Workflow hooks in apps:
+- Use `useWorkflowQuery(workflowUuid, params?, options?)` for page-load / param-driven data. It starts a workflow on mount and again when `JSON.stringify(params ?? {})` changes. Use `enabled: false` to gate execution.
+- Use `useWorkflowMutation(workflowUuid)` for click/submit actions. `execute(params)` resolves with the final workflow result, not the execution ID.
+- Both hooks expose `executionId`, `status`, `logs`, `data`, `isLoading`, `isError`, and `errorMessage` (`error` is only a deprecated string alias). `executionId` is reactive state: it becomes non-null once the platform creates the execution, before the final result is available. To redirect to an execution page, watch `executionId` in `useEffect`.
+- Hook state is latest-run state, not per-call state. Do not use one hook instance for concurrent `execute()` calls if the UI needs separate execution IDs/loading/error state per run.
+- There is currently no public workflow SDK method named `execution.publish`, `execution.update`, or `executions.publish` for arbitrary structured progress events. For live structured progress, write rows to a table and read them with `useTable`; for textual progress, use workflow logs.
+
 Run `bifrost apps <verb> --help` for the complete flag list.
 
 ## Integrations
@@ -162,7 +169,8 @@ Non-obvious semantics:
 - The policy `when` is a JSON AST. Operators: `and`/`or`/`not`, `eq`/`neq`/`lt`/`lte`/`gt`/`gte`, `in`, `is_null`, `call`. References: `{row: "field"}`, `{user: "field"}`. Functions: `has_role(name_or_uuid)`.
 - Browser apps call tables directly via `import { tables, useTable } from "bifrost"`. SDK calls return what the policy permits; no execution records.
 - Workflow SDK auto-attributes `created_by`/`updated_by` from `context.user_id`; pass `created_by=` to override.
-- Subscriptions: `useTable(name, query?)` is the unified live-query hook. Lower-level `tables.subscribe(tableId, filter, onEvent)` for non-React code. Server filters per-policy AND per-user-filter; the four-way fanout emits insert/update/delete including transitions into and out of visibility.
+- Subscriptions: `useTable(name, query?)` is the unified live-query hook. Its `where` uses the field-keyed shorthand DSL (`{status: "open"}`, `{amount: {gte: 100}}`), not raw policy `Expr` (`{eq: [...]}`). Lower-level `tables.subscribe(tableId, filter, onEvent)` is for non-React code and takes policy `Expr`. Server filters per-policy AND per-user-filter; the four-way fanout emits insert/update/delete including transitions into and out of visibility.
+- Query-only operators `contains`, `starts_with`, `ends_with`, and `has_key` work with `tables.query` but not with live `useTable.where`; using them in `useTable` surfaces an error because the subscription filter cannot represent them.
 - `update --name` prints a warning to stderr about workflow SDK references (SDK calls like `sdk.tables.get("clients")` reference tables by name). It does not block — the author must grep the workspace before pushing.
 - `--application` accepts app slug / UUID / name.
 

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -333,7 +333,7 @@ Before writing any app code, design what you're building.
 
 1. **Every `<PascalCase>` tag and identifier needs an explicit import.** There is no auto-injection. See [import-patterns.md](import-patterns.md) for which name comes from which source.
 2. **Root layout:** `_layout.tsx` uses `<Outlet />` from `"bifrost"` (or `"react-router-dom"`) — NOT `{children}`.
-3. **Workflow hooks:** Always use UUIDs, never names — `useWorkflowQuery("uuid-here")`. Resolve UUIDs with `bifrost workflows list --json` or `bifrost workflows get <ref> --json`.
+3. **Workflow hooks:** Always use UUIDs, never names — `useWorkflowQuery("uuid-here")`. Resolve UUIDs with `bifrost workflows list --json` or `bifrost workflows get <ref> --json`. Use `useWorkflowQuery` for page-load / param-driven data. Use `useWorkflowMutation` for click/submit actions. `execute()` resolves with the final result, not the execution ID; read `executionId` from hook state and react to it in `useEffect` if you need to redirect to `/executions/{executionId}`.
 4. **Fixed-height container:** Your app renders in a fixed-height box — manage your own scrolling (see [app-patterns.md](app-patterns.md) "Custom components" for layout patterns).
 5. **Styling:** Tailwind v4 with the full feature set — arbitrary values (`bg-[color:var(--x)]`, `lg:grid-cols-[1fr_360px]`), `@apply` and `@layer components` in `styles.css`, optional per-app `tailwind.config.{ts,js,mjs,cjs}` for custom theme tokens. Dark mode via `.dark` selector. See [app-patterns.md](app-patterns.md) §10.
 6. **Dependencies:** Declare npm packages with `bifrost apps create --deps`, `bifrost apps update <ref> --deps`, or `bifrost apps set-deps <ref> --deps` (max 20, loaded from esm.sh at runtime — no `package.json` required at runtime, though `--deps @package.json` works for one-shot import).
@@ -347,11 +347,15 @@ These patterns are required for every data-fetching page. Full code examples in 
 - Handle `isLoading` / `isError` on every `useWorkflowQuery`.
 - Null-safe access: `data?.items?.map(...)`, never `data.items.map(...)`.
 - Every `useWorkflowMutation` must handle errors (toast + stay on page).
+- Prefer `errorMessage` over deprecated `error` on workflow hooks.
+- Treat workflow hook `executionId`, `data`, `errorMessage`, and `isLoading` as latest-run state. Do not assume they are per-call state for concurrent `execute()` calls.
 - Verify `useEffect` dep arrays — no stale closures.
 - Custom components go in `components/<Name>.tsx`, imported relatively.
 - Heavy routes: split with `React.lazy(() => import("./pages/heavy"))` + `<Suspense>`.
 
 **Tables:** When you need to read or write structured data from an app, use the `tables.*` SDK + `useTable` hook directly (see [platform-api.md](platform-api.md) → tables). **If you're about to write a workflow just to read/write a table, configure policies and use the SDK directly.** See [app-patterns.md](app-patterns.md) §11 for the CRUD-with-live-updates pattern.
+
+**Workflow progress:** Apps can observe workflow status/logs through `useWorkflowQuery` / `useWorkflowMutation` (`status`, `logs`, `executionId`). There is currently no public workflow SDK method named `execution.publish`, `execution.update`, or `executions.publish` for arbitrary structured progress events. For live structured data, write rows to a table and read them with `useTable`; for textual progress, use workflow logs.
 
 ### Platform API Reference
 

--- a/plugins/bifrost/skills/bifrost-build/app-patterns.md
+++ b/plugins/bifrost/skills/bifrost-build/app-patterns.md
@@ -13,7 +13,7 @@ import { useWorkflowQuery, Alert, AlertTitle, AlertDescription, Skeleton } from 
 import { Loader2 } from "lucide-react";
 
 export default function ClientsPage() {
-  const { data, isLoading, isError, error } = useWorkflowQuery<{ items: any[] }>("uuid-here");
+  const { data, isLoading, isError, errorMessage } = useWorkflowQuery<{ items: any[] }>("uuid-here");
 
   if (isLoading) {
     return (
@@ -26,7 +26,7 @@ export default function ClientsPage() {
     return (
       <Alert variant="destructive">
         <AlertTitle>Error</AlertTitle>
-        <AlertDescription>{error ?? "Failed to load"}</AlertDescription>
+        <AlertDescription>{errorMessage ?? "Failed to load"}</AlertDescription>
       </Alert>
     );
   }
@@ -104,6 +104,37 @@ export default function SaveButton({ payload }: { payload: any }) {
   return <Button onClick={onClick} disabled={isLoading}>Save</Button>;
 }
 ```
+
+### Execution IDs and redirects
+
+`execute()` resolves with the final workflow result, not the execution ID. Both `useWorkflowMutation` and `useWorkflowQuery` expose `executionId` as reactive state; it becomes non-null after the workflow execution is created and before the final result is available. If you need to navigate to the execution page, react to `executionId` in `useEffect`.
+
+```tsx
+import { useEffect, useState, useWorkflowMutation, useNavigate, Button, toast } from "bifrost";
+
+export default function StartReportButton() {
+  const navigate = useNavigate();
+  const [shouldRedirect, setShouldRedirect] = useState(false);
+  const { execute, executionId, isLoading } = useWorkflowMutation("start-report-uuid");
+
+  useEffect(() => {
+    if (!shouldRedirect || !executionId) return;
+    navigate(`/executions/${executionId}`);
+  }, [shouldRedirect, executionId, navigate]);
+
+  function start() {
+    setShouldRedirect(true);
+    execute({ reportType: "monthly" }).catch((e) => {
+      setShouldRedirect(false);
+      toast.error(e instanceof Error ? e.message : "Could not start report");
+    });
+  }
+
+  return <Button onClick={start} disabled={isLoading}>Start report</Button>;
+}
+```
+
+Use the `shouldRedirect` guard so an old latest `executionId` does not redirect immediately. For concurrent/background runs, remember that the hook's `executionId`, `data`, `errorMessage`, and `isLoading` describe the latest run from that hook, not separate per-run state.
 
 ### Optimistic update reversal
 

--- a/plugins/bifrost/skills/bifrost-build/import-patterns.md
+++ b/plugins/bifrost/skills/bifrost-build/import-patterns.md
@@ -85,10 +85,10 @@ const WF_LIST_CLIENTS = "4f262085-f4d1-4b3d-a601-575ba4c9d207";
 export default function ClientsPage() {
   const [q, setQ] = useState("");
   const navigate = useNavigate();
-  const { data, isLoading, isError, error } = useWorkflowQuery(WF_LIST_CLIENTS, { q });
+  const { data, isLoading, isError, errorMessage } = useWorkflowQuery(WF_LIST_CLIENTS, { q });
 
   if (isError) {
-    toast.error(error ?? "Failed to load clients");
+    toast.error(errorMessage ?? "Failed to load clients");
     return null;
   }
 

--- a/plugins/bifrost/skills/bifrost-build/platform-api.md
+++ b/plugins/bifrost/skills/bifrost-build/platform-api.md
@@ -451,6 +451,8 @@ useWorkflowMutation<T = unknown>(workflowId: string): {
   execute: (params?: Record<string, unknown>) => Promise<T>;
   isLoading: boolean;
   isError: boolean;
+  errorMessage: string | null;
+  /** @deprecated use errorMessage */
   error: string | null;
   data: T | null;
   logs: StreamingLog[];
@@ -460,7 +462,9 @@ useWorkflowMutation<T = unknown>(workflowId: string): {
 }
 ```
 
-Imperative workflow execution. Does nothing until `execute()` is called. Every call is independent (concurrent calls don't interfere). `execute()` resolves with the workflow result or rejects on failure / timeout (5min).
+Imperative workflow execution. Use it for click/submit actions: save, approve, delete, sync, generate, send. It does nothing until `execute()` is called. `execute()` resolves with the final workflow result or rejects on failure / timeout (5min); it does **not** return the execution ID.
+
+`executionId` is reactive hook state. It becomes non-null as soon as the platform returns `execution_id` from `POST /api/workflows/execute`, before the workflow result resolves. If you need to redirect or show an execution link, watch `executionId` with `useEffect`. The hook state is latest-execution state, not per-call state; avoid concurrent `execute()` calls from one hook if the UI needs separate state for each run.
 
 ```tsx
 import { useWorkflowMutation, Button, toast } from "bifrost";
@@ -481,6 +485,30 @@ export default function SaveButton({ client }: { client: any }) {
 }
 ```
 
+```tsx
+import { useEffect, useState, useWorkflowMutation, useNavigate, Button } from "bifrost";
+
+const WF_START_REPORT = "uuid-here";
+
+export default function StartReportButton() {
+  const navigate = useNavigate();
+  const [shouldRedirect, setShouldRedirect] = useState(false);
+  const { execute, executionId, isLoading } = useWorkflowMutation(WF_START_REPORT);
+
+  useEffect(() => {
+    if (!shouldRedirect || !executionId) return;
+    navigate(`/executions/${executionId}`);
+  }, [shouldRedirect, executionId, navigate]);
+
+  function start() {
+    setShouldRedirect(true);
+    execute({ reportType: "monthly" }).catch(() => setShouldRedirect(false));
+  }
+
+  return <Button onClick={start} disabled={isLoading}>Start report</Button>;
+}
+```
+
 ### useWorkflowQuery
 
 Signature:
@@ -493,6 +521,8 @@ useWorkflowQuery<T = unknown>(
   data: T | null;
   isLoading: boolean;
   isError: boolean;
+  errorMessage: string | null;
+  /** @deprecated use errorMessage */
   error: string | null;
   logs: StreamingLog[];
   refetch: () => Promise<T>;
@@ -501,7 +531,9 @@ useWorkflowQuery<T = unknown>(
 }
 ```
 
-Declarative fetching. Executes on mount and re-executes when `params` change (JSON-stable shallow compare). Pass `{ enabled: false }` to gate execution.
+Declarative workflow execution for page data. Use it when rendering the page should run the workflow: list pages, detail pages, dashboards, and reports. It executes on mount and re-executes when `params` change (`JSON.stringify(params ?? {})`, so object key order matters). Pass `{ enabled: false }` to gate execution.
+
+`useWorkflowQuery` wraps `useWorkflowMutation`, so `executionId`, `status`, and `logs` behave the same way: `executionId` starts as `null`, becomes non-null after the execution is created, and stays as the latest execution ID for this hook. Use `useEffect` if you need to react when it appears.
 
 ```tsx
 import { useWorkflowQuery, Alert, AlertDescription } from "bifrost";
@@ -509,9 +541,9 @@ import { useWorkflowQuery, Alert, AlertDescription } from "bifrost";
 const WF_LIST_CLIENTS = "uuid-here";
 
 export default function Clients() {
-  const { data, isLoading, isError, error, refetch } = useWorkflowQuery<{ items: any[] }>(WF_LIST_CLIENTS);
+  const { data, isLoading, isError, errorMessage, refetch } = useWorkflowQuery<{ items: any[] }>(WF_LIST_CLIENTS);
   if (isLoading) return <div>Loading…</div>;
-  if (isError) return <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>;
+  if (isError) return <Alert variant="destructive"><AlertDescription>{errorMessage}</AlertDescription></Alert>;
   return <ul>{data?.items?.map((c) => <li key={c.id}>{c.name}</li>)}</ul>;
 }
 ```
@@ -1432,7 +1464,7 @@ await tables.insert("clients", [
 
 // Live query — preferred React surface
 const { rows, loading, error } = useTable("clients", {
-  where: { eq: [{ row: "status" }, "active"] },
+  where: { status: "active" },
 });
 ```
 
@@ -1465,12 +1497,18 @@ The `where` filter uses the **dict-shorthand DSL** — same shape the Python SDK
 ```tsx
 useTable("notes",    { where: { client_id: clientId } });
 useTable("invoices", { where: { amount: { gte: 100, lt: 1000 } } });
-useTable("clients",  { where: { name: { contains: "acme" } } });
+useTable("clients",  { where: { name: "Acme" } });
 useTable("tickets",  { where: { status: { in: ["open", "pending"] } } });
 useTable("tasks",    { where: { deleted_at: { is_null: true } } });
 ```
 
-Operators: `eq`, `neq` / `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `is_null`, `has_key`, `contains`, `starts_with`, `ends_with`. The last four are query-only (no policy `Expr` equivalent) — using them in `useTable.where` raises a clear error via `error`. For those, use `tables.query` for one-shot reads or filter client-side.
+Live `useTable.where` supports: equality shorthand, `eq`, `neq` / `ne`, `gt`, `gte`, `lt`, `lte`, `in`, and `is_null`. Query-only operators `contains`, `starts_with`, `ends_with`, and `has_key` work with `tables.query` but cannot be represented as the live subscription policy `Expr`; using them in `useTable.where` raises a clear error via `error`.
+
+```tsx
+const matches = await tables.query("clients", {
+  where: { name: { contains: "acme" } },
+});
+```
 
 ```tsx
 import { useTable } from "bifrost";


### PR DESCRIPTION
## Summary
- clarify when to use useWorkflowQuery vs useWorkflowMutation
- document executionId as reactive hook state and add redirect examples
- correct useTable docs around the field-keyed where DSL and query-only operators

## Tests
- git diff --check
- attempted focused Vitest hook/table tests; worktree lacks client/node_modules, and reusing the primary checkout's deps failed ESM config resolution