### PR TITLE
Improve auth exit actions

### DIFF
--- a/client/src/components/NoAccess.test.tsx
+++ b/client/src/components/NoAccess.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+
+const mockLogout = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({
+		logout: mockLogout,
+	}),
+}));
+
+vi.mock("react-router-dom", async () => {
+	const actual = await vi.importActual<typeof import("react-router-dom")>(
+		"react-router-dom",
+	);
+	return { ...actual, useNavigate: () => mockNavigate };
+});
+
+import { NoAccess } from "./NoAccess";
+
+beforeEach(() => {
+	mockLogout.mockReset();
+	mockNavigate.mockReset();
+});
+
+describe("NoAccess", () => {
+	it("lets the user return to the dashboard", async () => {
+		const { user } = renderWithProviders(<NoAccess />);
+
+		await user.click(
+			screen.getByRole("button", { name: /return to dashboard/i }),
+		);
+
+		expect(mockNavigate).toHaveBeenCalledWith("/");
+	});
+
+	it("keeps sign out available", async () => {
+		const { user } = renderWithProviders(<NoAccess />);
+
+		await user.click(screen.getByRole("button", { name: /sign out/i }));
+
+		expect(mockLogout).toHaveBeenCalledTimes(1);
+	});
+});

--- a/client/src/components/NoAccess.tsx
+++ b/client/src/components/NoAccess.tsx
@@ -1,10 +1,12 @@
-import { ShieldAlert } from "lucide-react";
+import { Home, LogOut, ShieldAlert } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/ui/button";
 
 export function NoAccess() {
 	const { logout } = useAuth();
+	const navigate = useNavigate();
 
 	return (
 		<div className="min-h-screen bg-background flex items-center justify-center p-4">
@@ -19,9 +21,23 @@ export function NoAccess() {
 						contact your administrator if you believe this is an
 						error.
 					</p>
-					<Button onClick={logout} variant="outline" className="mt-6">
-						Sign Out
-					</Button>
+					<div className="mt-6 flex w-full flex-col gap-2">
+						<Button
+							onClick={() => navigate("/")}
+							className="w-full"
+						>
+							<Home className="h-4 w-4" />
+							Return to Dashboard
+						</Button>
+						<Button
+							onClick={logout}
+							variant="ghost"
+							className="w-full"
+						>
+							<LogOut className="h-4 w-4" />
+							Sign Out
+						</Button>
+					</div>
 				</CardContent>
 			</Card>
 		</div>

--- a/client/src/pages/DevicePage.test.tsx
+++ b/client/src/pages/DevicePage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test-utils";
+
+const mockLogout = vi.fn();
+const mockNavigate = vi.fn();
+
+const authState = {
+	isAuthenticated: true,
+	isLoading: false,
+	logout: mockLogout,
+	user: { email: "dev@gobifrost.com" },
+};
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => authState,
+}));
+
+vi.mock("react-router-dom", async () => {
+	const actual = await vi.importActual<typeof import("react-router-dom")>(
+		"react-router-dom",
+	);
+	return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock("@/components/branding/Logo", () => ({
+	Logo: ({ alt = "Bifrost" }: { alt?: string }) => <img alt={alt} />,
+}));
+
+import { DevicePage } from "./DevicePage";
+
+beforeEach(() => {
+	mockLogout.mockReset();
+	mockNavigate.mockReset();
+	localStorage.clear();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("DevicePage", () => {
+	it("lets an authenticated user leave the device-code form", async () => {
+		const { user } = renderWithProviders(<DevicePage />, {
+			initialEntries: ["/device"],
+		});
+
+		expect(screen.getByText(/authorizing as/i)).toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole("button", { name: /return to dashboard/i }),
+		);
+		expect(mockNavigate).toHaveBeenCalledWith("/");
+
+		await user.click(screen.getByRole("button", { name: /sign out/i }));
+		expect(mockLogout).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows dashboard and secondary actions after authorization", async () => {
+		localStorage.setItem("bifrost_access_token", "access-token");
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				status: 200,
+				json: async () => ({}),
+			})) as unknown as typeof fetch,
+		);
+
+		const { user } = renderWithProviders(<DevicePage />, {
+			initialEntries: ["/device"],
+		});
+
+		await user.type(screen.getByLabelText(/device code/i), "abcd1234");
+		await user.click(
+			screen.getByRole("button", { name: /authorize device/i }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText(/cli authorized/i)).toBeInTheDocument();
+		});
+
+		expect(
+			screen.getByRole("button", { name: /return to dashboard/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /authorize another device/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /sign out/i }),
+		).toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole("button", { name: /return to dashboard/i }),
+		);
+		expect(mockNavigate).toHaveBeenCalledWith("/");
+	});
+});

