### PR TITLE
Enforce agent access during chat routing

### DIFF
--- a/api/src/repositories/agents.py
+++ b/api/src/repositories/agents.py
@@ -40,7 +40,11 @@ class AgentRepository(OrgScopedRepository[Agent]):
         from sqlalchemy import or_
         from src.models.enums import AgentAccessLevel
 
-        query = select(self.model).options(selectinload(self.model.tools))
+        query = select(self.model).options(
+            selectinload(self.model.tools),
+            selectinload(self.model.delegated_agents),
+            selectinload(self.model.roles),
+        )
 
         # Build scope filter: cascade (org + global) OR user's own private agents
         cascade_conditions = []
@@ -98,7 +102,11 @@ class AgentRepository(OrgScopedRepository[Agent]):
         Returns:
             List of Agent ORM objects with tools eager-loaded
         """
-        query = select(self.model).options(selectinload(self.model.tools))
+        query = select(self.model).options(
+            selectinload(self.model.tools),
+            selectinload(self.model.delegated_agents),
+            selectinload(self.model.roles),
+        )
 
         # Apply org filtering based on filter type
         if filter_type == OrgFilterType.ALL:

--- a/api/src/routers/chat.py
+++ b/api/src/routers/chat.py
@@ -340,6 +340,12 @@ async def send_message(
             detail=f"Conversation {conversation_id} not found",
         )
 
+    if conversation.agent and not await _check_agent_access(db, user, conversation.agent):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have access to this agent",
+        )
+
     # Agent is now optional - agentless chat uses default system prompt
 
     # Execute chat — executor manages its own short-lived sessions
@@ -359,6 +365,7 @@ async def send_message(
         conversation=conversation,
         user_message=request.message,
         stream=False,
+        user=user,
     ):
         if chunk.type == "delta" and chunk.content:
             final_content += chunk.content

--- a/api/src/routers/websocket.py
+++ b/api/src/routers/websocket.py
@@ -1082,6 +1082,25 @@ async def _process_chat_message(
             })
             return
 
+        if conversation.agent_id:
+            from src.repositories.agents import AgentRepository
+
+            async with session_factory() as db:
+                repo = AgentRepository(
+                    db,
+                    org_id=user.organization_id,
+                    user_id=user.user_id,
+                    is_superuser=user.is_superuser,
+                )
+                accessible_agent = await repo.get_agent_with_access_check(conversation.agent_id)
+            if accessible_agent is None:
+                await websocket.send_json({
+                    "type": "error",
+                    "conversation_id": conversation_id,
+                    "error": "You don't have access to this agent",
+                })
+                return
+
         # Check if conversation needs a title (no title set yet)
         needs_title = conversation.title is None
 
@@ -1099,6 +1118,7 @@ async def _process_chat_message(
                 user_message=message,
                 stream=True,
                 local_id=local_id,
+                user=user,
             ):
                 # Track partial content from deltas
                 if chunk.type == "delta" and chunk.content:

--- a/api/src/services/agent_executor.py
+++ b/api/src/services/agent_executor.py
@@ -25,6 +25,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
 
+from src.core.auth import UserPrincipal
 from src.models.contracts.agents import (
     AgentSwitch,
     ChatStreamChunk,
@@ -35,6 +36,7 @@ from src.models.contracts.agents import (
 )
 from src.models.enums import MessageRole
 from src.models.orm import Agent, Conversation, Message, Workflow
+from src.repositories.agents import AgentRepository
 from src.services.llm import (
     LLMMessage,
     ToolCallRequest,
@@ -116,7 +118,9 @@ class AgentExecutor:
         conversation: Conversation,
         new_agent: Agent,
         reason: str,
-    ) -> AsyncIterator[ChatStreamChunk]:
+        *,
+        user: UserPrincipal | None,
+    ) -> tuple[ChatStreamChunk | None, Agent | None]:
         """
         Centralized agent switching with all rule checks.
 
@@ -127,27 +131,56 @@ class AgentExecutor:
             conversation: The conversation to update
             new_agent: The agent to switch to
             reason: Why the switch happened ("@mention", "routed", etc.)
+            user: Current user whose agent access must authorize the switch
 
