### PR TITLE
Fix provider-org integration mapping listing

### DIFF
--- a/api/bifrost/_execution_context.py
+++ b/api/bifrost/_execution_context.py
@@ -163,7 +163,7 @@ class ExecutionContext:
     def set_scope(self, org_id: str | None) -> None:
         """Override the effective scope for all subsequent SDK calls.
 
-        C2 rule (matches ``resolve_scope`` and ``_get_cli_org_id``):
+        C2 rule (matches ``resolve_scope`` and ``_resolve_sdk_org_id``):
         platform admins (``is_platform_admin``) AND provider-org members
         (``organization.is_provider``) can both override to another org.
         Pass None to reset to the original scope.

--- a/api/bifrost/integrations.py
+++ b/api/bifrost/integrations.py
@@ -133,9 +133,10 @@ class integrations:
         Args:
             name: Integration name
             scope: Organization scope to list. Defaults to the execution
-                context's default scope. Pass ``"global"`` (only valid for
+                context's default scope. When that resolves to a provider org,
+                all mappings are returned. Pass ``"global"`` (only valid for
                 bypass callers — platform admin or provider-org member) to
-                list across all orgs.
+                list across all orgs explicitly.
 
         Returns:
             list[IntegrationMappingResponse] | None: List of mappings.

--- a/api/src/models/contracts/cli.py
+++ b/api/src/models/contracts/cli.py
@@ -268,8 +268,10 @@ class SDKIntegrationsListMappingsRequest(BaseModel):
         default=None,
         description=(
             "Optional org scope. Omit / pass null to list only the caller's "
-            "own org mapping. Platform admins and provider-org members may "
-            "pass 'global' (no filter, all orgs) or a specific org UUID."
+            "own org mapping, unless the resolved org is a provider org, "
+            "which lists all mappings. Platform admins and provider-org "
+            "members may pass 'global' (no filter, all orgs) or a specific "
+            "org UUID."
         ),
     )
 
@@ -495,4 +497,3 @@ class SDKTableInfo(BaseModel):
     updated_at: str = Field(..., description="Last update timestamp (ISO format)")
 
     model_config = ConfigDict(from_attributes=True)
-

--- a/api/src/repositories/README.md
+++ b/api/src/repositories/README.md
@@ -117,7 +117,7 @@ flags from an auth-verified principal:
 
 | Call site                                       | Caller principal source                                   |
 | ----------------------------------------------- | --------------------------------------------------------- |
-| `_get_cli_org_id` (API-side, `/api/sdk/*`)      | `current_user` from JWT (auth-verified)                   |
+| `_resolve_sdk_org_id` (API-side, `/api/sdk/*`)  | `current_user` from JWT (auth-verified)                   |
 | `resolve_scope()` (SDK-side, in workflow proc)  | `ExecutionContext` populated by engine from request       |
 | `ExecutionContext.set_scope()` (ambient)        | Same `ExecutionContext` instance                          |
 | REST routers using the resolver directly        | `current_user` from JWT                                   |
@@ -235,13 +235,13 @@ exclusive to it.
    triggers because the principal is `is_superuser=True`. The SDK-side
    resolver is the security boundary for this caller.
 2. **The user's local CLI** (`bifrost ...`), authenticated as that user
-   directly. The API-side `_get_cli_org_id` gate fires against the real
+   directly. The API-side `_resolve_sdk_org_id` gate fires against the real
    principal — same `is_platform_admin OR is_provider_org` rule the
    resolver enforces everywhere. The C2 e2e tests
    (`test_org_scoping_scenarios.py`) cover this path explicitly.
 
 The handlers do not differentiate the two callers — every scope-taking
-handler routes through `_get_cli_org_id` (the mechanical lint test
+handler routes through `_resolve_sdk_org_id` (the mechanical lint test
 asserts this). What differs is which gate ultimately catches an
 unauthorized request: SDK-side for engine traffic, API-side for direct
 CLI traffic.
@@ -424,7 +424,7 @@ If it doesn't fit, use the pattern.
   the repository. The lint test catches this on PR.
 - **Trusting `requested_scope` directly.** Passing whatever the request
   body contained as `org_id` to the repository without going through
-  `resolve_effective_scope`. This was the `_get_cli_org_id` bug class.
+  `resolve_effective_scope`. This was the `_resolve_sdk_org_id` bug class.
 - **Using `BaseRepository` for org-scoped entities.** Always use
   `OrgScopedRepository`. The lint test catches missing repositories on
   models with `organization_id`.

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -310,7 +310,7 @@ async def get_dev_context(
 # =============================================================================
 
 
-async def _get_cli_org_id(
+async def _resolve_sdk_org_id(
     current_user: "UserPrincipal",
     scope: str | None,
     db: AsyncSession,
@@ -409,7 +409,7 @@ async def cli_get_config(
     """Get a config value via CLI API."""
     from src.routers.config import ConfigRepository
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     # Canonical SDK config load: cascade (global + org-specific) merged.
@@ -465,7 +465,7 @@ async def cli_set_config(
     from src.models import Config as ConfigModel
     from src.models.enums import ConfigType as ConfigTypeEnum
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
     now = datetime.now(timezone.utc)
 
@@ -537,7 +537,7 @@ async def cli_list_config(
     """List all config values via CLI API."""
     from src.routers.config import ConfigRepository
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     repo = ConfigRepository(db, org_id=org_uuid, is_superuser=True)
@@ -583,7 +583,7 @@ async def cli_delete_config(
     """Delete a config value via CLI API."""
     from src.models import Config as ConfigModel
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     stmt = select(ConfigModel).where(
@@ -638,7 +638,7 @@ async def sdk_integrations_get(
     from src.services.oauth_provider import resolve_url_template
     from src.core.security import decrypt_secret
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     try:
@@ -723,7 +723,7 @@ async def sdk_integrations_get(
         return SDKIntegrationsGetResponse(**response_data)
 
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"SDK integrations.get failed: {log_safe(e)}")
@@ -870,7 +870,9 @@ async def sdk_integrations_list_mappings(
         # platform-admin or provider-org bypass. UNSET (None / "") falls
         # back to the caller's own org. ``scope="global"`` returns None
         # from the resolver — list all mappings (bypass already enforced).
-        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
+        # A resolved provider org is also an enumerate-all scope for mapping
+        # listing: providers need to see every customer mapping by default.
+        resolved_org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         if resolved_org_id is None and request.scope in (None, ""):
             # Caller has no org — system account on UNSET. Return empty.
             mappings = []
@@ -878,9 +880,16 @@ async def sdk_integrations_list_mappings(
             # Bypass verified by the resolver — request was "global".
             mappings = await repo.list_mappings(integration.id)
         else:
-            mappings = await repo.list_mappings(
-                integration.id, organization_id=UUID(resolved_org_id)
+            resolved_org_uuid = UUID(resolved_org_id)
+            org_row = await db.execute(
+                select(Organization.is_provider).where(Organization.id == resolved_org_uuid)
             )
+            if bool(org_row.scalar_one_or_none()):
+                mappings = await repo.list_mappings(integration.id)
+            else:
+                mappings = await repo.list_mappings(
+                    integration.id, organization_id=resolved_org_uuid
+                )
 
         logger.info(f"SDK listed {len(mappings)} mappings for integration '{log_safe(request.name)}' for user {current_user.email}")
 
@@ -903,7 +912,7 @@ async def sdk_integrations_list_mappings(
         return SDKIntegrationsListMappingsResponse(items=items)
 
     except HTTPException:
-        # Authorization failures (e.g. 403 from _get_cli_org_id) must
+        # Authorization failures (e.g. 403 from _resolve_sdk_org_id) must
         # surface to the client. The blanket ``except Exception`` below
         # would otherwise downgrade a 403 to a 200/null response and
         # make unauthorized requests indistinguishable from misses.
@@ -936,7 +945,7 @@ async def sdk_integrations_get_mapping(
 
         # Apply the C2 gate. Non-bypass callers can only target their own
         # org; cross-org or "global" requires platform-admin / provider-org.
-        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
+        resolved_org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         mapping = None
 
         # Direct lookup by org_id.
@@ -980,7 +989,7 @@ async def sdk_integrations_get_mapping(
         )
 
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"SDK integrations.get_mapping failed: {log_safe(e)}")
@@ -1012,7 +1021,7 @@ async def sdk_integrations_upsert_mapping(
             )
 
         # Apply the C2 gate before touching another org's mapping row.
-        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
+        resolved_org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         if resolved_org_id is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1104,7 +1113,7 @@ async def sdk_integrations_delete_mapping(
             return {"deleted": False}
 
         # Apply the C2 gate before touching another org's mapping row.
-        resolved_org_id = await _get_cli_org_id(current_user, request.scope, db)
+        resolved_org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         if resolved_org_id is None:
             return {"deleted": False}
         org_uuid = UUID(resolved_org_id)
@@ -1125,7 +1134,7 @@ async def sdk_integrations_delete_mapping(
         return {"deleted": deleted}
 
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"SDK integrations.delete_mapping failed: {log_safe(e)}")
@@ -1164,7 +1173,7 @@ async def sdk_integrations_refresh_token(
         refresh_oauth_token_http,
     )
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     try:
@@ -1918,7 +1927,7 @@ async def cli_ai_complete(
             from src.core.cache import get_shared_redis
 
             redis_client = await get_shared_redis()
-            org_id = await _get_cli_org_id(current_user, request.org_id, db)
+            org_id = await _resolve_sdk_org_id(current_user, request.org_id, db)
             await record_ai_usage(
                 session=db,
                 redis_client=redis_client,
@@ -1978,7 +1987,7 @@ async def cli_ai_stream(
     # the authenticated user so the streaming closure doesn't have to
     # re-derive bypass after CurrentUser falls out of scope.
     user_id = current_user.user_id
-    resolved_org_id = await _get_cli_org_id(current_user, request.org_id, db)
+    resolved_org_id = await _resolve_sdk_org_id(current_user, request.org_id, db)
     execution_id_str = request.execution_id
 
     async def generate():
@@ -2096,7 +2105,7 @@ async def cli_knowledge_store(
     from src.services.embeddings import get_embedding_client
 
     try:
-        org_id = await _get_cli_org_id(current_user, request.scope, db)
+        org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         embedding_client = await get_embedding_client(db)
@@ -2124,7 +2133,7 @@ async def cli_knowledge_store(
             detail=str(e),
         )
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"CLI knowledge store failed: {log_safe(e)}")
@@ -2148,7 +2157,7 @@ async def cli_knowledge_store_many(
     from src.services.embeddings import get_embedding_client
 
     try:
-        org_id = await _get_cli_org_id(current_user, request.scope, db)
+        org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         embedding_client = await get_embedding_client(db)
@@ -2179,7 +2188,7 @@ async def cli_knowledge_store_many(
             detail=str(e),
         )
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"CLI knowledge store-many failed: {log_safe(e)}")
@@ -2204,7 +2213,7 @@ async def cli_knowledge_search(
     from src.services.embeddings import get_embedding_client
 
     try:
-        org_id = await _get_cli_org_id(current_user, request.scope, db)
+        org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         # Generate query embedding
@@ -2243,7 +2252,7 @@ async def cli_knowledge_search(
             detail=str(e),
         )
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"CLI knowledge search failed: {log_safe(e)}")
@@ -2266,7 +2275,7 @@ async def cli_knowledge_delete(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user, request.scope, db)
+        org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2281,7 +2290,7 @@ async def cli_knowledge_delete(
 
         return {"deleted": deleted}
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"CLI knowledge delete failed: {log_safe(e)}")
@@ -2305,7 +2314,7 @@ async def cli_knowledge_delete_namespace(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user, scope, db)
+        org_id = await _resolve_sdk_org_id(current_user, scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2319,7 +2328,7 @@ async def cli_knowledge_delete_namespace(
 
         return {"deleted_count": deleted_count}
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"CLI knowledge delete namespace failed: {log_safe(e)}")
@@ -2344,7 +2353,7 @@ async def cli_knowledge_list_namespaces(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user, scope, db)
+        org_id = await _resolve_sdk_org_id(current_user, scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2360,7 +2369,7 @@ async def cli_knowledge_list_namespaces(
             for ns in results
         ]
     except HTTPException:
-        # Auth/scope failures (e.g. 403 from _get_cli_org_id) must surface.
+        # Auth/scope failures (e.g. 403 from _resolve_sdk_org_id) must surface.
         raise
     except Exception as e:
         logger.error(f"CLI knowledge list namespaces failed: {log_safe(e)}")
@@ -2386,7 +2395,7 @@ async def cli_knowledge_get(
     from src.repositories.knowledge import KnowledgeRepository
 
     try:
-        org_id = await _get_cli_org_id(current_user, scope, db)
+        org_id = await _resolve_sdk_org_id(current_user, scope, db)
         org_uuid = UUID(org_id) if org_id else None
 
         repo = KnowledgeRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2582,7 +2591,7 @@ async def cli_create_table(
     """Create a new table via SDK."""
     from src.models.orm.tables import Table
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     # Exact-scope uniqueness check (not a cascade): "is there already a
@@ -2649,7 +2658,7 @@ async def cli_list_tables(
     # Local import keeps the router file's top-level imports lean.
     from src.routers.tables import TableRepository
 
-    org_id = await _get_cli_org_id(current_user, request.scope, db)
+    org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None
 
     repo = TableRepository(db, org_id=org_uuid, is_superuser=True)
@@ -2668,4 +2677,3 @@ async def cli_list_tables(
         )
         for t in tables
     ]
-

--- a/api/tests/e2e/api/test_org_scoping_scenarios.py
+++ b/api/tests/e2e/api/test_org_scoping_scenarios.py
@@ -165,7 +165,7 @@ class TestScenario2b_ProviderOrgBypass:
     """A non-superuser in the provider org bypasses scope restrictions.
 
     Pre-overhaul this case would have failed in two ways:
