### PR TITLE
chore(release): bump all plugin manifests together

### DIFF
--- a/.claude/skills/bifrost-release/SKILL.md
+++ b/.claude/skills/bifrost-release/SKILL.md
@@ -224,9 +224,9 @@ grep -vE $'\t(jackmusick|app/dependabot|app/renovate|github-actions\\[bot\\])\t'
 - ❌ Crediting only in the Contributors section without per-bullet `(#NN by @user)` markers. Readers scanning the feature list shouldn't have to scroll to find out who shipped it.
 - ❌ Putting external contributors as a footnote. They led the work — lead with their name on the bullet that describes it.
 
-### 2c. Bump the Claude plugin manifest (REQUIRED)
+### 2c. Bump the Claude and Codex plugin manifests (REQUIRED)
 
-Claude Code's plugin marketplace only fetches plugin updates when `.claude-plugin/plugin.json`'s `version` field changes on the default branch. Without this step, users installed via the bifrost plugin will keep getting the old skill content.
+Claude Code and Codex plugin marketplaces key installed plugin content by manifest `version`. Without this step, users installed via the bifrost plugin can keep getting old skill content even after the Git changes are merged.
 
 Run the helper, commit the bump to `main` via a normal PR, and merge it **before** tagging:
 
@@ -234,12 +234,12 @@ Run the helper, commit the bump to `main` via a normal PR, and merge it **before
 # <tag> is the version you're about to cut, e.g. v0.8.1 — strip the leading v.
 VERSION="${TAG#v}"
 ./scripts/update-plugin-version.sh "$VERSION"