--- a/client/src/pages/DevicePage.tsx
+++ b/client/src/pages/DevicePage.tsx
@@ -18,7 +18,14 @@ import {
 	CardHeader,
 } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Loader2, Terminal, CheckCircle, AlertCircle } from "lucide-react";
+import {
+	Loader2,
+	Terminal,
+	CheckCircle,
+	AlertCircle,
+	Home,
+	LogOut,
+} from "lucide-react";
 import { motion } from "framer-motion";
 import { Logo } from "@/components/branding/Logo";
 import { toast } from "sonner";
@@ -28,7 +35,12 @@ type AuthorizationStep = "input" | "authorized" | "error";
 export function DevicePage() {
 	const navigate = useNavigate();
 	const location = useLocation();
-	const { isAuthenticated, isLoading: authLoading, user } = useAuth();
+	const {
+		isAuthenticated,
+		isLoading: authLoading,
+		logout,
+		user,
+	} = useAuth();
 
 	const [step, setStep] = useState<AuthorizationStep>("input");
 	const [userCode, setUserCode] = useState("");
@@ -128,6 +140,10 @@ export function DevicePage() {
 		setStep("input");
 		setUserCode("");
 		setError(null);
+	};
+
+	const returnHome = () => {
+		navigate("/");
 	};
 
 	if (authLoading) {
@@ -239,6 +255,25 @@ export function DevicePage() {
 										)}
 										Authorize Device
 									</Button>
+
+									<div className="grid gap-2 sm:grid-cols-2">
+										<Button
+											type="button"
+											variant="outline"
+											onClick={returnHome}
+										>
+											<Home className="h-4 w-4" />
+											Return to Dashboard
+										</Button>
+										<Button
+											type="button"
+											variant="ghost"
+											onClick={logout}
+										>
+											<LogOut className="h-4 w-4" />
+											Sign Out
+										</Button>
+									</div>
 								</form>
 							</>
 						)}
@@ -267,13 +302,31 @@ export function DevicePage() {
 									</p>
 								</div>
 
-								<Button
-									variant="outline"
-									className="w-full"
-									onClick={handleReset}
-								>
-									Authorize Another Device
-								</Button>
+								<div className="space-y-2">
+									<Button
+										className="w-full"
+										onClick={returnHome}
+									>
+										<Home className="h-4 w-4" />
+										Return to Dashboard
+									</Button>
+									<Button
+										variant="outline"
+										className="w-full"
+										onClick={handleReset}
+									>
+										<Terminal className="h-4 w-4" />
+										Authorize Another Device
+									</Button>
+									<Button
+										variant="ghost"
+										className="w-full"
+										onClick={logout}
+									>
+										<LogOut className="h-4 w-4" />
+										Sign Out
+									</Button>
+								</div>
 							</motion.div>
 						)}
 
@@ -318,9 +371,18 @@ export function DevicePage() {
 									<Button
 										variant="outline"
 										className="w-full"
-										onClick={() => navigate("/")}
+										onClick={returnHome}
 									>
+										<Home className="h-4 w-4" />
 										Return to Dashboard
+									</Button>
+									<Button
+										variant="ghost"
+										className="w-full"
+										onClick={logout}
+									>
+										<LogOut className="h-4 w-4" />
+										Sign Out
 									</Button>
 								</div>
 							</motion.div>


### PR DESCRIPTION
## Summary
- Add a dashboard exit action to Access Denied using the same stacked action pattern as device-code success
- Add dashboard and sign-out exits across device-code input, success, and error states
- Add focused component tests for Access Denied and DevicePage actions

## Verification
- ./test.sh client unit -- src/components/NoAccess.test.tsx src/pages/DevicePage.test.tsx
- npm run tsc
- npm run lint (existing FormRenderer React Compiler warning only)
- ./test.sh client unit
- ./test.sh client e2e (baseline failures in unrelated custom-claims, entity-logo, execution-detail, invitation, and docs manifest specs; relevant auth/permissions specs passed)