-    (a) The pre-overhaul ``_get_cli_org_id`` accepted any UUID without
+    (a) The pre-overhaul ``_resolve_sdk_org_id`` accepted any UUID without
         a gate, so even regular users could traverse — not a "test passes
         for the right reason" outcome.
     (b) Post-overhaul fix had to grant the provider-org membership path.
@@ -211,6 +211,67 @@ class TestScenario2b_ProviderOrgBypass:
         )
         assert r.json() is not None
 
+    def test_provider_member_unset_list_mappings_returns_all_orgs(
+        self, e2e_client, platform_admin, provider_org_user, org1, org1_user, org2
+    ):
+        integration_name = f"prov_list_mappings_{uuid4().hex[:8]}"
+        integration_resp = e2e_client.post(
+            "/api/integrations",
+            headers=platform_admin.headers,
+            json={
+                "name": integration_name,
+                "config_schema": [
+                    {"key": "endpoint", "type": "string", "required": True, "description": ""}
+                ],
+            },
+        )
+        assert integration_resp.status_code == 201, integration_resp.text
+        integration = integration_resp.json()
+
+        try:
+            for org_id, entity_id in (
+                (str(PROVIDER_ORG_ID), "provider-tenant"),
+                (org1["id"], "org1-tenant"),
+                (org2["id"], "org2-tenant"),
+            ):
+                mapping_resp = e2e_client.post(
+                    f"/api/integrations/{integration['id']}/mappings",
+                    headers=platform_admin.headers,
+                    json={
+                        "organization_id": org_id,
+                        "entity_id": entity_id,
+                        "entity_name": entity_id,
+                    },
+                )
+                assert mapping_resp.status_code == 201, mapping_resp.text
+
+            provider_resp = e2e_client.post(
+                "/api/sdk/integrations/list_mappings",
+                headers=provider_org_user.headers,
+                json={"name": integration_name},
+            )
+            assert provider_resp.status_code == 200, provider_resp.text
+            provider_items = provider_resp.json()["items"]
+            assert {item["entity_id"] for item in provider_items} == {
+                "provider-tenant",
+                "org1-tenant",
+                "org2-tenant",
+            }
+
+            org1_resp = e2e_client.post(
+                "/api/sdk/integrations/list_mappings",
+                headers=org1_user.headers,
+                json={"name": integration_name},
+            )
+            assert org1_resp.status_code == 200, org1_resp.text
+            org1_items = org1_resp.json()["items"]
+            assert [item["entity_id"] for item in org1_items] == ["org1-tenant"]
+        finally:
+            e2e_client.delete(
+                f"/api/integrations/{integration['id']}",
+                headers=platform_admin.headers,
+            )
+
     def test_provider_member_cross_org_read_through_engine(
         self, e2e_client, platform_admin, provider_org_user, org1
     ):