-git add .claude-plugin/plugin.json
-git commit -m "chore(release): bump plugin manifest to $VERSION"
+git add .claude-plugin/plugin.json .codex-plugin/plugin.json plugins/bifrost/.codex-plugin/plugin.json
+git commit -m "chore(release): bump plugin manifests to $VERSION"
 # PR + merge via the normal flow, then continue.
 ```
 
-The tag-build CI job (`build-api`) has a hard guard that fails the release if the manifest version doesn't match the tag — so forgetting this step blocks the build, it doesn't silently ship stale skills.
+The tag-build CI job (`build-api`) has a hard guard that fails the release if any plugin manifest version doesn't match the tag — so forgetting this step blocks the build, it doesn't silently ship stale skills.
 
 **Trade-off:** between releases the manifest reflects the last tagged version, not the current dev commit. Per-push commit-back was considered and rejected — main has branch protection with required PR review and no ruleset bypass, so CI cannot push directly, and an auto-PR loop would churn the merge queue on every commit. See issue #245 and PR #246 for the full rationale.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,25 +206,28 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
-      # Surface manifest drift to the job summary. The plugin manifest is
-      # updated at tag time (see bifrost-release skill) — between tags the
-      # `version` field reflects the last released version, not the current
-      # dev version. This step is informational only; it does not fail the
-      # build and does not commit anything back. See PR #246 for the
-      # rationale (branch protection + commit-back loop avoidance).
+      # Surface manifest drift to the job summary. Plugin manifests are updated
+      # at tag time (see bifrost-release skill) — between tags the `version`
+      # field reflects the last released version, not the current dev version.
+      # This step is informational only; it does not fail the build and does
+      # not commit anything back. See PR #246 for the rationale (branch
+      # protection + commit-back loop avoidance).
       - name: Report plugin manifest drift
         run: |
-          MANIFEST_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
           DEV_VERSION="${{ steps.version.outputs.version }}"
           {
-            echo "## Plugin manifest version"
+            echo "## Plugin manifest versions"
             echo ""
-            echo "- Manifest (.claude-plugin/plugin.json): \`${MANIFEST_VERSION}\`"
             echo "- Computed dev version: \`${DEV_VERSION}\`"
-            if [[ "$MANIFEST_VERSION" != "$DEV_VERSION" ]]; then
-              echo ""
-              echo "Manifest reflects the last tagged release; it advances at tag time via the bifrost-release skill."
-            fi
+            for manifest in \
+              .claude-plugin/plugin.json \
+              .codex-plugin/plugin.json \
+              plugins/bifrost/.codex-plugin/plugin.json; do
+              manifest_version=$(jq -r '.version' "$manifest")
+              echo "- Manifest (${manifest}): \`${manifest_version}\`"
+            done
+            echo ""
+            echo "Manifests reflect the last tagged release; they advance at tag time via the bifrost-release skill."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Docker Buildx
@@ -448,18 +451,27 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      # Hard guard: the plugin manifest version must match the tag, otherwise
-      # Claude Code's plugin marketplace will keep serving stale skill content
-      # to users who installed via this repo. The bifrost-release skill runs
-      # `scripts/update-plugin-version.sh <version>` locally before tagging,
-      # so when this fails the maintainer either forgot the skill step or the
-      # bump commit didn't make it onto the tagged ref.
+      # Hard guard: plugin manifest versions must match the tag, otherwise
+      # Claude Code and Codex plugin marketplaces can keep serving stale skill
+      # content to users who installed via this repo. The bifrost-release skill
+      # runs `scripts/update-plugin-version.sh <version>` locally before
+      # tagging, so when this fails the maintainer either forgot the skill step
+      # or the bump commit didn't make it onto the tagged ref.
       - name: Verify plugin manifest matches tag
         run: |
-          MANIFEST_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
           TAG_VERSION="${{ steps.version.outputs.version }}"
-          if [[ "$MANIFEST_VERSION" != "$TAG_VERSION" ]]; then
-            echo "::error::.claude-plugin/plugin.json version ($MANIFEST_VERSION) does not match tag ($TAG_VERSION)."
+          failed=0
+          for manifest in \
+            .claude-plugin/plugin.json \
+            .codex-plugin/plugin.json \
+            plugins/bifrost/.codex-plugin/plugin.json; do
+            manifest_version=$(jq -r '.version' "$manifest")
+            if [[ "$manifest_version" != "$TAG_VERSION" ]]; then
+              echo "::error::${manifest} version (${manifest_version}) does not match tag (${TAG_VERSION})."
+              failed=1
+            fi
+          done
+          if [[ "$failed" -ne 0 ]]; then
             echo "::error::Run 'scripts/update-plugin-version.sh $TAG_VERSION' on main, commit, then re-tag."
             exit 1
           fi

--- a/scripts/update-plugin-version.sh
+++ b/scripts/update-plugin-version.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-# Update `.claude-plugin/plugin.json`'s `version` field in place.
+# Update all Bifrost plugin manifest `version` fields in place.
 #
 # Usage: scripts/update-plugin-version.sh <version>
 #
-# Claude Code's plugin marketplace only fetches plugin updates when the
-# manifest's `version` field changes. Wire this to the dev version
-# (`scripts/compute-dev-version.sh`) at release time so users on the plugin
-# actually get our latest skill content.
+# Claude Code and Codex plugin marketplaces key installed content by manifest
+# version. Wire this to the release version at tag time so users on the
+# installed plugin actually get our latest skill content.
 #
-# Idempotent — if the file already matches, this is a no-op.
+# Idempotent — if a manifest already matches, that file is a no-op.
 # Requires: jq (standard in GitHub Actions runners and most dev environments).
 set -euo pipefail
 
@@ -19,31 +18,38 @@ fi
 
 version="$1"
 
-# Resolve the manifest path relative to the repo root (this script lives in
+# Resolve manifest paths relative to the repo root (this script lives in
 # scripts/, so go one directory up).
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-manifest="${script_dir}/../.claude-plugin/plugin.json"
+repo_root="${script_dir}/.."
+manifests=(
+  "${repo_root}/.claude-plugin/plugin.json"
+  "${repo_root}/.codex-plugin/plugin.json"
+  "${repo_root}/plugins/bifrost/.codex-plugin/plugin.json"
+)
 
-if [[ ! -f "$manifest" ]]; then
-  echo "update-plugin-version: manifest not found at $manifest" >&2
-  exit 1
-fi
+for manifest in "${manifests[@]}"; do
+  if [[ ! -f "$manifest" ]]; then
+    echo "update-plugin-version: manifest not found at $manifest" >&2
+    exit 1
+  fi
+done
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "update-plugin-version: jq is required but not installed" >&2
   exit 1
 fi
 
-current=$(jq -r '.version' "$manifest")
-if [[ "$current" == "$version" ]]; then
-  echo "update-plugin-version: already at $version, no change"
-  exit 0
-fi
+for manifest in "${manifests[@]}"; do
+  current=$(jq -r '.version' "$manifest")
+  if [[ "$current" == "$version" ]]; then
+    echo "update-plugin-version: ${manifest#"$repo_root"/} already at $version"
+    continue
+  fi
 
-tmp=$(mktemp)
-trap 'rm -f "$tmp"' EXIT
-jq --arg v "$version" '.version = $v' "$manifest" > "$tmp"
-mv "$tmp" "$manifest"
-trap - EXIT
+  tmp=$(mktemp)
+  jq --arg v "$version" '.version = $v' "$manifest" > "$tmp"
+  mv "$tmp" "$manifest"
 
-echo "update-plugin-version: $current -> $version"
+  echo "update-plugin-version: ${manifest#"$repo_root"/}: $current -> $version"
+done


### PR DESCRIPTION
## Summary
- update scripts/update-plugin-version.sh to bump Claude and Codex plugin manifests together
- update the release skill instructions to stage all plugin manifests
- update CI release-tag guard and drift summary to cover all plugin manifests

## Tests
- ./scripts/update-plugin-version.sh 0.9.2-dev.5
- bash -n scripts/update-plugin-version.sh
- git diff --check