### PR TITLE
fix(oauth): scope refreshed token to the provider, not the caller's org

### DIFF
--- a/api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py
+++ b/api/alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py
@@ -1,0 +1,89 @@
+"""promote provider-org-stamped tokens of global connections back to global
+
+Revision ID: 20260601_promote_global_tok
+Revises: 20260526_drop_developer_contexts
+Create Date: 2026-06-01
+
+Data fix companion to the refresh_token scope fix (api/src/routers/
+oauth_connections.py). Before that fix, the connections /refresh handler
+stored the refreshed token under the *caller's* org instead of the
+connection's own scope. A platform admin in the provider org refreshing a
+GLOBAL connection (oauth_providers.organization_id IS NULL) created an
+org-level token (user_id IS NULL) stamped with the provider org's id rather
+than NULL. The SDK read cascade only falls back to organization_id IS NULL,
+so every other org failed to resolve the token.
+
+This migration heals rows already mis-stamped, scoped tightly so it cannot
+touch a legitimately org-scoped token:
+
+  - the token's provider is itself GLOBAL (oauth_providers.organization_id
+    IS NULL) — never touches a per-org connection's provider;
+  - the token is org-level (user_id IS NULL);
+  - the token is stamped with the provider org specifically;
+  - no true-global (NULL) token already exists for that provider — so we
+    never collide with or shadow an existing correct row.
+
+When a provider has BOTH a provider-org-stamped token and a real NULL token
+(e.g. someone already cleared one manually and a refresh re-inserted the
+Covi one), we delete the redundant provider-org row instead of promoting it,
+to avoid two org-level rows for the same global provider.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260601_promote_global_tok"
+down_revision: Union[str, Sequence[str]] = "20260526_drop_developer_contexts"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Drop redundant provider-org-stamped org-level tokens when a correct
+    #    global (NULL) token already exists for the same global provider.
+    op.execute(
+        """
+        DELETE FROM oauth_tokens t
+        USING organizations o, oauth_providers p
+        WHERE t.organization_id = o.id
+          AND o.is_provider = true
+          AND t.user_id IS NULL
+          AND p.id = t.provider_id
+          AND p.organization_id IS NULL
+          AND EXISTS (
+              SELECT 1 FROM oauth_tokens g
+              WHERE g.provider_id = t.provider_id
+                AND g.organization_id IS NULL
+                AND g.user_id IS NULL
+          )
+        """
+    )
+
+    # 2. Promote the remaining provider-org-stamped org-level tokens of global
+    #    providers to global (organization_id = NULL).
+    op.execute(
+        """
+        UPDATE oauth_tokens t
+        SET organization_id = NULL
+        FROM organizations o, oauth_providers p
+        WHERE t.organization_id = o.id
+          AND o.is_provider = true
+          AND t.user_id IS NULL
+          AND p.id = t.provider_id
+          AND p.organization_id IS NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM oauth_tokens g
+              WHERE g.provider_id = t.provider_id
+                AND g.organization_id IS NULL
+                AND g.user_id IS NULL
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # No restore. Re-stamping these tokens with the provider org would
+    # reintroduce the cross-org resolution bug this migration fixes, and the
+    # original (deleted) rows cannot be reconstructed. Intentionally a no-op.
+    pass

--- a/api/src/routers/oauth_connections.py
+++ b/api/src/routers/oauth_connections.py
@@ -422,10 +422,21 @@ async def refresh_token(
             detail="No token URL configured for this connection",
         )
 
+    # The token's scope follows the PROVIDER, not the caller. A global
+    # connection (provider.organization_id IS NULL) must store a global
+    # (NULL) token regardless of which admin triggers the refresh —
+    # otherwise a provider-org admin re-stamps the shared token with their
+    # own org and every other org's read cascade misses it. Mirrors the SDK
+    # path in cli.py. See api/src/repositories/README.md and the
+    # project_oauth_global_token_restamp note.
+    token_repo = OAuthProviderRepository(
+        ctx.db, org_id=provider.organization_id, is_superuser=True
+    )
+
     # For authorization_code flows we need the stored token up front.
     stored_token: OAuthToken | None = None
     if provider.oauth_flow_type != "client_credentials":