@@ -218,7 +279,7 @@ class TestScenario2b_ProviderOrgBypass:
 
         This is the path the two tests above do NOT cover. They hit
         ``/api/sdk/config/get`` directly, where the API authenticates the
-        *user* and the API-side ``_get_cli_org_id`` resolves scope.
+        *user* and the API-side ``_resolve_sdk_org_id`` resolves scope.
 
         Under real workflow execution the path is different and is the one
         that actually matters for the C2 bypass:
@@ -663,7 +724,7 @@ class TestScenario4_CrossOrgBlocked:
         org's integration mapping via the SDK endpoints.
 
         Seeds a REAL integration with a REAL org2 mapping so the
-        handler's _get_cli_org_id call actually fires — the previous
+        handler's _resolve_sdk_org_id call actually fires — the previous
         version of this test used a nonexistent integration name and
         returned before the gate ran, which Codex correctly flagged as
         too weak to catch a swallowed-403 regression.

--- a/api/tests/unit/routers/test_cli_config_secret.py
+++ b/api/tests/unit/routers/test_cli_config_secret.py
@@ -29,7 +29,7 @@ class TestConfigGetDecryptsSecrets:
 
         request = CLIConfigGetRequest(key="test_secret")
 
-        with patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
+        with patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
              patch("src.routers.config.ConfigRepository", return_value=mock_resolver):
             result = await cli_get_config(request=request, current_user=mock_user, db=AsyncMock())
 