-        Yields:
-            - agent_switch event (always)
+        Returns:
+            Tuple of optional agent_switch event and the access-checked agent.
         """
-        # 1. Emit agent switch event
-        yield ChatStreamChunk(
-            type="agent_switch",
-            agent_switch=AgentSwitch(
-                agent_id=str(new_agent.id),
-                agent_name=new_agent.name,
-                reason=reason,
-            ),
-        )
+        if user is None:
+            logger.warning(
+                "Denied agent switch without user context: conversation_id=%s agent_id=%s reason=%s",
+                conversation.id,
+                new_agent.id,
+                reason,
+            )
+            return None, None
 
-        # 2. Persist to conversation
+        # Persist only after reloading the target through the repository access
+        # boundary. This prevents high-level routing or mention logic from
+        # binding a conversation to an otherwise inaccessible agent.
         async with self._db() as session:
+            repo = AgentRepository(
+                session,
+                org_id=user.organization_id,
+                user_id=user.user_id,
+                is_superuser=user.is_superuser,
+            )
+            accessible_agent = await repo.get_agent_with_access_check(new_agent.id)
+            if accessible_agent is None:
+                logger.warning(
+                    "Denied agent switch because user lacks access: user_id=%s conversation_id=%s agent_id=%s reason=%s",
+                    user.user_id,
+                    conversation.id,
+                    new_agent.id,
+                    reason,
+                )
+                return None, None
+
             conv = await session.get(Conversation, conversation.id)
             if conv:
-                conv.agent_id = new_agent.id
+                conv.agent_id = accessible_agent.id
+
         # Update in-memory object too so caller sees the change
-        conversation.agent_id = new_agent.id
+        conversation.agent_id = accessible_agent.id
+
+        return ChatStreamChunk(
+            type="agent_switch",
+            agent_switch=AgentSwitch(
+                agent_id=str(accessible_agent.id),
+                agent_name=accessible_agent.name,
+                reason=reason,
+            ),
+        ), accessible_agent
 
     async def chat(
         self,
@@ -158,6 +191,7 @@ class AgentExecutor:
         stream: bool = True,
         enable_routing: bool = True,
         local_id: str | None = None,
+        user: UserPrincipal | None = None,
     ) -> AsyncIterator[ChatStreamChunk]:
         """
         Process a user message and generate a response.
@@ -171,6 +205,7 @@ class AgentExecutor:
             user_message: The user's message text
             stream: Whether to stream the response (default True)
             enable_routing: Whether to enable @mention and AI routing (default True)
+            user: Current user for permission-aware agent routing
 
         Yields:
             ChatStreamChunk objects with response content, tool calls, etc.
@@ -178,19 +213,30 @@ class AgentExecutor:
         from src.services.agent_router import AgentRouter
 
         start_time = time.time()
-        router = AgentRouter(self._session_factory)
+        router = AgentRouter(
+            self._session_factory,
+            user_id=user.user_id if user else None,
+            org_id=user.organization_id if user else None,
+            is_superuser=user.is_superuser if user else False,
+        )
 
         try:
             # 1. Check for @mention agent switching
             if enable_routing:
                 mentioned_agent = await router.parse_mention(user_message)
                 if mentioned_agent:
-                    # Strip @mention from message for cleaner processing
-                    user_message = router.strip_mention(user_message)
                     # Switch to mentioned agent (handles events and persistence)
-                    async for chunk in self._switch_agent(conversation, mentioned_agent, "@mention"):
-                        yield chunk
-                    agent = mentioned_agent
+                    switch_chunk, switched_agent = await self._switch_agent(
+                        conversation,
+                        mentioned_agent,
+                        "@mention",
+                        user=user,
+                    )
+                    if switch_chunk and switched_agent:
+                        # Strip @mention from message for cleaner processing
+                        user_message = router.strip_mention(user_message)
+                        yield switch_chunk
+                        agent = switched_agent
 
             # 2. AI-based routing for agentless chat (first message only)
             if enable_routing and agent is None:
@@ -202,9 +248,15 @@ class AgentExecutor:
                     )
                     if routed_agent:
                         # Switch to routed agent (handles events and persistence)
