### PR TITLE
fix(manifest-import): link imported configs to schema

### DIFF
--- a/api/src/services/manifest_import.py
+++ b/api/src/services/manifest_import.py
@@ -2089,6 +2089,16 @@ class ManifestResolver:
                 )
             )
 
+        if cache is not None:
+            cs_refresh = await self.db.execute(
+                select(IntegrationConfigSchema).where(
+                    IntegrationConfigSchema.integration_id == integ_id
+                )
+            )
+            cache["integ_cs"][integ_id] = {
+                cs.key: cs for cs in cs_refresh.scalars().all()
+            }
+
         # Sync OAuth provider (structure only — client_secret never imported)
         if minteg.oauth_provider:
             op_data = minteg.oauth_provider
@@ -2194,6 +2204,10 @@ class ManifestResolver:
 
         # Check prefetch cache for existing config by natural key
         cache_hit = cache["config_by_natural"].get((mcfg.key, integ_id, org_id))
+        schema_id = None
+        if integ_id is not None:
+            schema = cache.get("integ_cs", {}).get(integ_id, {}).get(mcfg.key)
+            schema_id = schema.id if schema is not None else None
 
         # Convert string config_type to enum for proper DB storage
         from src.models.enums import ConfigType
@@ -2204,7 +2218,7 @@ class ManifestResolver:
             existing_id, existing_value, _config_schema_id = cache_hit
 
             # Secret with existing value — don't overwrite
-            if is_secret and existing_value is not None:
+            if is_secret and existing_value is not None and schema_id is None:
                 return []
 
             # Update existing row (including ID if it changed)
@@ -2217,6 +2231,8 @@ class ManifestResolver:
                 "organization_id": org_id,
                 "updated_by": "git-sync",
             }
+            if schema_id is not None:
+                update_values["config_schema_id"] = schema_id
             if not is_secret:
                 update_values["value"] = mcfg.value if mcfg.value is not None else {}
 
@@ -2237,6 +2253,8 @@ class ManifestResolver:
                 "value": mcfg.value if mcfg.value is not None else {},
                 "updated_by": "git-sync",
             }