@@ -55,7 +55,7 @@ class TestConfigGetDecryptsSecrets:
 
         request = CLIConfigGetRequest(key="bad_secret")
 
-        with patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
+        with patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
              patch("src.routers.config.ConfigRepository", return_value=mock_resolver):
             result = await cli_get_config(request=request, current_user=mock_user, db=AsyncMock())
 
@@ -80,7 +80,7 @@ class TestConfigGetDecryptsSecrets:
 
         request = CLIConfigGetRequest(key="normal_key")
 
-        with patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
+        with patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
              patch("src.routers.config.ConfigRepository", return_value=mock_resolver):
             result = await cli_get_config(request=request, current_user=mock_user, db=AsyncMock())
 
@@ -112,7 +112,7 @@ class TestConfigListMasksSecrets:
 
         request = CLIConfigListRequest()
 
-        with patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
+        with patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
              patch("src.routers.config.ConfigRepository", return_value=mock_resolver):
             result = await cli_list_config(request=request, current_user=mock_user, db=AsyncMock())
 
@@ -139,7 +139,7 @@ class TestConfigListMasksSecrets:
 
         request = CLIConfigListRequest()
 
-        with patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
+        with patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value="11111111-1111-1111-1111-111111111111"), \
              patch("src.routers.config.ConfigRepository", return_value=mock_resolver):
             result = await cli_list_config(request=request, current_user=mock_user, db=AsyncMock())
 