-                        async for chunk in self._switch_agent(conversation, routed_agent, "routed"):
-                            yield chunk
-                        agent = routed_agent
+                        switch_chunk, switched_agent = await self._switch_agent(
+                            conversation,
+                            routed_agent,
+                            "routed",
+                            user=user,
+                        )
+                        if switch_chunk and switched_agent:
+                            yield switch_chunk
+                            agent = switched_agent
 
             # 3. Save user message
             user_msg = await self._save_message(

--- a/api/src/services/agent_router.py
+++ b/api/src/services/agent_router.py
@@ -9,13 +9,14 @@ Routes user messages to the appropriate agent based on:
 import logging
 import re
 from contextlib import asynccontextmanager
+from uuid import UUID
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlalchemy.orm import selectinload
 
 from src.core.log_safety import log_safe
+from src.core.org_filter import OrgFilterType
 from src.models.orm import Agent
+from src.repositories.agents import AgentRepository
 from src.services.llm import get_llm_client, LLMMessage
 
 logger = logging.getLogger(__name__)
@@ -36,8 +37,18 @@ class AgentRouter:
     2. Automatic: AI analyzes message intent and routes to best-fit agent
     """
 
-    def __init__(self, session_factory: async_sessionmaker[AsyncSession]):
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        *,
+        user_id: UUID | None = None,
+        org_id: UUID | None = None,
+        is_superuser: bool = False,
+    ):
         self._session_factory = session_factory
+        self._user_id = user_id
+        self._org_id = org_id
+        self._is_superuser = is_superuser
 
     @asynccontextmanager
     async def _db(self):
@@ -46,7 +57,11 @@ class AgentRouter:
             yield session
             await session.commit()
 
-    async def parse_mention(self, message: str) -> Agent | None:
+    async def parse_mention(
+        self,
+        message: str,
+        available_agents: list[Agent] | None = None,
+    ) -> Agent | None:
         """
         Parse @mention from user message and find matching agent.
 
@@ -62,23 +77,16 @@ class AgentRouter:
 
         agent_name = match.group(1).strip()
 
-        # Find agent by name (case-insensitive), with tools and delegations loaded
-        async with self._db() as session:
-            result = await session.execute(
-                select(Agent)
-                .options(
-                    selectinload(Agent.tools),
-                    selectinload(Agent.delegated_agents),
-                )
-                .where(Agent.name.ilike(agent_name))
-                .where(Agent.is_active.is_(True))
-            )
-            agent = result.scalar_one_or_none()
+        if available_agents is None:
+            available_agents = await self.get_available_agents()
 
-        if agent:
-            logger.info(f"@mention routing to agent: {agent.name}")
+        for agent in available_agents:
+            if agent.name.lower() == agent_name.lower():
+                logger.info(f"@mention routing to agent: {agent.name}")
+                return agent
 
-        return agent
+        logger.info("@mention did not match an accessible agent: %s", log_safe(agent_name))
+        return None
 
     def _build_agent_description(self, agent: Agent) -> str:
         """Build agent description including tool and knowledge capabilities for routing."""
@@ -118,16 +126,7 @@ class AgentRouter:
         """
         # Get available agents if not provided (with tools and delegations eager-loaded)
         if available_agents is None:
-            async with self._db() as session:
-                result = await session.execute(
-                    select(Agent)
-                    .options(
-                        selectinload(Agent.tools),
-                        selectinload(Agent.delegated_agents),
-                    )
-                    .where(Agent.is_active.is_(True))
-                )
-                available_agents = list(result.scalars().all())
+            available_agents = await self.get_available_agents()
 
         # If no agents available, return None
         if not available_agents:
@@ -202,12 +201,24 @@ Your response (agent name or DIRECT):"""
             return None
 
     async def get_available_agents(self) -> list[Agent]:
-        """Get all active agents for routing."""
+        """Get active agents available to the current user for routing."""
+        if self._user_id is None:
+            logger.warning("Agent routing requested without user context; no agents are routable")
+            return []
+
         async with self._db() as session:
-            result = await session.execute(
-                select(Agent).where(Agent.is_active.is_(True))
+            repo = AgentRepository(
+                session=session,
+                org_id=self._org_id,
+                user_id=self._user_id,
+                is_superuser=self._is_superuser,
             )
-            return list(result.scalars().all())
+            if self._is_superuser:
+                return await repo.list_all_in_scope(
+                    filter_type=OrgFilterType.ALL,
+                    active_only=True,
+                )
+            return await repo.list_agents(active_only=True)
 
     def strip_mention(self, message: str) -> str:
         """

--- a/api/tests/unit/services/test_agent_router_access.py
+++ b/api/tests/unit/services/test_agent_router_access.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.core.auth import UserPrincipal
+from src.models.enums import AgentAccessLevel
+from src.models.orm.agents import Agent, AgentRole, Conversation
+from src.models.orm.organizations import Organization
+from src.models.orm.users import Role, User, UserRole
+from src.services.agent_executor import AgentExecutor
+from src.services.agent_router import AgentRouter
+from src.services.llm import LLMResponse
+
+
+class SessionBoundAgentExecutor(AgentExecutor):
+    def __init__(self, session: AsyncSession):
+        super().__init__(lambda: None)  # type: ignore[arg-type]
+        self._session = session
+
+    @asynccontextmanager
+    async def _db(self):
+        yield self._session
+        await self._session.flush()
+
+
+class SessionBoundAgentRouter(AgentRouter):
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        user_id: UUID,
+        org_id: UUID | None,
+        is_superuser: bool = False,
+    ):
+        super().__init__(
+            lambda: None,  # type: ignore[arg-type]
+            user_id=user_id,
+            org_id=org_id,
+            is_superuser=is_superuser,
+        )
+        self._session = session
+
+    @asynccontextmanager
+    async def _db(self):
+        yield self._session
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+async def _make_org(db: AsyncSession, name: str) -> Organization:
+    org = Organization(
+        id=uuid4(),
+        name=name,
+        domain=f"{uuid4().hex[:8]}.example.com",
+        created_by="test@example.com",
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _make_user(
+    db: AsyncSession,
+    *,
+    org_id: UUID,
+    email_prefix: str,
+    is_superuser: bool = False,
+) -> User:
+    user = User(
+        id=uuid4(),
+        email=f"{email_prefix}-{uuid4().hex[:8]}@example.com",
+        name=email_prefix,
+        is_active=True,
+        is_superuser=is_superuser,
+        is_verified=True,
+        is_registered=True,
+        organization_id=org_id,
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _make_role(db: AsyncSession, user: User | None = None) -> Role:
+    role = Role(
+        id=uuid4(),
+        name=f"role-{uuid4().hex[:8]}",
+        created_by="test@example.com",
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    db.add(role)
+    await db.flush()
+    if user is not None:
+        db.add(UserRole(user_id=user.id, role_id=role.id, assigned_by="test@example.com"))
+        await db.flush()
+    return role
+
+
+async def _make_agent(
+    db: AsyncSession,
+    name: str,
+    *,
+    org_id: UUID | None,
+    access_level: AgentAccessLevel = AgentAccessLevel.AUTHENTICATED,
+    owner_user_id: UUID | None = None,
+    role: Role | None = None,
+) -> Agent:
+    agent = Agent(
+        id=uuid4(),
+        name=name,
+        description=f"{name} description",
+        system_prompt="You are a test agent.",
+        channels=["chat"],
+        access_level=access_level,
+        organization_id=org_id,
+        owner_user_id=owner_user_id,
+        is_active=True,
+        knowledge_sources=[],
+        system_tools=[],
+        created_by="test@example.com",
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    db.add(agent)
+    await db.flush()
+    if role is not None:
+        db.add(AgentRole(agent_id=agent.id, role_id=role.id, assigned_by="test@example.com"))
+        await db.flush()
+    return agent
+
+
+async def _make_conversation(db: AsyncSession, *, user_id: UUID) -> Conversation:
+    conversation = Conversation(
+        id=uuid4(),
+        user_id=user_id,
+        agent_id=None,
+        channel="chat",
+        title=None,
+        extra_data={},
+        is_active=True,
+        created_at=_now(),
+        updated_at=_now(),
+    )
+    db.add(conversation)
+    await db.flush()
+    return conversation
+
+
+def _principal(user: User) -> UserPrincipal:
+    return UserPrincipal(
+        user_id=user.id,
+        email=user.email,
+        organization_id=user.organization_id,
+        name=user.name or "",
+        is_active=user.is_active,
+        is_superuser=user.is_superuser,
+        is_verified=user.is_verified,
+    )
+
+
+@pytest.mark.asyncio
+async def test_available_agents_are_limited_to_user_access(db_session: AsyncSession):
+    org_a = await _make_org(db_session, "Org A")
+    org_b = await _make_org(db_session, "Org B")
+    user = await _make_user(db_session, org_id=org_b.id, email_prefix="org-b-user")
+    other_user = await _make_user(db_session, org_id=org_b.id, email_prefix="other-user")
+    user_role = await _make_role(db_session, user)
+    unassigned_role = await _make_role(db_session)
+
+    await _make_agent(db_session, "Org B Auth Agent", org_id=org_b.id)
+    await _make_agent(db_session, "Global Role Agent", org_id=None, access_level=AgentAccessLevel.ROLE_BASED, role=user_role)
+    await _make_agent(db_session, "Own Private Agent", org_id=org_b.id, access_level=AgentAccessLevel.PRIVATE, owner_user_id=user.id)
+    await _make_agent(db_session, "Cross Org Agent", org_id=org_a.id)
+    await _make_agent(db_session, "Unassigned Role Agent", org_id=None, access_level=AgentAccessLevel.ROLE_BASED, role=unassigned_role)
+    await _make_agent(db_session, "Other Private Agent", org_id=org_b.id, access_level=AgentAccessLevel.PRIVATE, owner_user_id=other_user.id)
+
+    router = SessionBoundAgentRouter(db_session, user_id=user.id, org_id=org_b.id)
+
+    names = {agent.name for agent in await router.get_available_agents()}
+
+    assert names == {"Global Role Agent", "Org B Auth Agent", "Own Private Agent"}
+
+
+@pytest.mark.asyncio
+async def test_auto_route_cannot_select_inaccessible_agent(db_session: AsyncSession):
+    org_a = await _make_org(db_session, "Org A")
+    org_b = await _make_org(db_session, "Org B")
+    user = await _make_user(db_session, org_id=org_b.id, email_prefix="org-b-user")
+
+    await _make_agent(db_session, "Accessible Helpdesk", org_id=org_b.id)
+    await _make_agent(db_session, "Cross Org Payroll", org_id=org_a.id)
+
+    router = SessionBoundAgentRouter(db_session, user_id=user.id, org_id=org_b.id)
+    llm_client = AsyncMock()
+    llm_client.complete = AsyncMock(return_value=LLMResponse(content="Cross Org Payroll"))
+
+    with patch("src.services.agent_router.get_llm_client", return_value=llm_client):
+        routed = await router.route_message("I need help with payroll")
+
+    assert routed is None
+    prompt = llm_client.complete.call_args.kwargs["messages"][1].content
+    assert "Accessible Helpdesk" in prompt
+    assert "Cross Org Payroll" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_mention_cannot_select_inaccessible_agent(db_session: AsyncSession):
+    org_a = await _make_org(db_session, "Org A")
+    org_b = await _make_org(db_session, "Org B")
+    user = await _make_user(db_session, org_id=org_b.id, email_prefix="org-b-user")
+
+    await _make_agent(db_session, "Cross Org Payroll", org_id=org_a.id)
+    accessible = await _make_agent(db_session, "Accessible Helpdesk", org_id=org_b.id)
+
+    router = SessionBoundAgentRouter(db_session, user_id=user.id, org_id=org_b.id)
+
+    assert await router.parse_mention("@[Cross Org Payroll] hello") is None
+    assert await router.parse_mention("@[Accessible Helpdesk] hello") == accessible
+
+
+@pytest.mark.asyncio
+async def test_executor_switch_agent_denies_inaccessible_agent(db_session: AsyncSession):
+    org_a = await _make_org(db_session, "Org A")
+    org_b = await _make_org(db_session, "Org B")
+    user = await _make_user(db_session, org_id=org_b.id, email_prefix="org-b-user")
+    inaccessible = await _make_agent(db_session, "Cross Org Payroll", org_id=org_a.id)
+    conversation = await _make_conversation(db_session, user_id=user.id)
+
+    executor = SessionBoundAgentExecutor(db_session)
+
+    switch_chunk, switched_agent = await executor._switch_agent(
+        conversation,
+        inaccessible,
+        "routed",
+        user=_principal(user),
+    )
+
+    await db_session.refresh(conversation)
+    assert switch_chunk is None
+    assert switched_agent is None
+    assert conversation.agent_id is None
+
+
+@pytest.mark.asyncio
+async def test_executor_switch_agent_persists_accessible_agent(db_session: AsyncSession):
+    org = await _make_org(db_session, "Org")
+    user = await _make_user(db_session, org_id=org.id, email_prefix="org-user")
+    accessible = await _make_agent(db_session, "Accessible Helpdesk", org_id=org.id)
+    conversation = await _make_conversation(db_session, user_id=user.id)
+
+    executor = SessionBoundAgentExecutor(db_session)
+
+    switch_chunk, switched_agent = await executor._switch_agent(
+        conversation,
+        accessible,
+        "@mention",
+        user=_principal(user),
+    )
+
+    await db_session.refresh(conversation)
+    assert switched_agent == accessible
+    assert switch_chunk is not None
+    assert switch_chunk.agent_switch is not None
+    assert switch_chunk.agent_switch.agent_id == str(accessible.id)
+    assert switch_chunk.agent_switch.agent_name == "Accessible Helpdesk"
+    assert conversation.agent_id == accessible.id


### PR DESCRIPTION
## Summary
- restrict chat routing and @mentions to agents accessible to the current user
- enforce an executor-level access check before binding conversations to routed agents
- re-check existing conversation agent access for HTTP and WebSocket chat paths
- add regression coverage for accessible/inaccessible routing and switch behavior

## Tests
- ./test.sh tests/unit/services/test_agent_router_access.py -v
- ./test.sh tests/e2e/api/test_chat.py::TestConversationsAccessControl tests/e2e/api/test_chat.py::TestMessages -v
- cd api && ruff check .
- cd api && pyright
- ./test.sh all