-        stored_token = await repo.get_token(connection_name)
+        stored_token = await token_repo.get_token(connection_name)
         if not stored_token or not stored_token.encrypted_refresh_token:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -441,11 +452,14 @@ async def refresh_token(
     # Build context and delegate. The {entity_id} fallback chain lives in
     # build_token_refresh_context so this handler, the SDK endpoint, and the
     # scheduler cannot drift.
+    # Resolve {entity_id} against the token's scope (the provider's org), not
+    # the caller's. A global connection must template against integration
+    # defaults, not the connecting admin's org mapping.
     td = await build_token_refresh_context(
         db=ctx.db,
         provider=provider,
         token=stored_token,
-        org_id=org_id,
+        org_id=provider.organization_id,
     )
     outcome = await refresh_oauth_token_http(td)
 
@@ -470,7 +484,7 @@ async def refresh_token(
             # Default to 1 hour from now if no expiry provided
             new_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
 
-        await repo.store_token(
+        await token_repo.store_token(
             connection_name=connection_name,
             access_token=outcome["access_token"],
             refresh_token=None,  # client_credentials doesn't have refresh tokens
@@ -496,10 +510,12 @@ async def refresh_token(
 
         logger.info(f"Token refreshed successfully for {log_safe(connection_name)}")
 
-    # Invalidate cache (token was updated)
+    # Invalidate cache (token was updated). Key on the token's scope —
+    # the provider's org — not the caller's, so the cached entry that
+    # actually changed is the one busted.
     if CACHE_INVALIDATION_AVAILABLE and invalidate_oauth_token:
-        org_id_str = str(org_id) if org_id else None
-        await invalidate_oauth_token(org_id_str, connection_name)
+        token_org_str = str(provider.organization_id) if provider.organization_id else None
+        await invalidate_oauth_token(token_org_str, connection_name)
 
     expires_at_str = new_expires_at.isoformat() if new_expires_at else None
     return RefreshTokenResponse(

--- a/api/tests/unit/routers/test_oauth_refresh_token_scope.py
+++ b/api/tests/unit/routers/test_oauth_refresh_token_scope.py
@@ -1,0 +1,217 @@
+"""Regression tests for OAuth token *scope* on the connections /refresh path.
+
+These are DB-backed (real session) because the bug they guard against is
+"which ``organization_id`` gets written onto the token row" — a mock session
+swallows exactly that. See ``project_oauth_global_token_restamp`` memory.
+
+Bug: ``refresh_token`` (api/src/routers/oauth_connections.py) resolved and
+persisted the token under the *caller's* ``ctx.org_id`` instead of the
+*provider's* ``organization_id``. A platform admin in the provider org (Covi)
+refreshing the GLOBAL client_credentials connection created/updated a token row
+stamped with Covi's org id, not NULL. The SDK read cascade
+(``get_org_level_for_provider``) only falls back to ``organization_id IS NULL``,
+so every non-Covi org then failed to resolve the token.
+
+The token's scope must follow the provider, not the caller.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from src.core.auth import ExecutionContext, UserPrincipal
+from src.models.orm.oauth import OAuthProvider, OAuthToken
+from src.models.orm.organizations import Organization
+
+
+async def _make_org(db_session, name: str) -> Organization:
+    """A real organization row so the FK on oauth_tokens.organization_id holds.
+
+    The bug stamps the *caller's* org onto the token; without a real org row
+    the failure is an FK violation that masks the assertion we care about.
+    """
+    org = Organization(name=name, created_by="test")
+    db_session.add(org)
+    await db_session.flush()
+    return org
+
+
+def _principal(org_id):
+    return UserPrincipal(
+        user_id=uuid4(),
+        email="admin@gobifrost.com",
+        organization_id=org_id,
+        is_superuser=True,
+    )
+
+
+async def _make_global_cc_provider(db_session, *, connection_name: str) -> OAuthProvider:
+    """A global (organization_id IS NULL) client_credentials provider."""
+    provider = OAuthProvider(
+        provider_name=connection_name,
+        display_name=connection_name,
+        oauth_flow_type="client_credentials",
+        client_id="test-client-id",
+        encrypted_client_secret=b"encrypted-secret",
+        token_url="https://login.example.com/oauth/token",
+        scopes=["scope.default"],
+        status="completed",
+        organization_id=None,  # global connection
+    )
+    db_session.add(provider)
+    await db_session.flush()
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_refresh_of_global_connection_stores_token_as_global(db_session):
+    """Refreshing a global connection as a provider-org admin must keep the
+    token global (organization_id IS NULL), not stamp it with the caller's org.
+    """
+    from src.routers.oauth_connections import refresh_token
+
+    connection_name = f"halo_{uuid4().hex[:8]}"
+    provider = await _make_global_cc_provider(db_session, connection_name=connection_name)
+
+    # Caller is a platform admin whose home org is a concrete (non-global) org —
+    # this is the Covi-admin scenario that caused the re-stamp.
+    caller = await _make_org(db_session, f"Provider Org {uuid4().hex[:6]}")
+    ctx = ExecutionContext(user=_principal(caller.id), org_id=caller.id, db=db_session)
+
+    outcome = {
+        "success": True,
+        "access_token": "fresh-access-token",
+        "encrypted_access_token": b"enc-access",
+        "encrypted_refresh_token": None,
+        "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        "scopes": ["scope.default"],
+    }
+
+    with patch(
+        "src.routers.oauth_connections.refresh_oauth_token_http",
+        new=AsyncMock(return_value=outcome),
+    ):
+        resp = await refresh_token(connection_name, ctx, ctx.user)
+
+    assert resp.success is True
+    await db_session.flush()
+
+    rows = (
+        await db_session.execute(
+            select(OAuthToken).where(OAuthToken.provider_id == provider.id)
+        )
+    ).scalars().all()
+
+    assert len(rows) == 1, "refresh should produce exactly one org-level token row"
+    token = rows[0]
+    assert token.organization_id is None, (
+        "global connection's token must be stored with organization_id=NULL, "
+        f"got {token.organization_id} (the caller's org leaked onto the token)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_updates_existing_global_token_in_place(db_session):
+    """A pre-existing global token must be updated in place, not duplicated
+    under the caller's org.
+    """
+    from src.routers.oauth_connections import refresh_token
+
+    connection_name = f"halo_{uuid4().hex[:8]}"
+    provider = await _make_global_cc_provider(db_session, connection_name=connection_name)
+
+    existing = OAuthToken(
+        organization_id=None,
+        provider_id=provider.id,
+        user_id=None,
+        encrypted_access_token=b"old-access",
+        scopes=["scope.default"],
+        status="completed",
+    )
+    db_session.add(existing)
+    await db_session.flush()
+
+    caller = await _make_org(db_session, f"Provider Org {uuid4().hex[:6]}")
+    ctx = ExecutionContext(user=_principal(caller.id), org_id=caller.id, db=db_session)
+
+    outcome = {
+        "success": True,
+        "access_token": "fresh-access-token",
+        "encrypted_access_token": b"enc-access",
+        "encrypted_refresh_token": None,
+        "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        "scopes": ["scope.default"],
+    }
+
+    with patch(
+        "src.routers.oauth_connections.refresh_oauth_token_http",
+        new=AsyncMock(return_value=outcome),
+    ):
+        await refresh_token(connection_name, ctx, ctx.user)
+
+    await db_session.flush()
+    rows = (
+        await db_session.execute(
+            select(OAuthToken).where(OAuthToken.provider_id == provider.id)
+        )
+    ).scalars().all()
+
+    assert len(rows) == 1, "must update the existing global token, not create a second row"
+    assert rows[0].organization_id is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_of_org_specific_connection_stays_org_scoped(db_session):
+    """An org-specific connection (provider.organization_id set) must keep its
+    token scoped to THAT org — the fix must not collapse every token to global.
+    This is the "Covi connecting for itself, like any org" case.
+    """
+    from src.routers.oauth_connections import refresh_token
+
+    org = await _make_org(db_session, f"Managed Org {uuid4().hex[:6]}")
+    connection_name = f"halo_{uuid4().hex[:8]}"
+    provider = OAuthProvider(
+        provider_name=connection_name,
+        display_name=connection_name,
+        oauth_flow_type="client_credentials",
+        client_id="test-client-id",
+        encrypted_client_secret=b"encrypted-secret",
+        token_url="https://login.example.com/oauth/token",
+        scopes=["scope.default"],
+        status="completed",
+        organization_id=org.id,  # org-specific connection
+    )
+    db_session.add(provider)
+    await db_session.flush()
+
+    ctx = ExecutionContext(user=_principal(org.id), org_id=org.id, db=db_session)
+
+    outcome = {
+        "success": True,
+        "access_token": "fresh-access-token",
+        "encrypted_access_token": b"enc-access",
+        "encrypted_refresh_token": None,
+        "expires_at": datetime.now(timezone.utc) + timedelta(hours=1),
+        "scopes": ["scope.default"],
+    }
+
+    with patch(
+        "src.routers.oauth_connections.refresh_oauth_token_http",
+        new=AsyncMock(return_value=outcome),
+    ):
+        await refresh_token(connection_name, ctx, ctx.user)
+
+    await db_session.flush()
+    rows = (
+        await db_session.execute(
+            select(OAuthToken).where(OAuthToken.provider_id == provider.id)
+        )
+    ).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].organization_id == org.id, (
+        "org-specific connection's token must stay scoped to its own org"
+    )

--- a/api/tests/unit/test_promote_global_oauth_tokens_migration.py
+++ b/api/tests/unit/test_promote_global_oauth_tokens_migration.py
@@ -1,0 +1,161 @@
+"""Behavioral test for the global-OAuth-token heal migration.
+
+The migration (alembic/versions/20260601_promote_mis_stamped_global_oauth_tokens.py)
+is pure SQL, so we run its two statements against a seeded DB and assert it:
+
+  - promotes a provider-org-stamped org-level token of a GLOBAL provider to NULL;
+  - leaves a legitimately org-scoped connection's token alone;
+  - drops the redundant provider-org row when a real NULL token already exists;
+  - never touches per-user tokens.
+
+Coupled to the migration file by importing its SQL via op.execute capture, so a
+drift in the migration's WHERE clauses fails this test rather than passing silently.
+"""
+
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+
+from src.models.orm.oauth import OAuthProvider, OAuthToken
+from src.models.orm.organizations import Organization
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "20260601_promote_mis_stamped_global_oauth_tokens.py"
+)
+
+
+def _migration_sql() -> list[str]:
+    """Capture the SQL strings the migration's upgrade() passes to op.execute."""
+    spec = importlib.util.spec_from_file_location("_heal_migration", MIGRATION_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+
+    captured: list[str] = []
+
+    class _FakeOp:
+        @staticmethod
+        def execute(sql):
+            captured.append(str(sql))
+
+    # Inject a fake `op` before exec so `from alembic import op` resolves to it.
+    import sys
+    import types
+
+    fake_alembic = types.ModuleType("alembic")
+    fake_alembic.op = _FakeOp()  # type: ignore[attr-defined]
+    sys.modules["alembic"] = fake_alembic
+    try:
+        spec.loader.exec_module(module)
+        module.upgrade()
+    finally:
+        sys.modules.pop("alembic", None)
+    assert len(captured) == 2, "migration should issue exactly DELETE then UPDATE"
+    return captured
+
+
+async def _org(db, name, *, is_provider=False):
+    o = Organization(name=name, created_by="test", is_provider=is_provider)
+    db.add(o)
+    await db.flush()
+    return o
+
+
+async def _provider(db, *, organization_id):
+    p = OAuthProvider(
+        provider_name=f"conn_{uuid4().hex[:8]}",
+        oauth_flow_type="client_credentials",
+        client_id="cid",
+        encrypted_client_secret=b"sec",
+        organization_id=organization_id,
+    )
+    db.add(p)
+    await db.flush()
+    return p
+
+
+async def _token(db, *, provider_id, organization_id, user_id=None):
+    t = OAuthToken(
+        provider_id=provider_id,
+        organization_id=organization_id,
+        user_id=user_id,
+        encrypted_access_token=b"acc",
+        status="completed",
+    )
+    db.add(t)
+    await db.flush()
+    return t
+
+
+async def _run_migration(db):
+    for sql in _migration_sql():
+        await db.execute(text(sql))
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_promotes_provider_org_token_of_global_provider(db_session):
+    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
+    gp = await _provider(db_session, organization_id=None)  # GLOBAL provider
+    tok = await _token(db_session, provider_id=gp.id, organization_id=provider_org.id)
+
+    await _run_migration(db_session)
+
+    await db_session.refresh(tok)
+    assert tok.organization_id is None, "mis-stamped global token should be promoted to NULL"
+
+
+@pytest.mark.asyncio
+async def test_leaves_org_specific_connection_token_alone(db_session):
+    """A connection whose PROVIDER is org-scoped is a legitimate per-org
+    connection — its token must not be touched even if stamped with the
+    provider org.
+    """
+    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
+    op_ = await _provider(db_session, organization_id=provider_org.id)  # org-scoped provider
+    tok = await _token(db_session, provider_id=op_.id, organization_id=provider_org.id)
+
+    await _run_migration(db_session)
+
+    await db_session.refresh(tok)
+    assert tok.organization_id == provider_org.id, "per-org connection token must be preserved"
+
+
+@pytest.mark.asyncio
+async def test_drops_redundant_provider_org_token_when_global_exists(db_session):
+    provider_org = await _org(db_session, f"Provider {uuid4().hex[:6]}", is_provider=True)
+    gp = await _provider(db_session, organization_id=None)
+    good = await _token(db_session, provider_id=gp.id, organization_id=None)
+    dup = await _token(db_session, provider_id=gp.id, organization_id=provider_org.id)
+
+    await _run_migration(db_session)
+
+    rows = (
+        await db_session.execute(
+            select(OAuthToken).where(OAuthToken.provider_id == gp.id)
+        )
+    ).scalars().all()
+    ids = {r.id for r in rows}
+    assert good.id in ids, "the real global token must survive"
+    assert dup.id not in ids, "the redundant provider-org token must be dropped"
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_ignores_non_provider_org_token(db_session):
+    """A token stamped with a normal (non-provider) org is a real per-org
+    token and must never be promoted.
+    """
+    normal_org = await _org(db_session, f"Managed {uuid4().hex[:6]}", is_provider=False)
+    gp = await _provider(db_session, organization_id=None)
+    tok = await _token(db_session, provider_id=gp.id, organization_id=normal_org.id)
+
+    await _run_migration(db_session)
+
+    await db_session.refresh(tok)
+    assert tok.organization_id == normal_org.id, "non-provider-org token must be left alone"


### PR DESCRIPTION
## Problem

A global integration OAuth connection (`oauth_providers.organization_id IS NULL`) becomes unusable for every org except the one whose admin last refreshed it.

Confirmed in prod: the **HaloPSA** provider row is global (`organization_id = NULL`), but its org-level OAuth token (`user_id = NULL`) is stamped with **Covi's** org id. Workflows resolving the integration under any other org get *"OAuth not configured or access token missing"* even though the integration record and per-org entity mapping cascade fine. Clearing the token to NULL by hand didn't hold — the next refresh re-inserted a Covi-scoped row.

## Root cause

`api/src/routers/oauth_connections.py::refresh_token` resolved and persisted the token under the **caller's** `ctx.org_id` instead of the **connection's** own scope. `get_token`/`store_token` are not cascaded (they key off the repo's `org_id`), so for a global provider they miss the NULL row and INSERT a new caller-org row. A provider-org (Covi) admin refreshing the global `client_credentials` connection therefore stamps the shared token with Covi, and the read cascade (`OAuthTokenRepository.get_org_level_for_provider`, org-specific → NULL only) never finds it for other orgs.

The SDK refresh path (`routers/cli.py`) already scoped writes to `provider.organization_id`; the UI handler had drifted — a regression from the #326 org-scoping consolidation.

## Fix

**Code** — in `refresh_token`, the token's scope follows the **provider**, not the caller:
- `get_token` / `store_token` / `build_token_refresh_context` / cache invalidation all route through `provider.organization_id`.
- The provider *lookup* still uses `ctx.org_id` so an org-specific provider is still found via cascade.
- Other token-write paths audited and confirmed correct: scheduler (`oauth_token_refresh.py`, in-place by id), per-mapping refresh (`integrations.py`), SDK refresh (`cli.py`), callback (request-body org), read-only auto-refresh in `_build_oauth_data`.

**Data** — an Alembic migration heals tokens already mis-stamped before this fix, so deploying self-corrects (no manual SQL):
- promotes a global provider's org-level token stamped with the provider org back to NULL;
- drops the redundant provider-org row when a real NULL token already exists;
- tightly scoped (`provider.organization_id IS NULL` + `is_provider`) so a legitimate per-org connection's token, or a normal org's token, is never touched.

## Behavioral guarantees (and why Covi stays a normal org)

- Global connection → token stored/healed as NULL, regardless of which admin refreshes it.
- Org-specific connection (Covi connecting *for itself*, like any org) → token stays scoped to that org.

## Tests

- `test_oauth_refresh_token_scope.py` (DB-backed): global stays NULL, global updates in place (no duplicate row), org-specific stays org-scoped.
- `test_promote_global_oauth_tokens_migration.py`: runs the migration's actual SQL over seeded rows — promote / preserve per-org / drop duplicate / ignore non-provider org.
- Existing OAuth refresh + repository suites pass (incl. cross-tenant isolation); full backend e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)