--- a/api/tests/unit/routers/test_cli_get_org_id.py
+++ b/api/tests/unit/routers/test_cli_get_org_id.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``_get_cli_org_id`` scope validation and authorization.
+"""Unit tests for ``_resolve_sdk_org_id`` scope validation and authorization.
 
 The 2026-05 org-scoping overhaul replaced the pre-existing forgery surface
 (``DeveloperContext.default_org_id``, settable by any authenticated user
@@ -26,7 +26,7 @@ import pytest
 from fastapi import HTTPException
 
 from src.core.auth import UserPrincipal
-from src.routers.cli import _get_cli_org_id
+from src.routers.cli import _resolve_sdk_org_id
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +71,7 @@ def _db_no_lookup():
 async def test_platform_admin_global_returns_none():
     user = _user(org_id=uuid4(), is_superuser=True)
     db = _db_with_provider(False)
-    assert await _get_cli_org_id(user, "global", db) is None
+    assert await _resolve_sdk_org_id(user, "global", db) is None
 
 
 @pytest.mark.asyncio
@@ -79,7 +79,7 @@ async def test_platform_admin_can_target_any_org():
     user = _user(org_id=uuid4(), is_superuser=True)
     target = str(uuid4())
     db = _db_with_provider(False)
-    assert await _get_cli_org_id(user, target, db) == target
+    assert await _resolve_sdk_org_id(user, target, db) == target
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +93,7 @@ async def test_provider_org_member_can_request_global():
     """A regular user in a provider org gets the bypass even without is_superuser."""
     user = _user(org_id=uuid4(), is_superuser=False)
     db = _db_with_provider(True)
-    assert await _get_cli_org_id(user, "global", db) is None
+    assert await _resolve_sdk_org_id(user, "global", db) is None
 
 
 @pytest.mark.asyncio
@@ -101,7 +101,7 @@ async def test_provider_org_member_can_target_other_org():
     user = _user(org_id=uuid4(), is_superuser=False)
     other = str(uuid4())
     db = _db_with_provider(True)
-    assert await _get_cli_org_id(user, other, db) == other
+    assert await _resolve_sdk_org_id(user, other, db) == other
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +115,7 @@ async def test_non_admin_non_provider_cannot_request_global():
     user = _user(org_id=uuid4(), is_superuser=False)
     db = _db_with_provider(False)
     with pytest.raises(HTTPException) as exc:
-        await _get_cli_org_id(user, "global", db)
+        await _resolve_sdk_org_id(user, "global", db)
     assert exc.value.status_code == 403
 
 
@@ -125,7 +125,7 @@ async def test_non_admin_non_provider_cannot_target_other_org():
     other = str(uuid4())
     db = _db_with_provider(False)
     with pytest.raises(HTTPException) as exc:
-        await _get_cli_org_id(user, other, db)
+        await _resolve_sdk_org_id(user, other, db)
     assert exc.value.status_code == 403
 
 
@@ -139,7 +139,7 @@ async def test_non_admin_can_target_own_org():
     own_org = uuid4()
     user = _user(org_id=own_org, is_superuser=False)
     db = _db_no_lookup()
-    assert await _get_cli_org_id(user, str(own_org), db) == str(own_org)
+    assert await _resolve_sdk_org_id(user, str(own_org), db) == str(own_org)
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +157,7 @@ async def test_unset_scope_uses_current_user_org():
     own_org = uuid4()
     user = _user(org_id=own_org, is_superuser=False)
     db = _db_no_lookup()
-    assert await _get_cli_org_id(user, None, db) == str(own_org)
+    assert await _resolve_sdk_org_id(user, None, db) == str(own_org)
 
 
 @pytest.mark.asyncio
@@ -165,7 +165,7 @@ async def test_unset_scope_with_no_org_returns_none():
     """A user with no organization_id (e.g. system account) on UNSET → None."""
     user = _user(org_id=None, is_superuser=True)
     db = _db_no_lookup()
-    assert await _get_cli_org_id(user, None, db) is None
+    assert await _resolve_sdk_org_id(user, None, db) is None
 
 
 @pytest.mark.asyncio
@@ -174,7 +174,7 @@ async def test_empty_string_treated_as_unset():
     own_org = uuid4()
     user = _user(org_id=own_org, is_superuser=False)
     db = _db_no_lookup()
-    assert await _get_cli_org_id(user, "", db) == str(own_org)
+    assert await _resolve_sdk_org_id(user, "", db) == str(own_org)
 
 
 # ---------------------------------------------------------------------------
@@ -187,7 +187,7 @@ async def test_garbage_scope_raises_422():
     user = _user(org_id=uuid4(), is_superuser=False)
     db = _db_no_lookup()
     with pytest.raises(HTTPException) as exc:
-        await _get_cli_org_id(user, "not-a-uuid", db)
+        await _resolve_sdk_org_id(user, "not-a-uuid", db)
     assert exc.value.status_code == 422
 
 
@@ -196,5 +196,5 @@ async def test_uppercase_uuid_accepted_for_admin():
     user = _user(org_id=uuid4(), is_superuser=True)
     upper = str(uuid4()).upper()
     db = _db_with_provider(False)
-    result = await _get_cli_org_id(user, upper, db)
+    result = await _resolve_sdk_org_id(user, upper, db)
     assert UUID(result) == UUID(upper)

--- a/api/tests/unit/routers/test_cli_refresh_token.py
+++ b/api/tests/unit/routers/test_cli_refresh_token.py
@@ -79,7 +79,7 @@ class TestRefreshTokenClientCredentials:
         }
 
         with (
-            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=None),
+            patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value=None),
             patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
             patch("src.services.oauth_provider.decrypt_secret", return_value="decrypted-secret"),
             patch("src.services.oauth_provider.encrypt_secret", return_value="encrypted-new-token"),
@@ -149,7 +149,7 @@ class TestRefreshTokenClientCredentials:
         }
 
         with (
-            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=None),
+            patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value=None),
             patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
             patch("src.services.oauth_provider.decrypt_secret", return_value="decrypted-secret"),
             patch("src.services.oauth_provider.encrypt_secret", return_value="encrypted-new-token"),
@@ -224,7 +224,7 @@ class TestRefreshTokenAuthorizationCode:
         }
 
         with (
-            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=None),
+            patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value=None),
             patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
             patch("src.services.oauth_provider.decrypt_secret", return_value="decrypted-value"),
             patch("src.services.oauth_provider.encrypt_secret", return_value="encrypted-new-value"),
@@ -295,7 +295,7 @@ class TestRefreshTokenAuthorizationCode:
         }
 
         with (
-            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=None),
+            patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value=None),
             patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
             patch("src.services.oauth_provider.decrypt_secret", return_value="decrypted-value"),
             patch("src.services.oauth_provider.encrypt_secret", return_value="encrypted-new-value"),
@@ -355,7 +355,7 @@ class TestRefreshTokenAuthorizationCode:
         ])
 
         with (
-            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=None),
+            patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value=None),
             pytest.raises(HTTPException) as exc_info,
         ):
             await sdk_integrations_refresh_token(request, mock_user, mock_db)
@@ -386,7 +386,7 @@ class TestRefreshTokenErrorHandling:
         mock_db.execute = AsyncMock(return_value=provider_result)
 
         with (
-            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=None),
+            patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value=None),
             pytest.raises(HTTPException) as exc_info,
         ):
             await sdk_integrations_refresh_token(request, mock_user, mock_db)
@@ -424,7 +424,7 @@ class TestRefreshTokenErrorHandling:
         mock_db.execute = AsyncMock(return_value=provider_result)
 
         with (
-            patch("src.routers.cli._get_cli_org_id", new_callable=AsyncMock, return_value=None),
+            patch("src.routers.cli._resolve_sdk_org_id", new_callable=AsyncMock, return_value=None),
             patch("src.services.oauth_provider.OAuthProviderClient") as mock_client_class,
             patch("src.services.oauth_provider.decrypt_secret", return_value="decrypted-secret"),
             pytest.raises(HTTPException) as exc_info,

--- a/api/tests/unit/test_org_scoping_enforcement.py
+++ b/api/tests/unit/test_org_scoping_enforcement.py
@@ -404,14 +404,14 @@ SDK_ROUTER_FILES = {
 
 
 # Handlers under /api/sdk/* that are exempt from the
-# "must call _get_cli_org_id or resolve_effective_scope" rule. Keyed on
+# "must call _resolve_sdk_org_id or resolve_effective_scope" rule. Keyed on
 # handler function name (qualname is fine too but FastAPI handlers are
 # module-level so the simple name is unambiguous). The key TRAVELS with
 # the function across URL renames; the path-based version would have
 # missed the same drift the resolver test was meant to catch.
 EXEMPT_SDK_HANDLERS: dict[str, str] = {
     # As of 2026-05-26 every scope-taking SDK handler in cli.py routes
-    # through _get_cli_org_id. This list is left in place so that future
+    # through _resolve_sdk_org_id. This list is left in place so that future
     # exempt handlers can be added with an explicit justification — adding
     # an entry without a one-line reason is itself a CI failure
     # (test_exempt_list_well_formed).
@@ -419,8 +419,8 @@ EXEMPT_SDK_HANDLERS: dict[str, str] = {
 
 
 # Names that count as "calling the resolver" — direct call to
-# resolve_effective_scope, or call to the thin _get_cli_org_id wrapper.
-RESOLVER_CALL_NAMES = {"resolve_effective_scope", "_get_cli_org_id"}
+# resolve_effective_scope, or call to the thin _resolve_sdk_org_id wrapper.
+RESOLVER_CALL_NAMES = {"resolve_effective_scope", "_resolve_sdk_org_id"}
 
 
 def _handler_names_taking_scope(tree: ast.AST) -> dict[str, ast.AsyncFunctionDef | ast.FunctionDef]:
@@ -554,7 +554,7 @@ def _handler_calls_resolver(node: ast.AsyncFunctionDef | ast.FunctionDef) -> boo
 class TestSDKEndpointsUseResolver:
     """Every SDK handler that takes a ``scope`` (either as a direct
     parameter or via the ``request.scope`` pattern that is standard in
-    cli.py) must call ``_get_cli_org_id`` or ``resolve_effective_scope``.
+    cli.py) must call ``_resolve_sdk_org_id`` or ``resolve_effective_scope``.
 
     The original placeholder (pre-2026-05-26 audit) only verified the
     exempt list was well-formed and the resolver module imported. That