+            if schema_id is not None:
+                insert_values["config_schema_id"] = schema_id
             return [Upsert(
                 model=Config,
                 id=cfg_id,

--- a/api/tests/e2e/platform/test_git_sync_local.py
+++ b/api/tests/e2e/platform/test_git_sync_local.py
@@ -1979,6 +1979,125 @@ class TestSplitManifestFormat:
         assert cfg.config_type == "string"
         assert cfg.value == "https://api.example.com"
 
+    async def test_pull_integration_config_links_config_schema_id(
+        self,
+        db_session: AsyncSession,
+        sync_service,
+        working_clone,
+    ):
+        """Integration configs imported from split manifests must link to
+        their IntegrationConfigSchema rows and keep that link after export.
+        """
+        from uuid import UUID as UUIDType
+
+        from src.models.orm.config import Config
+        from src.models.orm.integrations import Integration, IntegrationConfigSchema
+
+        work_dir = Path(working_clone.working_dir)
+        integ_id = str(uuid4())
+        config_id = str(uuid4())
+
+        bifrost_dir = work_dir / ".bifrost"
+        bifrost_dir.mkdir(exist_ok=True)
+        (bifrost_dir / "integrations.yaml").write_text(yaml.dump({
+            "integrations": {
+                "TestIntegConfigSchemaLink": {
+                    "id": integ_id,
+                    "config_schema": [
+                        {
+                            "key": "EXAMPLE_TOKEN",
+                            "type": "secret",
+                            "required": True,
+                            "position": 0,
+                        },
+                    ],
+                },
+            },
+        }, default_flow_style=False))
+        (bifrost_dir / "configs.yaml").write_text(yaml.dump({
+            "configs": {
+                "EXAMPLE_TOKEN": {
+                    "id": config_id,
+                    "integration_id": integ_id,
+                    "key": "EXAMPLE_TOKEN",
+                    "config_type": "secret",
+                    "value": {"value": ""},
+                },
+            },
+        }, default_flow_style=False))
+
+        working_clone.index.add([
+            ".bifrost/integrations.yaml",
+            ".bifrost/configs.yaml",
+        ])
+        working_clone.index.commit("add integration config with schema")
+        working_clone.remotes.origin.push()
+
+        result = await sync_service.desktop_sync(confirm_deletes=True)
+        assert result.success is True
+
+        schema = (
+            await db_session.execute(
+                select(IntegrationConfigSchema).where(
+                    IntegrationConfigSchema.integration_id == UUIDType(integ_id),
+                    IntegrationConfigSchema.key == "EXAMPLE_TOKEN",
+                )
+            )
+        ).scalar_one()
+        cfg = await db_session.get(Config, UUIDType(config_id))
+
+        assert cfg is not None
+        assert cfg.config_schema_id == schema.id
+
+        # Existing secret configs keep their value during import, but sync
+        # must still repair a missing schema link.
+        cfg.config_schema_id = None
+        await db_session.commit()
+        result = await sync_service.desktop_sync(confirm_deletes=True)
+        assert result.success is True
+        await db_session.refresh(cfg)
+        assert cfg.value == {"value": ""}
+        assert cfg.config_schema_id == schema.id
+
+        # Export should preserve the portable shape: schema lives under the
+        # integration and the config references that integration by UUID.
+        commit_result = await sync_service.desktop_commit("round trip integration config")
+        assert commit_result.success is True
+        exported = read_manifest_from_dir(sync_service._persistent_dir / ".bifrost")
+        exported_integ = exported.integrations[integ_id]
+        assert [cs.key for cs in exported_integ.config_schema] == ["EXAMPLE_TOKEN"]
+        exported_cfg = exported.configs[config_id]
+        assert exported_cfg.integration_id == integ_id
+        assert exported_cfg.key == "EXAMPLE_TOKEN"
+
+        # Re-import the exported manifest into an empty DB state; the schema
+        # linkage must be restored from integration_id + key.
+        await db_session.execute(delete(Config).where(Config.id == UUIDType(config_id)))
+        await db_session.execute(
+            delete(IntegrationConfigSchema).where(
+                IntegrationConfigSchema.integration_id == UUIDType(integ_id)
+            )
+        )
+        await db_session.execute(
+            delete(Integration).where(Integration.id == UUIDType(integ_id))
+        )
+        await db_session.commit()
+
+        result = await sync_service.desktop_sync(confirm_deletes=True)
+        assert result.success is True
+
+        roundtrip_schema = (
+            await db_session.execute(
+                select(IntegrationConfigSchema).where(
+                    IntegrationConfigSchema.integration_id == UUIDType(integ_id),
+                    IntegrationConfigSchema.key == "EXAMPLE_TOKEN",
+                )
+            )
+        ).scalar_one()
+        roundtrip_cfg = await db_session.get(Config, UUIDType(config_id))
+        assert roundtrip_cfg is not None
+        assert roundtrip_cfg.config_schema_id == roundtrip_schema.id
+
     async def test_pull_table_from_manifest(
         self,
         db_session: AsyncSession,


### PR DESCRIPTION
Fixes #329

## Summary
- refresh manifest-import schema cache after integration config schema rows are synced
- set `Config.config_schema_id` on imported integration configs by matching `(integration_id, key)`
- preserve existing secret values while still repairing missing schema links

## Verification
- Reproduced the original failure before the fix: imported config had `config_schema_id = NULL`
- `./test.sh tests/e2e/platform/test_git_sync_local.py::TestSplitManifestFormat::test_pull_integration_config_links_config_schema_id -q`
- adjacent git-sync integration/config-schema tests: 4 passed
- `./test.sh tests/e2e/platform/test_manifest_import_config_cache.py -q`
- `ruff check src/services/manifest_import.py tests/e2e/platform/test_git_sync_local.py`

Note: `pyright` was not available in the test-runner image used for this worktree.