### PR TITLE
fix(apps): keep draft hot reload out of live apps

### DIFF
--- a/client/src/components/jsx-app/BundledAppShell.test.tsx
+++ b/client/src/components/jsx-app/BundledAppShell.test.tsx
@@ -102,10 +102,10 @@ afterEach(() => {
 		.forEach((el) => el.remove());
 });
 
-async function renderShell() {
+async function renderShell({ isPreview = true }: { isPreview?: boolean } = {}) {
 	const { BundledAppShell } = await import("./BundledAppShell");
 	return renderWithProviders(
-		<BundledAppShell appId="app-1" appSlug="my-app" isPreview={true} />,
+		<BundledAppShell appId="app-1" appSlug="my-app" isPreview={isPreview} />,
 	);
 }
 
@@ -174,5 +174,21 @@ describe("BundledAppShell — websocket subscription", () => {
 			expect(mockConnectToAppDraft).toHaveBeenCalledWith("app-1"),
 		);
 		expect(mockOnAppCodeFileUpdate).toHaveBeenCalled();
+	});
+
+	it("does not subscribe to draft rebuilds in live mode", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {});
+		mockManifestOk({ mode: "live" });
+
+		await renderShell({ isPreview: false });
+
+		await waitFor(() =>
+			expect(mockAuthFetch).toHaveBeenCalledWith(
+				"/api/applications/app-1/bundle-manifest?mode=live",
+				expect.any(Object),
+			),
+		);
+		expect(mockConnectToAppDraft).not.toHaveBeenCalled();
+		expect(mockOnAppCodeFileUpdate).not.toHaveBeenCalled();
 	});
 });

--- a/client/src/components/jsx-app/BundledAppShell.tsx
+++ b/client/src/components/jsx-app/BundledAppShell.tsx
@@ -311,27 +311,29 @@ export function BundledAppShell({ appId, appSlug, isPreview }: BundledAppShellPr
 
 		loadBundle();
 
-		// Subscribe to bundle updates for this app. Success → reload entry.
-		// Failure → show banner over last-good render.
+		// Preview-only: subscribe to draft bundle updates for this app.
+		// Success → reload entry. Failure → show banner over last-good render.
 		let unsub: (() => void) | null = null;
-		(async () => {
-			try {
-				await webSocketService.connectToAppDraft(appId);
-				unsub = webSocketService.onAppCodeFileUpdate(
-					appId,
-					(update: AppCodeFileUpdate) => {
-						if (update.error && update.error.messages.length > 0) {
-							setBuildErrors(update.error.messages);
-							setBuildErrorDismissed(false);
-						} else if (update.bundle) {
-							loadBundle(update.bundle.entry, update.bundle.css);
-						}
-					},
-				);
-			} catch (e) {
-				console.warn("[Bifrost] Failed to subscribe to app updates:", e);
-			}
-		})();
+		if (isPreview) {
+			(async () => {
+				try {
+					await webSocketService.connectToAppDraft(appId);
+					unsub = webSocketService.onAppCodeFileUpdate(
+						appId,
+						(update: AppCodeFileUpdate) => {
+							if (update.error && update.error.messages.length > 0) {
+								setBuildErrors(update.error.messages);
+								setBuildErrorDismissed(false);
+							} else if (update.bundle) {
+								loadBundle(update.bundle.entry, update.bundle.css);
+							}
+						},
+					);
+				} catch (e) {
+					console.warn("[Bifrost] Failed to subscribe to app updates:", e);
+				}
+			})();
+		}
 
 		return () => {
 			controller.abort();


### PR DESCRIPTION
## Summary
- gate app draft websocket rebuild subscriptions behind preview mode
- keep published app routes from reacting to draft bundle rebuild events
- add a regression test for live-mode subscription behavior

## Validation
- ./test.sh client unit src/components/jsx-app/BundledAppShell.test.tsx
- ./test.sh client unit
- cd client && npm run tsc
- cd client && npm run lint (passes with existing FormRenderer react-hooks/incompatible-library warning)
- Playwright debug-stack validation: preview subscribed to app:draft and hot-reloaded; live route did not subscribe and stayed on published content