@@ -591,7 +591,7 @@ class TestSDKEndpointsUseResolver:
         @router-decorated handler that accepts a scope (direct parameter,
         ``request.scope`` body access, OR a Pydantic body annotation whose
         model declares a ``scope`` field). If it does, the handler body
-        must call ``_get_cli_org_id`` or ``resolve_effective_scope``
+        must call ``_resolve_sdk_org_id`` or ``resolve_effective_scope``
         unless it's on the exempt list.
 
         The Pydantic-annotation tripwire (added post-Codex 2026-05-26) is
@@ -618,7 +618,7 @@ class TestSDKEndpointsUseResolver:
                 if not _handler_calls_resolver(node):
                     violations.append(
                         f"{path.name}::{name} accepts `scope` but does not call "
-                        f"_get_cli_org_id or resolve_effective_scope; "
+                        f"_resolve_sdk_org_id or resolve_effective_scope; "
                         f"add it to EXEMPT_SDK_HANDLERS with a one-line reason "
                         f"if exemption is justified."
                     )

--- a/api/tests/unit/test_resolve_scope_sdk.py
+++ b/api/tests/unit/test_resolve_scope_sdk.py
@@ -4,7 +4,7 @@ The SDK runs inside the workflow process and resolves scope locally before
 making API calls. This is the *engine-side* security boundary — the API
 trusts the resolved scope because the engine authenticates as the sentinel
 superuser identity. So whatever rule applies here must match the API-side
