### PR TITLE
Org-scoping cleanup: route tools listing through repository

### DIFF
--- a/api/src/repositories/workflows.py
+++ b/api/src/repositories/workflows.py
@@ -24,8 +24,10 @@ from datetime import datetime, timezone
 from typing import Literal, Sequence
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
+from sqlalchemy.orm import selectinload
 
+from src.core.org_filter import OrgFilterType
 from src.models import Workflow
 from src.models.orm.workflow_roles import WorkflowRole
 from src.repositories.org_scoped import OrgScopedRepository
@@ -156,6 +158,40 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
         Convenience method for get_by_type('tool').
         """
         return await self.get_by_type("tool", active_only=active_only)
+
+    async def list_tools_for_filter(
+        self,
+        filter_type: OrgFilterType,
+        filter_org_id: UUID | None,
+        active_only: bool = True,
+    ) -> Sequence[Workflow]:
+        """List workflow tools for an already-resolved organization filter."""
+        stmt = (
+            select(Workflow)
+            .where(Workflow.type == "tool")
+            .options(selectinload(Workflow.organization))
+        )
+        if active_only:
+            stmt = stmt.where(Workflow.is_active.is_(True))
+
+        if filter_type is OrgFilterType.ORG_PLUS_GLOBAL:
+            if filter_org_id is None:
+                stmt = stmt.where(Workflow.organization_id.is_(None))
+            else:
+                stmt = stmt.where(
+                    or_(
+                        Workflow.organization_id == filter_org_id,
+                        Workflow.organization_id.is_(None),
+                    )
+                )
+        elif filter_type is OrgFilterType.ORG_ONLY:
+            stmt = stmt.where(Workflow.organization_id == filter_org_id)
+        elif filter_type is OrgFilterType.GLOBAL_ONLY:
+            stmt = stmt.where(Workflow.organization_id.is_(None))
+
+        stmt = stmt.order_by(Workflow.name)
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
 
     async def get_workflows_only(
         self,

--- a/api/src/routers/tools.py
+++ b/api/src/routers/tools.py
@@ -9,14 +9,12 @@ import logging
 from typing import Literal
 
 from fastapi import APIRouter, Query
-from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 
 from src.core.auth import CurrentActiveUser
 from src.core.database import DbSession
 from src.core.org_filter import resolve_org_filter
 from src.models.contracts.agents import ToolInfo, ToolsResponse
-from src.models.orm import Workflow
+from src.repositories.workflows import WorkflowRepository
 
 from src.services.mcp_server.server import get_system_tools as get_system_tools_from_server
 
@@ -97,24 +95,17 @@ async def list_tools(
             # Invalid scope - just return system tools
             return ToolsResponse(tools=tools)
 
-        # Query workflows that are tools
-        query = (
-            select(Workflow)
-            .where(Workflow.type == "tool")
-            .options(selectinload(Workflow.organization))
+        workflow_repo = WorkflowRepository(
+            db,
+            org_id=user.organization_id,
+            user_id=user.user_id,
+            is_superuser=user.is_superuser,
         )
-        if not include_inactive:
-            query = query.where(Workflow.is_active.is_(True))
-
-        # Apply org filter
-        if filter_type == "org" and filter_org_id:
-            query = query.where(Workflow.organization_id == filter_org_id)
-        elif filter_type == "global":
-            query = query.where(Workflow.organization_id.is_(None))
-        # "all" means no additional filter (superuser sees everything)
-
-        result = await db.execute(query.order_by(Workflow.name))
-        workflows = result.scalars().all()
+        workflows = await workflow_repo.list_tools_for_filter(
+            filter_type,
+            filter_org_id,
+            active_only=not include_inactive,
+        )
 
         for workflow in workflows:
             tools.append(

--- a/api/tests/e2e/api/test_tools.py
+++ b/api/tests/e2e/api/test_tools.py
@@ -123,3 +123,79 @@ class TestToolsEndpointOrgFields:
             assert tool["organization_name"] is None, (
                 f"system tool {tool['id']} unexpectedly has organization_name"
             )
+
+
+@pytest.fixture
+def scoped_workflow_tools(e2e_client, platform_admin, org1, org2):
+    """Create one global tool and one tool in each test org."""
+    tools = [
+        _register_tool(e2e_client, platform_admin.headers, organization_id=None),
+        _register_tool(
+            e2e_client, platform_admin.headers, organization_id=str(org1["id"])
+        ),
+        _register_tool(
+            e2e_client, platform_admin.headers, organization_id=str(org2["id"])
+        ),
+    ]
+    try:
+        yield tools
+    finally:
+        for tool in tools:
+            _cleanup_tool(e2e_client, platform_admin.headers, tool)
+
+
+@pytest.mark.e2e
+class TestToolsEndpointOrgScope:
+    """The /api/tools workflow list uses resolved org-scope semantics."""
+
+    def _workflow_tool_ids(self, e2e_client, headers, scope: str | None = None) -> set[str]:
+        params = {"type": "workflow"}
+        if scope is not None:
+            params["scope"] = scope
+        resp = e2e_client.get("/api/tools", headers=headers, params=params)
+        assert resp.status_code == 200, resp.text
+        return {tool["id"] for tool in resp.json()["tools"]}
+
+    def test_platform_admin_no_scope_sees_all_workflow_tools(
+        self, e2e_client, platform_admin, scoped_workflow_tools
+    ):
+        ids = self._workflow_tool_ids(e2e_client, platform_admin.headers)
+
+        assert {tool["id"] for tool in scoped_workflow_tools}.issubset(ids)
+
+    def test_platform_admin_global_scope_sees_only_global_workflow_tools(
+        self, e2e_client, platform_admin, scoped_workflow_tools
+    ):
+        global_tool, org1_tool, org2_tool = scoped_workflow_tools
+
+        ids = self._workflow_tool_ids(
+            e2e_client, platform_admin.headers, scope="global"
+        )
+
+        assert global_tool["id"] in ids
+        assert org1_tool["id"] not in ids
+        assert org2_tool["id"] not in ids
+
+    def test_platform_admin_org_scope_sees_only_that_org_workflow_tools(
+        self, e2e_client, platform_admin, org1, scoped_workflow_tools
+    ):
+        global_tool, org1_tool, org2_tool = scoped_workflow_tools
+
+        ids = self._workflow_tool_ids(
+            e2e_client, platform_admin.headers, scope=str(org1["id"])
+        )
+
+        assert global_tool["id"] not in ids
+        assert org1_tool["id"] in ids
+        assert org2_tool["id"] not in ids
+
+    def test_org_user_sees_own_org_plus_global_workflow_tools(
+        self, e2e_client, org1_user, scoped_workflow_tools
+    ):
+        global_tool, org1_tool, org2_tool = scoped_workflow_tools
+
+        ids = self._workflow_tool_ids(e2e_client, org1_user.headers)
+
+        assert global_tool["id"] in ids
+        assert org1_tool["id"] in ids
+        assert org2_tool["id"] not in ids

--- a/api/tests/unit/test_org_scoping_enforcement.py
+++ b/api/tests/unit/test_org_scoping_enforcement.py
@@ -118,8 +118,6 @@ ALLOW_LIST_INLINE_ORG: set[tuple[str, str, str]] = {
     ('routers/roi_reports.py', '.join(Organization, ExecutionMetricsDaily.organization_id == Organization.id)', 'identity-entity scope filter (permanent)'),
     ('routers/roles.py', 'KnowledgeNamespaceRoleORM.organization_id == entry.organization_id,', 'KnowledgeNamespaceRole identity-entity filter (permanent)'),
     ('routers/tables.py', 'CustomClaimORM.organization_id == organization_id', 'tables custom claim cross-ref; phase 6 migrates'),
-    ('routers/tools.py', 'query = query.where(Workflow.organization_id == filter_org_id)', 'tools workflow list; phase 6 migrates'),
-    ('routers/tools.py', 'query = query.where(Workflow.organization_id.is_(None))', 'tools workflow list; phase 6 migrates'),
     ('routers/usage_reports.py', 'base_conditions.append(AIUsage.organization_id == filter_org_id)', 'identity-entity scope filter (permanent)'),
     ('routers/usage_reports.py', 'exec_conditions.append(Execution.organization_id == filter_org_id)', 'identity-entity scope filter (permanent)'),
     ('routers/usage_reports.py', 'workflow_query = workflow_query.where(AIUsage.organization_id == filter_org_id)', 'identity-entity scope filter (permanent)'),


### PR DESCRIPTION
## Summary
- move /api/tools workflow-list org filtering into WorkflowRepository
- use resolved OrgFilterType values instead of router-local enum/string checks
- remove the tools.py inline-org-scoping allow-list entries
- add E2E coverage for platform-admin all/global/org scope and org-user org+global visibility

## Verification
- cd api && ruff check src/repositories/workflows.py src/routers/tools.py tests/e2e/api/test_tools.py tests/unit/test_org_scoping_enforcement.py
- cd api && pyright src/repositories/workflows.py src/routers/tools.py tests/e2e/api/test_tools.py
- git diff --check origin/main
- ./test.sh tests/unit/test_org_scoping_enforcement.py -v
- ./test.sh tests/e2e/api/test_tools.py -v

Refs #309