-``_get_cli_org_id`` rule exactly:
+``_resolve_sdk_org_id`` rule exactly:
 
     bypass = is_platform_admin OR ctx.organization.is_provider
 

--- a/api/tests/unit/test_scope_resolver.py
+++ b/api/tests/unit/test_scope_resolver.py
@@ -165,9 +165,9 @@ class TestCrossTenantRequiresPlatformAdmin:
 # ---------------------------------------------------------------------------
 # UNSET vs explicit None must NOT be collapsed.
 #
-# This is the bug class that today's `_get_cli_org_id` exhibits: it treats
-# "didn't pass scope" and "passed scope=null" the same way. The resolver
-# must distinguish them because they have different security semantics.
+# This is the bug class this resolver exists to prevent: adapters must not
+# treat "didn't pass scope" and "passed scope=null" the same way, because they
+# have different security semantics.
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- treat provider-org default scope as an enumerate-all scope for integrations.list_mappings
- rename the lingering SDK scope adapter from _get_cli_org_id to _resolve_sdk_org_id
- add e2e coverage for provider default list_mappings vs regular org default list_mappings

## Tests
- ./test.sh tests/e2e/api/test_org_scoping_scenarios.py::TestScenario2b_ProviderOrgBypass::test_provider_member_unset_list_mappings_returns_all_orgs -v
- ./test.sh tests/e2e/api/test_org_scoping_scenarios.py::TestScenario2b_ProviderOrgBypass::test_provider_member_unset_list_mappings_returns_all_orgs tests/unit/test_resolve_scope_sdk.py tests/unit/routers/test_cli_get_org_id.py tests/unit/test_org_scoping_enforcement.py -v
- ./test.sh tests/unit/routers/test_cli_config_secret.py tests/unit/routers/test_cli_refresh_token.py -v
- ruff check touched files
- pyright touched backend files

No issue.