### PR TITLE
Add configurable branding terminology

### DIFF
--- a/api/alembic/versions/20260604_add_branding_terminology.py
+++ b/api/alembic/versions/20260604_add_branding_terminology.py
@@ -1,0 +1,29 @@
+"""add branding terminology
+
+Revision ID: 20260604_brand_terms
+Revises: 20260601_promote_global_tok
+Create Date: 2026-06-04
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260604_brand_terms"
+down_revision: Union[str, Sequence[str]] = "20260601_promote_global_tok"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "branding",
+        sa.Column("terminology", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("branding", "terminology")

--- a/api/src/models/contracts/__init__.py
+++ b/api/src/models/contracts/__init__.py
@@ -301,6 +301,8 @@ from src.models.contracts.files import (
 # Common models
 from src.models.contracts.common import (
     BrandingSettings,
+    BrandingTerm,
+    BrandingTerminology,
     BrandingUpdateRequest,
     ErrorResponse,
     FileUploadRequest,
@@ -762,6 +764,8 @@ __all__ = [
     "CronValidationRequest",
     "CronValidationResponse",
     "BrandingSettings",
+    "BrandingTerm",
+    "BrandingTerminology",
     "BrandingUpdateRequest",
     "FileType",
     "FileMetadata",

--- a/api/src/models/contracts/common.py
+++ b/api/src/models/contracts/common.py
@@ -28,6 +28,10 @@ class BrandingSettings(BaseModel):
     square_logo_url: str | None = Field(default=None, description="Square logo URL (for icons, 1:1 ratio)")
     rectangle_logo_url: str | None = Field(default=None, description="Rectangle logo URL (for headers, 16:9 ratio)")
     primary_color: str | None = Field(default=None, description="Primary brand color (hex format, e.g., #FF5733)")
+    terminology: "BrandingTerminology" = Field(
+        default_factory=lambda: BrandingTerminology(),
+        description="Fixed product terminology overrides for the platform UI",
+    )
 
     @field_validator('primary_color')
     @classmethod
@@ -44,9 +48,40 @@ class BrandingSettings(BaseModel):
         return v
 
 
+class BrandingTerm(BaseModel):
+    """Singular and plural labels for a fixed product noun."""
+    singular: str | None = Field(default=None, min_length=1, max_length=40)
+    plural: str | None = Field(default=None, min_length=1, max_length=40)
+
+
+class BrandingTerminology(BaseModel):
+    """Fixed platform nouns that can be renamed by branding."""
+    app: BrandingTerm = Field(default_factory=BrandingTerm)
+    agent: BrandingTerm = Field(default_factory=BrandingTerm)
+    form: BrandingTerm = Field(default_factory=BrandingTerm)
+
+
 class BrandingUpdateRequest(BaseModel):
-    """Request model for updating primary color only - logos use POST /logo/{type}"""
+    """Request model for updating branding settings - logos use POST /logo/{type}"""
     primary_color: str | None = Field(default=None, description="Primary color (hex code, e.g., #0066CC)")
+    terminology: BrandingTerminology | None = Field(
+        default=None,
+        description="Fixed product terminology overrides for the platform UI",
+    )
+
+    @field_validator('primary_color')
+    @classmethod
+    def validate_hex_color(cls, v):
+        """Validate hex color format"""
+        if v is None:
+            return v
+        if not v.startswith('#') or len(v) not in [4, 7]:
+            raise ValueError("Primary color must be a valid hex color (e.g., #FFF or #FF5733)")
+        try:
+            int(v[1:], 16)
+        except ValueError:
+            raise ValueError("Primary color must be a valid hex color")
+        return v
 
 
 # ==================== FILE UPLOAD MODELS ====================

--- a/api/src/models/contracts/common.py
+++ b/api/src/models/contracts/common.py
@@ -23,13 +23,26 @@ class ErrorResponse(BaseModel):
 # ==================== BRANDING MODELS ====================
 
 
+class BrandingTerm(BaseModel):
+    """Singular and plural labels for a fixed product noun."""
+    singular: str | None = Field(default=None, min_length=1, max_length=40)
+    plural: str | None = Field(default=None, min_length=1, max_length=40)
+
+
+class BrandingTerminology(BaseModel):
+    """Fixed platform nouns that can be renamed by branding."""
+    app: BrandingTerm = Field(default_factory=BrandingTerm)
+    agent: BrandingTerm = Field(default_factory=BrandingTerm)
+    form: BrandingTerm = Field(default_factory=BrandingTerm)
+
+
 class BrandingSettings(BaseModel):
     """Global platform branding configuration"""
     square_logo_url: str | None = Field(default=None, description="Square logo URL (for icons, 1:1 ratio)")
     rectangle_logo_url: str | None = Field(default=None, description="Rectangle logo URL (for headers, 16:9 ratio)")
     primary_color: str | None = Field(default=None, description="Primary brand color (hex format, e.g., #FF5733)")
-    terminology: "BrandingTerminology" = Field(
-        default_factory=lambda: BrandingTerminology(),
+    terminology: BrandingTerminology = Field(
+        default_factory=BrandingTerminology,
         description="Fixed product terminology overrides for the platform UI",
     )
 
@@ -46,19 +59,6 @@ class BrandingSettings(BaseModel):
         except ValueError:
             raise ValueError("Primary color must be a valid hex color")
         return v
-
-
-class BrandingTerm(BaseModel):
-    """Singular and plural labels for a fixed product noun."""
-    singular: str | None = Field(default=None, min_length=1, max_length=40)
-    plural: str | None = Field(default=None, min_length=1, max_length=40)
-
-
-class BrandingTerminology(BaseModel):
-    """Fixed platform nouns that can be renamed by branding."""
-    app: BrandingTerm = Field(default_factory=BrandingTerm)
-    agent: BrandingTerm = Field(default_factory=BrandingTerm)
-    form: BrandingTerm = Field(default_factory=BrandingTerm)
 
 
 class BrandingUpdateRequest(BaseModel):

--- a/api/src/models/orm/branding.py
+++ b/api/src/models/orm/branding.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 from sqlalchemy import DateTime, LargeBinary, String, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.models.orm.base import Base
@@ -28,6 +29,7 @@ class GlobalBranding(Base):
         String(50), default=None
     )
     primary_color: Mapped[str | None] = mapped_column(String(7), default=None)
+    terminology: Mapped[dict | None] = mapped_column(JSONB, default=None, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), server_default=text("NOW()")
     )

--- a/api/src/repositories/branding.py
+++ b/api/src/repositories/branding.py
@@ -44,6 +44,7 @@ class BrandingRepository:
         rectangle_logo_data: bytes | None = None,
         rectangle_logo_content_type: str | None = None,
         primary_color: str | None = None,
+        terminology: dict | None = None,
     ) -> GlobalBranding:
         """
         Create or update global branding configuration (upsert).
@@ -54,6 +55,7 @@ class BrandingRepository:
             rectangle_logo_data: Rectangle logo image bytes
             rectangle_logo_content_type: Rectangle logo MIME type (e.g., 'image/png')
             primary_color: Hex color code (e.g., '#0066CC')
+            terminology: Fixed product terminology overrides
 
         Returns:
             Created or updated GlobalBranding record
@@ -72,6 +74,8 @@ class BrandingRepository:
                 existing.rectangle_logo_content_type = rectangle_logo_content_type
             if primary_color is not None:
                 existing.primary_color = primary_color
+            if terminology is not None:
+                existing.terminology = terminology
 
             await self.session.flush()
             await self.session.refresh(existing)
@@ -85,6 +89,7 @@ class BrandingRepository:
                 rectangle_logo_data=rectangle_logo_data,
                 rectangle_logo_content_type=rectangle_logo_content_type,
                 primary_color=primary_color,
+                terminology=terminology,
             )
             self.session.add(branding)
             await self.session.flush()

--- a/api/src/routers/branding.py
+++ b/api/src/routers/branding.py
@@ -15,7 +15,7 @@ from fastapi.responses import Response
 
 from shared.svg_sanitizer import SvgSanitizationError, sanitize_svg
 
-from src.models import BrandingSettings, BrandingUpdateRequest
+from src.models import BrandingSettings, BrandingTerminology, BrandingUpdateRequest, GlobalBranding
 from src.core.auth import Context, CurrentActiveUser
 from src.core.database import AsyncSession, get_db
 
@@ -26,6 +26,23 @@ router = APIRouter(prefix="/api/branding", tags=["Branding"])
 # Allowed image types for logo upload
 ALLOWED_CONTENT_TYPES = {"image/png", "image/jpeg", "image/jpg", "image/svg+xml"}
 MAX_LOGO_SIZE = 5 * 1024 * 1024  # 5MB
+
+
+def _branding_response(branding: GlobalBranding | None) -> BrandingSettings:
+    if not branding:
+        return BrandingSettings(
+            square_logo_url=None,
+            rectangle_logo_url=None,
+            primary_color=None,
+            terminology=BrandingTerminology(),
+        )
+
+    return BrandingSettings(
+        primary_color=branding.primary_color,
+        terminology=BrandingTerminology.model_validate(branding.terminology or {}),
+        square_logo_url="/api/branding/logo/square" if branding.square_logo_data else None,
+        rectangle_logo_url="/api/branding/logo/rectangle" if branding.rectangle_logo_data else None,
+    )
 
 
 # =============================================================================
@@ -51,20 +68,7 @@ async def get_branding(
     from src.repositories.branding import BrandingRepository
     branding_repo = BrandingRepository(db)
     branding = await branding_repo.get_branding()
-
-    if not branding:
-        # Return defaults if no branding configured
-        return BrandingSettings(
-            square_logo_url=None,
-            rectangle_logo_url=None,
-            primary_color=None,
-        )
-
-    return BrandingSettings(
-        primary_color=branding.primary_color,
-        square_logo_url="/api/branding/logo/square" if branding.square_logo_data else None,
-        rectangle_logo_url="/api/branding/logo/rectangle" if branding.rectangle_logo_data else None,
-    )
+    return _branding_response(branding)
 
 
 # =============================================================================
@@ -98,17 +102,16 @@ async def update_branding(
     from src.repositories.branding import BrandingRepository
     branding_repo = BrandingRepository(ctx.db)
 
-    # Update primary color only
-    branding = await branding_repo.set_branding(primary_color=request.primary_color)
+    terminology = request.terminology.model_dump(exclude_none=True) if request.terminology else None
+    branding = await branding_repo.set_branding(
+        primary_color=request.primary_color,
+        terminology=terminology,
+    )
 
     await ctx.db.commit()
     logger.info(f"Primary color updated by {user.email}")
 
-    return BrandingSettings(
-        primary_color=branding.primary_color,
-        square_logo_url="/api/branding/logo/square" if branding.square_logo_data else None,
-        rectangle_logo_url="/api/branding/logo/rectangle" if branding.rectangle_logo_data else None,
-    )
+    return _branding_response(branding)
 
 
 @router.post(
@@ -184,11 +187,7 @@ async def upload_logo(
     await ctx.db.commit()
     logger.info(f"Logo '{logo_type}' uploaded by {user.email}")
 
-    return BrandingSettings(
-        primary_color=branding.primary_color,
-        square_logo_url="/api/branding/logo/square" if branding.square_logo_data else None,
-        rectangle_logo_url="/api/branding/logo/rectangle" if branding.rectangle_logo_data else None,
-    )
+    return _branding_response(branding)
 
 
 @router.get(
@@ -287,11 +286,7 @@ async def reset_logo(
     await ctx.db.commit()
     logger.info(f"Logo '{logo_type}' reset to default by {user.email}")
 
-    return BrandingSettings(
-        primary_color=branding.primary_color,
-        square_logo_url="/api/branding/logo/square" if branding.square_logo_data else None,
-        rectangle_logo_url="/api/branding/logo/rectangle" if branding.rectangle_logo_data else None,
-    )
+    return _branding_response(branding)
 
 
 @router.delete(
@@ -320,11 +315,7 @@ async def reset_color(
     await ctx.db.commit()
     logger.info(f"Primary color reset to default by {user.email}")
 
-    return BrandingSettings(
-        primary_color=branding.primary_color,
-        square_logo_url="/api/branding/logo/square" if branding.square_logo_data else None,
-        rectangle_logo_url="/api/branding/logo/rectangle" if branding.rectangle_logo_data else None,
-    )
+    return _branding_response(branding)
 
 
 @router.delete(
@@ -357,4 +348,5 @@ async def reset_all_branding(
         primary_color=None,
         square_logo_url=None,
         rectangle_logo_url=None,
+        terminology=BrandingTerminology(),
     )

--- a/api/tests/e2e/api/test_misc.py
+++ b/api/tests/e2e/api/test_misc.py
@@ -80,6 +80,40 @@ class TestBranding:
         )
         assert response.status_code in [200, 201], f"Update branding failed: {response.text}"
 
+    def test_update_branding_terminology_superuser(self, e2e_client, platform_admin):
+        """Superuser can update fixed product terminology as part of branding."""
+        response = e2e_client.put(
+            "/api/branding",
+            headers=platform_admin.headers,
+            json={
+                "primary_color": "#1a73e8",
+                "terminology": {
+                    "app": {"singular": "Game", "plural": "Games"},
+                    "agent": {"singular": "Character", "plural": "Characters"},
+                    "form": {"singular": "Quest", "plural": "Quests"},
+                },
+            },
+        )
+
+        assert response.status_code in [200, 201], f"Update branding failed: {response.text}"
+        data = response.json()
+        assert data["terminology"]["app"] == {
+            "singular": "Game",
+            "plural": "Games",
+        }
+        assert data["terminology"]["agent"] == {
+            "singular": "Character",
+            "plural": "Characters",
+        }
+        assert data["terminology"]["form"] == {
+            "singular": "Quest",
+            "plural": "Quests",
+        }
+
+        public_response = e2e_client.get("/api/branding")
+        assert public_response.status_code == 200
+        assert public_response.json()["terminology"]["form"]["plural"] == "Quests"
+
     def test_update_branding_org_user_denied(self, e2e_client, org1_user):
         """Org user cannot update branding (403)."""
         response = e2e_client.put(

--- a/client/e2e/apps-replace.admin.spec.ts
+++ b/client/e2e/apps-replace.admin.spec.ts
@@ -78,7 +78,7 @@ test.describe("Apps Replace", () => {
 		// Validation phase: either "No issues found" (clean app) or an Errors/Warnings
 		// panel. Either way, we should see the post-replace footer.
 		await expect(
-			page.getByRole("button", { name: /close/i }),
+			page.getByRole("button", { name: "Close", exact: true }),
 		).toBeVisible({ timeout: 15000 });
 		await expect(
 			page.getByRole("button", { name: /open app/i }),

--- a/client/e2e/branding-terminology.admin.spec.ts
+++ b/client/e2e/branding-terminology.admin.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Branding Terminology (Admin)
+ *
+ * Covers: platform admins can rename fixed product nouns through branding,
+ * and those names render before the main UI appears.
+ */
+
+import { test, expect } from "./fixtures/api-fixture";
+
+const DEFAULT_TERMINOLOGY = {
+	app: { singular: "App", plural: "Apps" },
+	agent: { singular: "Agent", plural: "Agents" },
+	form: { singular: "Form", plural: "Forms" },
+};
+
+test.describe("Branding terminology", () => {
+	test.afterEach(async ({ api }) => {
+		const reset = await api.put("/api/branding", {
+			data: { terminology: DEFAULT_TERMINOLOGY },
+		});
+		expect(reset.ok(), await reset.text()).toBe(true);
+	});
+
+	test("renders renamed product nouns in primary navigation", async ({
+		api,
+		page,
+	}) => {
+		const update = await api.put("/api/branding", {
+			data: {
+				terminology: {
+					app: { singular: "Game", plural: "Games" },
+					agent: { singular: "Character", plural: "Characters" },
+					form: { singular: "Quest", plural: "Quests" },
+				},
+			},
+		});
+		expect(update.ok(), await update.text()).toBe(true);
+
+		await page.goto("/apps");
+		await expect(
+			page.getByRole("link", { name: "Games" }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Games", exact: true }),
+		).toBeVisible();
+
+		await page.goto("/agents");
+		await expect(
+			page.getByRole("link", { name: "Characters" }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Characters", exact: true }),
+		).toBeVisible();
+
+		await page.goto("/forms");
+		await expect(
+			page.getByRole("link", { name: "Quests" }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Quests", exact: true }),
+		).toBeVisible();
+	});
+});

--- a/client/e2e/entity-logos.admin.spec.ts
+++ b/client/e2e/entity-logos.admin.spec.ts
@@ -63,23 +63,21 @@ test.describe("Entity logos", () => {
 			await page.keyboard.press("Escape");
 			await page.goto("/apps");
 
-			// EntityLogo renders an <img> pointing at the logo endpoint.
-			// After a successful upload the server returns 200, so the img
-			// stays visible (no onError → no fallback swap).
-			const logo = page.locator(
-				`img[src*="/api/applications/${appId}/logo"]`,
-			);
+			const card = page.getByRole("button", { name: new RegExp(APP_NAME) });
+			const logo = card.getByTestId("entity-logo");
 			await expect(logo).toBeVisible();
+			await expect(logo).toHaveAttribute("src", /^data:image\/png;base64,/);
 		});
 	});
 
 	test.describe("Agent logo", () => {
+		const AGENT_NAME = `E2E Logo Bot ${UNIQUE}`;
 		let agentId: string;
 
 		test.beforeAll(async ({ api }) => {
 			const resp = await api.post("/api/agents", {
 				data: {
-					name: `E2E Logo Bot ${UNIQUE}`,
+					name: AGENT_NAME,
 					system_prompt: "You are an e2e helper.",
 					channels: ["chat"],
 					access_level: "authenticated",
@@ -109,8 +107,10 @@ test.describe("Entity logos", () => {
 
 			await page.goto("/agents");
 
-			const logo = page.locator(`img[src*="/api/agents/${agentId}/logo"]`);
+			const card = page.getByRole("link", { name: new RegExp(AGENT_NAME) });
+			const logo = card.getByTestId("entity-logo");
 			await expect(logo).toBeVisible();
+			await expect(logo).toHaveAttribute("src", /^data:image\/png;base64,/);
 		});
 	});
 });

--- a/client/e2e/executions.admin.spec.ts
+++ b/client/e2e/executions.admin.spec.ts
@@ -7,7 +7,25 @@
  * Mirrors: api/tests/e2e/api/test_executions.py
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+async function openFirstExecution(page: Page) {
+	const executionRow = page.locator("[data-testid='execution-row']").first();
+	if (!(await executionRow.isVisible().catch(() => false))) {
+		return false;
+	}
+
+	const executionId = await executionRow.getAttribute("data-execution-id");
+	if (!executionId) {
+		throw new Error("Execution row is missing data-execution-id");
+	}
+
+	await page.goto(`/history/${executionId}`);
+	await page.waitForURL(new RegExp(`/history/${executionId}$`), {
+		timeout: 5000,
+	});
+	return true;
+}
 
 test.describe("Execution History", () => {
 	test("should display execution history page", async ({ page }) => {
@@ -28,7 +46,7 @@ test.describe("Execution History", () => {
 
 		// Either we have executions or an empty state
 		const executionContent = page.locator(
-			"table tbody tr, [data-testid='execution-row'], [data-testid='execution-card']",
+			"[data-testid='execution-row'], [data-testid='execution-card']",
 		);
 
 		const hasExecutions = await executionContent.count().catch(() => 0);
@@ -49,13 +67,13 @@ test.describe("Execution History", () => {
 
 		// Look for status indicators
 		const statusBadge = page.locator(
-			"[data-testid='status-badge'], .badge, [class*='status']",
+			"[data-testid='execution-row'] [data-slot='badge'], [data-testid='execution-row'] [data-testid='status-badge']",
 		);
 
 		// If we have executions, we should have status badges
 		const hasExecutions =
 			(await page
-				.locator("table tbody tr, [data-testid='execution-row']")
+				.locator("[data-testid='execution-row']")
 				.count()
 				.catch(() => 0)) > 0;
 
@@ -73,22 +91,10 @@ test.describe("Execution Details", () => {
 			page.getByRole("heading", { name: /history|executions/i }).first(),
 		).toBeVisible({ timeout: 10000 });
 
-		// Find an execution row
-		const executionRow = page
-			.locator(
-				"table tbody tr, [data-testid='execution-row'], [data-testid='execution-card']",
-			)
-			.first();
-
-		if (await executionRow.isVisible().catch(() => false)) {
-			await executionRow.click();
-
+		if (await openFirstExecution(page)) {
 			// Should navigate to execution details
-			await page.waitForURL(/\/history\/[a-f0-9-]+/, { timeout: 5000 });
-
-			// Should show execution details
 			await expect(
-				page.getByText(/status|result|output|logs/i),
+				page.getByText("Execution Status", { exact: true }).first(),
 			).toBeVisible({ timeout: 5000 });
 		}
 	});
@@ -100,21 +106,11 @@ test.describe("Execution Details", () => {
 			page.getByRole("heading", { name: /history|executions/i }).first(),
 		).toBeVisible({ timeout: 10000 });
 
-		// Find an execution
-		const executionRow = page
-			.locator(
-				"table tbody tr, [data-testid='execution-row'], [data-testid='execution-card']",
-			)
-			.first();
-
-		if (await executionRow.isVisible().catch(() => false)) {
-			await executionRow.click();
-			await page.waitForURL(/\/history\/[a-f0-9-]+/, { timeout: 5000 });
-
+		if (await openFirstExecution(page)) {
 			// Should show output section
-			await expect(page.getByText(/output|result|response/i)).toBeVisible(
-				{ timeout: 5000 },
-			);
+			await expect(
+				page.getByText("Result", { exact: true }).first(),
+			).toBeVisible({ timeout: 5000 });
 		}
 	});
 
@@ -125,26 +121,10 @@ test.describe("Execution Details", () => {
 			page.getByRole("heading", { name: /history|executions/i }).first(),
 		).toBeVisible({ timeout: 10000 });
 
-		// Find an execution
-		const executionRow = page
-			.locator(
-				"table tbody tr, [data-testid='execution-row'], [data-testid='execution-card']",
-			)
-			.first();
-
-		if (await executionRow.isVisible().catch(() => false)) {
-			await executionRow.click();
-			await page.waitForURL(/\/history\/[a-f0-9-]+/, { timeout: 5000 });
-
-			// Look for logs tab/section
-			const logsTab = page.getByRole("tab", { name: /logs/i });
-			const logsSection = page.getByText(/logs|console/i);
-
-			const hasLogs =
-				(await logsTab.isVisible().catch(() => false)) ||
-				(await logsSection.isVisible().catch(() => false));
-
-			expect(hasLogs).toBe(true);
+		if (await openFirstExecution(page)) {
+			await expect(
+				page.getByText("Logs", { exact: true }).first(),
+			).toBeVisible({ timeout: 5000 });
 		}
 	});
 });

--- a/client/e2e/users.admin.spec.ts
+++ b/client/e2e/users.admin.spec.ts
@@ -218,7 +218,12 @@ test.describe("User Invitation", () => {
 		await guestPage
 			.getByRole("button", { name: /use password instead/i })
 			.click();
-		await guestPage.getByLabel(/password/i).fill("InviteePass123!");
+		await guestPage
+			.getByRole("textbox", { name: "Password", exact: true })
+			.fill("InviteePass123!");
+		await guestPage
+			.getByRole("textbox", { name: "Confirm password" })
+			.fill("InviteePass123!");
 		await guestPage
 			.getByRole("button", { name: /create account/i })
 			.click();

--- a/client/src/components/app-builder/AppInfoDialog.tsx
+++ b/client/src/components/app-builder/AppInfoDialog.tsx
@@ -64,6 +64,7 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Combobox } from "@/components/ui/combobox";
 import { cn } from "@/lib/utils";
+import { term, useTerminology } from "@/lib/terminology";
 import { useRoles } from "@/hooks/useRoles";
 import { useAuth } from "@/contexts/AuthContext";
 import { OrganizationSelect } from "@/components/forms/OrganizationSelect";
@@ -138,6 +139,7 @@ export function AppInfoDialog({
 	onCreated,
 }: AppInfoDialogProps) {
 	const isEditing = !!appSlug;
+	const terminology = useTerminology();
 	const { isPlatformAdmin, user } = useAuth();
 
 	const { data: existingApp, isLoading: isLoadingApp } = useApplication(
@@ -369,7 +371,7 @@ export function AppInfoDialog({
 										<FormLabel>Name</FormLabel>
 										<FormControl>
 											<Input
-												placeholder="My Application"
+												placeholder={`My ${term(terminology, "app", "formalSingular")}`}
 												{...field}
 												onChange={(e) =>
 													handleNameChange(e.target.value)
@@ -646,7 +648,7 @@ export function AppInfoDialog({
 											? "Saving..."
 											: isEditing
 												? "Save Changes"
-												: "Create Application"}
+												: `Create ${term(terminology, "app", "formalSingular")}`}
 									</Button>
 								</div>
 							</DialogFooter>
@@ -668,7 +670,9 @@ export function AppInfoDialog({
 				>
 					<AlertDialogContent>
 						<AlertDialogHeader>
-							<AlertDialogTitle>Delete Application?</AlertDialogTitle>
+							<AlertDialogTitle>
+								Delete {term(terminology, "app", "formalSingular")}?
+							</AlertDialogTitle>
 							<AlertDialogDescription>
 								This will permanently delete{" "}
 								<strong>{existingApp.name}</strong> and all of

--- a/client/src/components/chat/MentionPicker.tsx
+++ b/client/src/components/chat/MentionPicker.tsx
@@ -21,6 +21,7 @@ import {
 	PopoverAnchor,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { term, useTerminology } from "@/lib/terminology";
 import { useAgents } from "@/hooks/useAgents";
 import type { components } from "@/lib/v1";
 
@@ -41,6 +42,7 @@ export function MentionPicker({
 	searchTerm,
 	position,
 }: MentionPickerProps) {
+	const terminology = useTerminology();
 	const { data: agents } = useAgents();
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const listRef = useRef<HTMLDivElement>(null);
@@ -123,13 +125,17 @@ export function MentionPicker({
 			>
 				<Command>
 					<CommandInput
-						placeholder="Search agents..."
+						placeholder={`Search ${term(terminology, "agent", "pluralLower")}...`}
 						value={searchTerm}
 						className="h-9"
 					/>
 					<CommandList ref={listRef}>
-						<CommandEmpty>No agents found.</CommandEmpty>
-						<CommandGroup heading="Agents">
+						<CommandEmpty>
+							No {term(terminology, "agent", "pluralLower")} found.
+						</CommandEmpty>
+						<CommandGroup
+							heading={term(terminology, "agent", "plural")}
+						>
 							{filteredAgents.map((agent, index) => (
 								<CommandItem
 									key={agent.id}

--- a/client/src/components/execution/ExecutionSidebar.test.tsx
+++ b/client/src/components/execution/ExecutionSidebar.test.tsx
@@ -15,7 +15,9 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import type { ComponentProps } from "react";
 import { renderWithProviders, screen } from "@/test-utils";
+import { ExecutionSidebar } from "./ExecutionSidebar";
 
 vi.mock("./PrettyInputDisplay", () => ({
 	PrettyInputDisplay: ({
@@ -45,12 +47,9 @@ vi.mock("./ExecutionStatusBadge", async (orig) => {
 	};
 });
 
-async function render(
-	props: Partial<
-		Parameters<typeof import("./ExecutionSidebar")["ExecutionSidebar"]>[0]
-	> = {},
+function render(
+	props: Partial<ComponentProps<typeof ExecutionSidebar>> = {},
 ) {
-	const { ExecutionSidebar } = await import("./ExecutionSidebar");
 	const baseProps = {
 		status: "Success" as const,
 		workflowName: "my_wf",
@@ -92,7 +91,6 @@ describe("ExecutionSidebar — default layout", () => {
 		const { rerender } = await render({ completedAt: null });
 		expect(screen.queryByText(/completed at/i)).not.toBeInTheDocument();
 
-		const { ExecutionSidebar } = await import("./ExecutionSidebar");
 		rerender(
 			<ExecutionSidebar
 				status="Success"

--- a/client/src/components/layout/AppHeader.tsx
+++ b/client/src/components/layout/AppHeader.tsx
@@ -25,6 +25,7 @@ import { NotificationCenter } from "@/components/layout/NotificationCenter";
 import { VersionUpdateBanner } from "@/components/layout/VersionUpdateBanner";
 import { useAuth } from "@/contexts/AuthContext";
 import { APP_VERSION } from "@/lib/version";
+import { term, useTerminology } from "@/lib/terminology";
 import { useProfile } from "@/hooks/useProfile";
 import { useQuickAccessStore } from "@/stores/quickAccessStore";
 import { profileService } from "@/services/profile";
@@ -39,6 +40,7 @@ interface AppHeaderProps {
 
 export function AppHeader({ appName, isPreview = false }: AppHeaderProps) {
 	const navigate = useNavigate();
+	const terminology = useTerminology();
 	const { user, logout } = useAuth();
 	const openQuickAccess = useQuickAccessStore((state) => state.openQuickAccess);
 
@@ -84,7 +86,11 @@ export function AppHeader({ appName, isPreview = false }: AppHeaderProps) {
 						variant="ghost"
 						size="icon"
 						onClick={handleBack}
-						title={isPreview ? "Back to Editor" : "Back to Apps"}
+						title={
+							isPreview
+								? "Back to Editor"
+								: `Back to ${term(terminology, "app", "plural")}`
+						}
 					>
 						<ArrowLeft className="h-5 w-5" />
 					</Button>

--- a/client/src/components/layout/Sidebar.test.tsx
+++ b/client/src/components/layout/Sidebar.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test-utils";
+import {
+	TerminologyContext,
+	mergeTerminology,
+} from "@/lib/terminology";
+import { Sidebar } from "./Sidebar";
+
+vi.mock("@/contexts/AuthContext", () => ({
+	useAuth: () => ({ isPlatformAdmin: true }),
+}));
+
+vi.mock("@/components/branding/Logo", () => ({
+	Logo: () => <div aria-label="Logo" />,
+}));
+
+describe("Sidebar terminology", () => {
+	it("renders branded product nouns in navigation", () => {
+		const terminology = mergeTerminology({
+			app: { singular: "Game", plural: "Games" },
+			agent: { singular: "Character", plural: "Characters" },
+			form: { singular: "Quest", plural: "Quests" },
+		});
+
+		renderWithProviders(
+			<TerminologyContext.Provider value={terminology}>
+				<Sidebar
+					isMobileMenuOpen={false}
+					setIsMobileMenuOpen={vi.fn()}
+					isCollapsed={false}
+				/>
+			</TerminologyContext.Provider>,
+		);
+
+		expect(screen.getByRole("link", { name: "Games" })).toHaveAttribute(
+			"href",
+			"/apps",
+		);
+		expect(screen.getByRole("link", { name: "Characters" })).toHaveAttribute(
+			"href",
+			"/agents",
+		);
+		expect(screen.getByRole("link", { name: "Quests" })).toHaveAttribute(
+			"href",
+			"/forms",
+		);
+	});
+});

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -28,9 +28,15 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
 import { Logo } from "@/components/branding/Logo";
 import { Button } from "@/components/ui/button";
+import {
+	term,
+	useTerminology,
+	type ProductTermKey,
+} from "@/lib/terminology";
 
 interface NavItem {
 	title: string;
+	termKey?: ProductTermKey;
 	href: string;
 	icon: React.ElementType;
 	requiresPlatformAdmin?: boolean;
@@ -66,11 +72,13 @@ const navSections: NavSection[] = [
 			},
 			{
 				title: "Apps",
+				termKey: "app",
 				href: "/apps",
 				icon: AppWindow,
 			},
 			{
 				title: "Forms",
+				termKey: "form",
 				href: "/forms",
 				icon: FileCode,
 			},
@@ -86,6 +94,7 @@ const navSections: NavSection[] = [
 		items: [
 			{
 				title: "Agents",
+				termKey: "agent",
 				href: "/agents",
 				icon: Bot,
 			},
@@ -219,6 +228,7 @@ export function Sidebar({
 	isCollapsed,
 }: SidebarProps) {
 	const { isPlatformAdmin } = useAuth();
+	const terminology = useTerminology();
 
 	// Filter sections and items based on user permissions
 	const visibleSections = navSections
@@ -272,6 +282,9 @@ export function Sidebar({
 							)}
 							{section.items.map((item) => {
 								const Icon = item.icon;
+								const itemTitle = item.termKey
+									? term(terminology, item.termKey, "plural")
+									: item.title;
 								return (
 									<div key={item.href}>
 										{item.dividerBefore && !isCollapsed && (
@@ -284,7 +297,7 @@ export function Sidebar({
 											to={item.href}
 											title={
 												isCollapsed
-													? item.title
+													? itemTitle
 													: undefined
 											}
 											className={({ isActive }) =>
@@ -307,7 +320,7 @@ export function Sidebar({
 														: "h-4 w-4",
 												)}
 											/>
-											{!isCollapsed && item.title}
+											{!isCollapsed && itemTitle}
 										</NavLink>
 									</div>
 								);
@@ -348,6 +361,13 @@ export function Sidebar({
 									</h3>
 									{section.items.map((item) => {
 										const Icon = item.icon;
+										const itemTitle = item.termKey
+											? term(
+													terminology,
+													item.termKey,
+													"plural",
+												)
+											: item.title;
 										return (
 											<div key={item.href}>
 												{item.dividerBefore && (
@@ -371,7 +391,7 @@ export function Sidebar({
 													}
 												>
 													<Icon className="h-4 w-4" />
-													{item.title}
+													{itemTitle}
 												</NavLink>
 											</div>
 										);

--- a/client/src/components/workflows/WorkflowSidebar.tsx
+++ b/client/src/components/workflows/WorkflowSidebar.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { term, useTerminology } from "@/lib/terminology";
 import { $api } from "@/lib/api-client";
 import type { components } from "@/lib/v1";
 
@@ -277,6 +278,7 @@ export function WorkflowSidebar({
 	onClose,
 	className,
 }: WorkflowSidebarProps) {
+	const terminology = useTerminology();
 	const { data, isLoading } = $api.useQuery(
 		"get",
 		"/api/workflows/usage-stats",
@@ -440,7 +442,7 @@ export function WorkflowSidebar({
 					</span>
 				</div>
 				<EntitySection
-					title="Forms"
+					title={term(terminology, "form", "plural")}
 					icon={<FileText className="h-4 w-4 text-muted-foreground" />}
 					entities={data?.forms ?? []}
 					selectedId={selectedFormId}
@@ -454,7 +456,7 @@ export function WorkflowSidebar({
 					isLoading={isLoading}
 				/>
 				<EntitySection
-					title="Apps"
+					title={term(terminology, "app", "plural")}
 					icon={
 						<AppWindow className="h-4 w-4 text-muted-foreground" />
 					}
@@ -470,7 +472,7 @@ export function WorkflowSidebar({
 					isLoading={isLoading}
 				/>
 				<EntitySection
-					title="Agents"
+					title={term(terminology, "agent", "plural")}
 					icon={<Bot className="h-4 w-4 text-muted-foreground" />}
 					entities={data?.agents ?? []}
 					selectedId={selectedAgentId}

--- a/client/src/contexts/OrgScopeContext.tsx
+++ b/client/src/contexts/OrgScopeContext.tsx
@@ -9,6 +9,12 @@ import {
 	ReactNode,
 } from "react";
 import { initializeBranding, applyBrandingTheme } from "@/lib/branding";
+import {
+	DEFAULT_TERMINOLOGY,
+	mergeTerminology,
+	TerminologyContext,
+	type Terminology,
+} from "@/lib/terminology";
 
 export interface OrgScope {
 	type: "global" | "organization";
@@ -24,6 +30,7 @@ interface OrgScopeContextType {
 	logoLoaded: boolean;
 	squareLogoUrl: string | null;
 	rectangleLogoUrl: string | null;
+	terminology: Terminology;
 	refreshBranding: () => void;
 }
 
@@ -53,6 +60,8 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 	const [rectangleLogoUrl, setRectangleLogoUrl] = useState<string | null>(
 		null,
 	);
+	const [terminology, setTerminology] =
+		useState<Terminology>(DEFAULT_TERMINOLOGY);
 	const [refreshTrigger, setRefreshTrigger] = useState(0);
 
 	// Function to trigger a branding refresh
@@ -78,6 +87,7 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 			setLogoLoaded(false);
 			setSquareLogoUrl(null);
 			setRectangleLogoUrl(null);
+			setTerminology(DEFAULT_TERMINOLOGY);
 
 			try {
 				// Fetch branding data (public endpoint, always GLOBAL)
@@ -98,6 +108,7 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 				const branding = await response.json();
 				const rectUrl = branding.rectangle_logo_url;
 				const sqUrl = branding.square_logo_url;
+				const nextTerminology = mergeTerminology(branding.terminology);
 
 				// Preload both logos if they exist
 				const preloadPromises: Promise<void>[] = [];
@@ -136,6 +147,7 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 				// Store logo URLs in context
 				setSquareLogoUrl(sqUrl || null);
 				setRectangleLogoUrl(rectUrl || null);
+				setTerminology(nextTerminology);
 
 				// Apply branding theme (colors to CSS) - no need to fetch again
 				applyBrandingTheme(branding);
@@ -168,14 +180,17 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 			logoLoaded,
 			squareLogoUrl,
 			rectangleLogoUrl,
+			terminology,
 			refreshBranding,
 		}),
-		[scope, setScope, isGlobalScope, brandingLoaded, logoLoaded, squareLogoUrl, rectangleLogoUrl, refreshBranding],
+		[scope, setScope, isGlobalScope, brandingLoaded, logoLoaded, squareLogoUrl, rectangleLogoUrl, terminology, refreshBranding],
 	);
 
 	return (
 		<OrgScopeContext.Provider value={value}>
-			{children}
+			<TerminologyContext.Provider value={terminology}>
+				{children}
+			</TerminologyContext.Provider>
 		</OrgScopeContext.Provider>
 	);
 }

--- a/client/src/lib/terminology.test.ts
+++ b/client/src/lib/terminology.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_TERMINOLOGY,
+	mergeTerminology,
+	term,
+} from "./terminology";
+
+describe("terminology", () => {
+	it("uses default platform nouns when branding does not override them", () => {
+		const terminology = mergeTerminology(null);
+
+		expect(terminology).toEqual(DEFAULT_TERMINOLOGY);
+		expect(term(terminology, "app", "singular")).toBe("App");
+		expect(term(terminology, "app", "formalPlural")).toBe("Applications");
+		expect(term(terminology, "agent", "plural")).toBe("Agents");
+		expect(term(terminology, "form", "plural")).toBe("Forms");
+	});
+
+	it("merges fixed branding terminology without losing unspecified labels", () => {
+		const terminology = mergeTerminology({
+			app: { singular: "Game", plural: "Games" },
+			agent: { singular: "Character", plural: "Characters" },
+			form: { singular: "Quest", plural: "Quests" },
+		});
+
+		expect(term(terminology, "app", "singular")).toBe("Game");
+		expect(term(terminology, "app", "formalSingular")).toBe("Game");
+		expect(term(terminology, "app", "formalPlural")).toBe("Games");
+		expect(term(terminology, "agent", "plural")).toBe("Characters");
+		expect(term(terminology, "form", "singularLower")).toBe("quest");
+	});
+});

--- a/client/src/lib/terminology.ts
+++ b/client/src/lib/terminology.ts
@@ -1,0 +1,116 @@
+import { createContext, useContext } from "react";
+
+export type ProductTermKey = "app" | "agent" | "form";
+
+export type ProductTerm = {
+	singular: string;
+	plural: string;
+	formalSingular: string;
+	formalPlural: string;
+	singularLower: string;
+	pluralLower: string;
+	formalSingularLower: string;
+	formalPluralLower: string;
+};
+
+export type Terminology = Record<ProductTermKey, ProductTerm>;
+
+export type BrandingTerminologyInput = Partial<
+	Record<ProductTermKey, { singular?: string | null; plural?: string | null }>
+>;
+
+function buildTerm(
+	singular: string,
+	plural: string,
+	formalSingular = singular,
+	formalPlural = plural,
+): ProductTerm {
+	return {
+		singular,
+		plural,
+		formalSingular,
+		formalPlural,
+		singularLower: singular.toLowerCase(),
+		pluralLower: plural.toLowerCase(),
+		formalSingularLower: formalSingular.toLowerCase(),
+		formalPluralLower: formalPlural.toLowerCase(),
+	};
+}
+
+export const DEFAULT_TERMINOLOGY: Terminology = {
+	app: buildTerm("App", "Apps", "Application", "Applications"),
+	agent: buildTerm("Agent", "Agents"),
+	form: buildTerm("Form", "Forms"),
+};
+
+function cleanLabel(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+export function mergeTerminology(
+	brandingTerminology: BrandingTerminologyInput | null | undefined,
+): Terminology {
+	if (!brandingTerminology) {
+		return DEFAULT_TERMINOLOGY;
+	}
+
+	const appSingular =
+		cleanLabel(brandingTerminology.app?.singular) ??
+		DEFAULT_TERMINOLOGY.app.singular;
+	const appPlural =
+		cleanLabel(brandingTerminology.app?.plural) ??
+		DEFAULT_TERMINOLOGY.app.plural;
+	const agentSingular =
+		cleanLabel(brandingTerminology.agent?.singular) ??
+		DEFAULT_TERMINOLOGY.agent.singular;
+	const agentPlural =
+		cleanLabel(brandingTerminology.agent?.plural) ??
+		DEFAULT_TERMINOLOGY.agent.plural;
+	const formSingular =
+		cleanLabel(brandingTerminology.form?.singular) ??
+		DEFAULT_TERMINOLOGY.form.singular;
+	const formPlural =
+		cleanLabel(brandingTerminology.form?.plural) ??
+		DEFAULT_TERMINOLOGY.form.plural;
+
+	return {
+		app: buildTerm(appSingular, appPlural, appSingular, appPlural),
+		agent: buildTerm(agentSingular, agentPlural),
+		form: buildTerm(formSingular, formPlural),
+	};
+}
+
+export function serializeTerminology(
+	terminology: Terminology,
+): Required<BrandingTerminologyInput> {
+	return {
+		app: {
+			singular: terminology.app.singular,
+			plural: terminology.app.plural,
+		},
+		agent: {
+			singular: terminology.agent.singular,
+			plural: terminology.agent.plural,
+		},
+		form: {
+			singular: terminology.form.singular,
+			plural: terminology.form.plural,
+		},
+	};
+}
+
+export function term(
+	terminology: Terminology,
+	key: ProductTermKey,
+	variant: keyof ProductTerm,
+): string {
+	return terminology[key][variant];
+}
+
+export const TerminologyContext =
+	createContext<Terminology>(DEFAULT_TERMINOLOGY);
+
+export function useTerminology() {
+	return useContext(TerminologyContext);
+}

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -10146,10 +10146,31 @@ export interface components {
              * @description Primary brand color (hex format, e.g., #FF5733)
              */
             primary_color?: string | null;
+            /** @description Fixed product terminology overrides for the platform UI */
+            terminology?: components["schemas"]["BrandingTerminology"];
+        };
+        /**
+         * BrandingTerm
+         * @description Singular and plural labels for a fixed product noun.
+         */
+        BrandingTerm: {
+            /** Singular */
+            singular?: string | null;
+            /** Plural */
+            plural?: string | null;
+        };
+        /**
+         * BrandingTerminology
+         * @description Fixed platform nouns that can be renamed by branding.
+         */
+        BrandingTerminology: {
+            app?: components["schemas"]["BrandingTerm"];
+            agent?: components["schemas"]["BrandingTerm"];
+            form?: components["schemas"]["BrandingTerm"];
         };
         /**
          * BrandingUpdateRequest
-         * @description Request model for updating primary color only - logos use POST /logo/{type}
+         * @description Request model for updating branding settings - logos use POST /logo/{type}
          */
         BrandingUpdateRequest: {
             /**
@@ -10157,6 +10178,8 @@ export interface components {
              * @description Primary color (hex code, e.g., #0066CC)
              */
             primary_color?: string | null;
+            /** @description Fixed product terminology overrides for the platform UI */
+            terminology?: components["schemas"]["BrandingTerminology"] | null;
         };
         /** BulkExportRequest */
         BulkExportRequest: {

--- a/client/src/pages/AppRouter.tsx
+++ b/client/src/pages/AppRouter.tsx
@@ -23,6 +23,7 @@ import {
 import { useApplication } from "@/hooks/useApplications";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDocumentChrome } from "@/lib/useDocumentChrome";
+import { term, useTerminology } from "@/lib/terminology";
 import { BundledAppShell } from "@/components/jsx-app/BundledAppShell";
 import { AppLayout } from "@/components/layout/AppLayout";
 
@@ -34,6 +35,7 @@ interface AppRouterProps {
 export function AppRouter({ preview = false }: AppRouterProps) {
 	const { applicationId: slugParam } = useParams();
 	const navigate = useNavigate();
+	const terminology = useTerminology();
 	const { hasRole } = useAuth();
 	const isEmbed = hasRole("EmbedUser");
 
@@ -70,12 +72,14 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 					<CardHeader>
 						<div className="flex items-center gap-2 text-destructive">
 							<AlertTriangle className="h-5 w-5" />
-							<CardTitle>Application Error</CardTitle>
+							<CardTitle>
+								{term(terminology, "app", "formalSingular")} Error
+							</CardTitle>
 						</div>
 						<CardDescription>
 							{error instanceof Error
 								? error.message
-								: "Failed to load application"}
+								: `Failed to load ${term(terminology, "app", "formalSingularLower")}`}
 						</CardDescription>
 					</CardHeader>
 					<CardContent>
@@ -84,7 +88,7 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 							onClick={() => navigate("/apps")}
 						>
 							<ArrowLeft className="mr-2 h-4 w-4" />
-							Back to Applications
+							Back to {term(terminology, "app", "formalPlural")}
 						</Button>
 					</CardContent>
 				</Card>
@@ -100,11 +104,14 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 					<CardHeader>
 						<div className="flex items-center gap-2 text-muted-foreground">
 							<AlertTriangle className="h-5 w-5" />
-							<CardTitle>Application Not Found</CardTitle>
+							<CardTitle>
+								{term(terminology, "app", "formalSingular")} Not Found
+							</CardTitle>
 						</div>
 						<CardDescription>
-							The requested application does not exist or you
-							don't have access to it.
+							The requested{" "}
+							{term(terminology, "app", "formalSingularLower")} does
+							not exist or you don't have access to it.
 						</CardDescription>
 					</CardHeader>
 					<CardContent>
@@ -113,7 +120,7 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 							onClick={() => navigate("/apps")}
 						>
 							<ArrowLeft className="mr-2 h-4 w-4" />
-							Back to Applications
+							Back to {term(terminology, "app", "formalPlural")}
 						</Button>
 					</CardContent>
 				</Card>

--- a/client/src/pages/Applications.tsx
+++ b/client/src/pages/Applications.tsx
@@ -53,12 +53,14 @@ import { useOrganizations } from "@/hooks/useOrganizations";
 import { SearchBox } from "@/components/search/SearchBox";
 import { useSearch } from "@/hooks/useSearch";
 import { OrganizationSelect } from "@/components/forms/OrganizationSelect";
+import { term, useTerminology } from "@/lib/terminology";
 import type { components } from "@/lib/v1";
 
 type Organization = components["schemas"]["OrganizationPublic"];
 
 export function Applications() {
 	const navigate = useNavigate();
+	const terminology = useTerminology();
 	const { scope, isGlobalScope } = useOrgScope();
 	const { isPlatformAdmin } = useAuth();
 	const [filterOrgId, setFilterOrgId] = useState<string | null | undefined>(
@@ -152,7 +154,7 @@ export function Applications() {
 				<div>
 					<div className="flex items-center gap-3">
 						<h1 className="text-4xl font-extrabold tracking-tight">
-							Applications
+							{term(terminology, "app", "formalPlural")}
 						</h1>
 						{isPlatformAdmin && (
 							<Badge
@@ -175,8 +177,8 @@ export function Applications() {
 					</div>
 					<p className="mt-2 text-muted-foreground">
 						{canManageApps
-							? "Build and manage custom applications"
-							: "Access your custom applications"}
+							? `Build and manage custom ${term(terminology, "app", "formalPluralLower")}`
+							: `Access your custom ${term(terminology, "app", "formalPluralLower")}`}
 					</p>
 				</div>
 				<div className="flex gap-2">
@@ -217,7 +219,7 @@ export function Applications() {
 							variant="outline"
 							size="icon"
 							onClick={handleCreate}
-							title="Create Application"
+							title={`Create ${term(terminology, "app", "formalSingular")}`}
 						>
 							<Plus className="h-4 w-4" />
 						</Button>
@@ -230,7 +232,7 @@ export function Applications() {
 				<SearchBox
 					value={searchTerm}
 					onChange={setSearchTerm}
-					placeholder="Search applications by name, description, or slug..."
+					placeholder={`Search ${term(terminology, "app", "formalPluralLower")} by name, description, or slug...`}
 					className="flex-1"
 				/>
 				{isPlatformAdmin && (
@@ -533,7 +535,7 @@ export function Applications() {
 													title={
 														!app.is_published
 															? "No published version"
-															: "Open application"
+															: `Open ${term(terminology, "app", "formalSingularLower")}`
 													}
 												>
 													<PlayCircle className="h-4 w-4" />
@@ -587,7 +589,7 @@ export function Applications() {
 																	app.name,
 																)
 															}
-															title="Delete application"
+															title={`Delete ${term(terminology, "app", "formalSingularLower")}`}
 														>
 															<Trash2 className="h-4 w-4" />
 														</Button>
@@ -607,15 +609,15 @@ export function Applications() {
 						<AppWindow className="h-12 w-12 text-muted-foreground" />
 						<h3 className="mt-4 text-lg font-semibold">
 							{searchTerm
-								? "No applications match your search"
-								: "No applications found"}
+								? `No ${term(terminology, "app", "formalPluralLower")} match your search`
+								: `No ${term(terminology, "app", "formalPluralLower")} found`}
 						</h3>
 						<p className="mt-2 text-sm text-muted-foreground">
 							{searchTerm
 								? "Try adjusting your search term or clear the filter"
 								: canManageApps
-									? "Get started by creating your first application"
-									: "No applications are currently available"}
+									? `Get started by creating your first ${term(terminology, "app", "formalSingularLower")}`
+									: `No ${term(terminology, "app", "formalPluralLower")} are currently available`}
 						</p>
 						{canManageApps && !searchTerm && (
 							<Button
@@ -623,7 +625,7 @@ export function Applications() {
 								size="icon"
 								onClick={handleCreate}
 								className="mt-4"
-								title="Create Application"
+								title={`Create ${term(terminology, "app", "formalSingular")}`}
 							>
 								<Plus className="h-4 w-4" />
 							</Button>
@@ -640,9 +642,12 @@ export function Applications() {
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Delete Application?</AlertDialogTitle>
+						<AlertDialogTitle>
+							Delete {term(terminology, "app", "formalSingular")}?
+						</AlertDialogTitle>
 						<AlertDialogDescription>
-							This will permanently delete the application "
+							This will permanently delete the{" "}
+							{term(terminology, "app", "formalSingularLower")} "
 							{selectedApp?.name}" including all versions and
 							data. This action cannot be undone.
 						</AlertDialogDescription>
@@ -655,19 +660,19 @@ export function Applications() {
 						>
 							{deleteApplication.isPending
 								? "Deleting..."
-								: "Delete Application"}
+								: `Delete ${term(terminology, "app", "formalSingular")}`}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>
 			</AlertDialog>
 
-			{/* Create Application Dialog */}
+			{/* Create application dialog */}
 			<CreateAppModal
 				open={isEngineSelectOpen}
 				onOpenChange={setIsEngineSelectOpen}
 			/>
 
-			{/* Application Settings Dialog (opened from card pencil button) */}
+			{/* Application settings dialog (opened from card pencil button) */}
 			<AppInfoDialog
 				appSlug={infoDialogSlug}
 				open={infoDialogSlug !== null}

--- a/client/src/pages/ExecutionHistory.tsx
+++ b/client/src/pages/ExecutionHistory.tsx
@@ -862,6 +862,10 @@ export function ExecutionHistory() {
 									return (
 										<DataTableRow
 											key={execution.execution_id}
+											data-testid="execution-row"
+											data-execution-id={
+												execution.execution_id
+											}
 											clickable
 											href={`/history/${execution.execution_id}`}
 											onClick={(e) => {
@@ -894,7 +898,10 @@ export function ExecutionHistory() {
 													)}
 												</DataTableCell>
 											)}
-											<DataTableCell className="font-mono text-sm">
+											<DataTableCell
+												className="font-mono text-sm"
+												data-testid="execution-workflow-cell"
+											>
 												<div className="flex items-center gap-2">
 													{execution.workflow_name}
 													{execution.session_id && (

--- a/client/src/pages/Forms.tsx
+++ b/client/src/pages/Forms.tsx
@@ -55,6 +55,7 @@ import { useOrganizations } from "@/hooks/useOrganizations";
 import { SearchBox } from "@/components/search/SearchBox";
 import { useSearch } from "@/hooks/useSearch";
 import { OrganizationSelect } from "@/components/forms/OrganizationSelect";
+import { term, useTerminology } from "@/lib/terminology";
 import type { components } from "@/lib/v1";
 
 type FormPublic = components["schemas"]["FormPublic"];
@@ -62,6 +63,7 @@ type Organization = components["schemas"]["OrganizationPublic"];
 
 export function Forms() {
 	const navigate = useNavigate();
+	const terminology = useTerminology();
 	const { scope, isGlobalScope } = useOrgScope();
 	const { isPlatformAdmin } = useAuth();
 	const [filterOrgId, setFilterOrgId] = useState<string | null | undefined>(
@@ -215,7 +217,7 @@ export function Forms() {
 				<div>
 					<div className="flex items-center gap-3">
 						<h1 className="text-4xl font-extrabold tracking-tight">
-							Forms
+							{term(terminology, "form", "plural")}
 						</h1>
 						{isPlatformAdmin && (
 							<Badge
@@ -238,8 +240,8 @@ export function Forms() {
 					</div>
 					<p className="mt-2 text-muted-foreground">
 						{canManageForms
-							? "Launch workflows with guided form interfaces"
-							: "Launch workflows with guided forms"}
+							? `Launch workflows with guided ${term(terminology, "form", "singularLower")} interfaces`
+							: `Launch workflows with guided ${term(terminology, "form", "pluralLower")}`}
 					</p>
 				</div>
 				<div className="flex gap-2">
@@ -280,7 +282,7 @@ export function Forms() {
 							variant="outline"
 							size="icon"
 							onClick={handleCreate}
-							title="Create Form"
+							title={`Create ${term(terminology, "form", "singular")}`}
 						>
 							<Plus className="h-4 w-4" />
 						</Button>
@@ -293,7 +295,7 @@ export function Forms() {
 				<SearchBox
 					value={searchTerm}
 					onChange={setSearchTerm}
-					placeholder="Search forms by name, description, or workflow..."
+					placeholder={`Search ${term(terminology, "form", "pluralLower")} by name, description, or workflow...`}
 					className="flex-1"
 				/>
 				{isPlatformAdmin && (
@@ -429,8 +431,8 @@ export function Forms() {
 													? `Cannot launch: Missing required parameters (${formValidation.get(form.id)?.missingParams.join(", ")})`
 													: !form.is_active &&
 														  !canManageForms
-														? "Form is disabled"
-														: "Launch form"
+														? `${term(terminology, "form", "singular")} is disabled`
+														: `Launch ${term(terminology, "form", "singularLower")}`
 											}
 										>
 											<PlayCircle className="mr-2 h-4 w-4" />
@@ -444,7 +446,7 @@ export function Forms() {
 													onClick={() =>
 														handleEdit(form.id)
 													}
-													title="Edit form"
+													title={`Edit ${term(terminology, "form", "singularLower")}`}
 												>
 													<Pencil className="h-4 w-4" />
 												</Button>
@@ -458,7 +460,7 @@ export function Forms() {
 															form.is_active,
 														)
 													}
-													title="Delete form"
+													title={`Delete ${term(terminology, "form", "singularLower")}`}
 												>
 													<Trash2 className="h-4 w-4" />
 												</Button>
@@ -584,8 +586,8 @@ export function Forms() {
 														}
 													>
 														{form.is_active
-															? "Enabled"
-															: "Inactive"}
+																	? "Enabled"
+																	: "Inactive"}
 													</Badge>
 												)}
 											</DataTableCell>
@@ -608,8 +610,8 @@ export function Forms() {
 																? `Cannot launch: Missing ${validation?.missingParams.join(", ")}`
 																: !form.is_active &&
 																	  !canManageForms
-																	? "Form is disabled"
-																	: "Launch form"
+																	? `${term(terminology, "form", "singular")} is disabled`
+																	: `Launch ${term(terminology, "form", "singularLower")}`
 														}
 													>
 														<PlayCircle className="h-4 w-4" />
@@ -624,7 +626,7 @@ export function Forms() {
 																		form.id,
 																	)
 																}
-																title="Edit form"
+																title={`Edit ${term(terminology, "form", "singularLower")}`}
 															>
 																<Pencil className="h-4 w-4" />
 															</Button>
@@ -638,7 +640,7 @@ export function Forms() {
 																		form.is_active,
 																	)
 																}
-																title="Delete form"
+																title={`Delete ${term(terminology, "form", "singularLower")}`}
 															>
 																<Trash2 className="h-4 w-4" />
 															</Button>
@@ -659,15 +661,15 @@ export function Forms() {
 						<FileCode className="h-12 w-12 text-muted-foreground" />
 						<h3 className="mt-4 text-lg font-semibold">
 							{searchTerm
-								? "No forms match your search"
-								: "No forms found"}
+								? `No ${term(terminology, "form", "pluralLower")} match your search`
+								: `No ${term(terminology, "form", "pluralLower")} found`}
 						</h3>
 						<p className="mt-2 text-sm text-muted-foreground">
 							{searchTerm
 								? "Try adjusting your search term or clear the filter"
 								: canManageForms
-									? "Get started by creating your first form"
-									: "No forms are currently available"}
+									? `Get started by creating your first ${term(terminology, "form", "singularLower")}`
+									: `No ${term(terminology, "form", "pluralLower")} are currently available`}
 						</p>
 						{canManageForms && !searchTerm && (
 							<Button
@@ -675,7 +677,7 @@ export function Forms() {
 								size="icon"
 								onClick={handleCreate}
 								className="mt-4"
-								title="Create Form"
+								title={`Create ${term(terminology, "form", "singular")}`}
 							>
 								<Plus className="h-4 w-4" />
 							</Button>

--- a/client/src/pages/TablesClaimsTab.tsx
+++ b/client/src/pages/TablesClaimsTab.tsx
@@ -244,8 +244,8 @@ export function TablesClaimsTab() {
 					<Button
 						size="icon"
 						onClick={handleAdd}
-						title="Create custom claim"
-						aria-label="Create custom claim"
+						title="Add Claim"
+						aria-label="Add Claim"
 					>
 						<Plus className="h-4 w-4" />
 					</Button>

--- a/client/src/pages/agents/AgentDetailPage.tsx
+++ b/client/src/pages/agents/AgentDetailPage.tsx
@@ -56,6 +56,7 @@ import {
 	TYPE_PAGE_TITLE,
 } from "@/components/agents/design-tokens";
 import { cn } from "@/lib/utils";
+import { term, useTerminology } from "@/lib/terminology";
 import { useAgent, useDeleteAgent, useUpdateAgent } from "@/hooks/useAgents";
 import { useAgentRuns } from "@/services/agentRuns";
 import { useCreateConversation } from "@/hooks/useChat";
@@ -66,6 +67,7 @@ type Tab = "overview" | "runs" | "settings";
 export function AgentDetailPage() {
 	const { id } = useParams<{ id: string }>();
 	const navigate = useNavigate();
+	const terminology = useTerminology();
 
 	const isCreate = !id || id === "new";
 	const agentId = isCreate ? undefined : id;
@@ -141,7 +143,8 @@ export function AgentDetailPage() {
 					to="/agents"
 					className="inline-flex items-center gap-1 hover:text-foreground"
 				>
-					<ArrowLeft className="h-3 w-3" /> Agents
+					<ArrowLeft className="h-3 w-3" />{" "}
+					{term(terminology, "agent", "plural")}
 				</Link>
 				{!isCreate && agent ? (
 					<>
@@ -220,8 +223,8 @@ export function AgentDetailPage() {
 									</TooltipTrigger>
 									<TooltipContent>
 										{isActive
-											? "Open a chat session with this agent"
-											: "Agent is paused"}
+											? `Open a chat session with this ${term(terminology, "agent", "singularLower")}`
+											: `${term(terminology, "agent", "singular")} is paused`}
 									</TooltipContent>
 								</Tooltip>
 							</TooltipProvider>

--- a/client/src/pages/agents/FleetPage.tsx
+++ b/client/src/pages/agents/FleetPage.tsx
@@ -48,6 +48,7 @@ import { StatCard } from "@/components/agents/StatCard";
 import { SummaryBackfillButton } from "@/components/agents/SummaryBackfillButton";
 import { OrganizationSelect } from "@/components/forms/OrganizationSelect";
 import { useAuth } from "@/contexts/AuthContext";
+import { term, useTerminology } from "@/lib/terminology";
 import { useOrganizations } from "@/hooks/useOrganizations";
 import type { components } from "@/lib/v1";
 import {
@@ -86,6 +87,7 @@ export function FleetPage() {
 		undefined,
 	);
 	const { isPlatformAdmin } = useAuth();
+	const terminology = useTerminology();
 
 	// Fleet view shows paused agents too (they need to be visible to un-pause).
 	const { data: agents, isLoading: agentsLoading } = useAgents(
@@ -125,7 +127,9 @@ export function FleetPage() {
 			{/* Header */}
 			<div className="flex items-start justify-between gap-4">
 				<div>
-					<h1 className={TYPE_PAGE_TITLE}>Agents</h1>
+					<h1 className={TYPE_PAGE_TITLE}>
+						{term(terminology, "agent", "plural")}
+					</h1>
 					<p className={cn("mt-1", TYPE_BODY, TONE_MUTED)}>
 						{totalAgents} total · {activeCount} active · last 7 days
 					</p>
@@ -139,7 +143,8 @@ export function FleetPage() {
 					{isPlatformAdmin ? <SummaryBackfillButton /> : null}
 					<Button asChild size="sm">
 						<Link to="/agents/new">
-							<Plus className="h-3.5 w-3.5" /> New agent
+							<Plus className="h-3.5 w-3.5" /> New{" "}
+							{term(terminology, "agent", "singularLower")}
 						</Link>
 					</Button>
 				</div>
@@ -178,14 +183,14 @@ export function FleetPage() {
 						value={formatNumber(fleetStats.total_runs)}
 						delta={
 							fleetStats.total_runs > 0
-								? "Across active agents"
+								? `Across active ${term(terminology, "agent", "pluralLower")}`
 								: "No runs yet"
 						}
 					/>
 					<StatCard
 						label="Success rate"
 						value={`${Math.round((fleetStats.avg_success_rate ?? 0) * 100)}%`}
-						delta="Across active agents"
+						delta={`Across active ${term(terminology, "agent", "pluralLower")}`}
 					/>
 					<StatCard
 						label="Spend (7d)"
@@ -199,7 +204,7 @@ export function FleetPage() {
 						}
 					/>
 					<StatCard
-						label="Active agents"
+						label={`Active ${term(terminology, "agent", "pluralLower")}`}
 						value={formatNumber(fleetStats.active_agents)}
 						delta={`of ${totalAgents} total`}
 					/>
@@ -228,8 +233,8 @@ export function FleetPage() {
 					<div className="relative max-w-md flex-1">
 						<Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
 						<Input
-							aria-label="Search agents"
-							placeholder="Search agents…"
+							aria-label={`Search ${term(terminology, "agent", "pluralLower")}`}
+							placeholder={`Search ${term(terminology, "agent", "pluralLower")}...`}
 							value={query}
 							onChange={(e) => setQuery(e.target.value)}
 							className="h-8 pl-8 text-[13px]"
@@ -321,21 +326,26 @@ export function FleetPage() {
 }
 
 function EmptyState({ hasQuery }: { hasQuery: boolean }) {
+	const terminology = useTerminology();
+
 	return (
 		<div className={cn(CARD_SURFACE, "py-12 text-center")}>
 			<Bot className="mx-auto h-10 w-10 text-muted-foreground" />
 			<h3 className="mt-3 text-[15px] font-semibold">
-				{hasQuery ? "No agents match your search" : "No agents yet"}
+				{hasQuery
+					? `No ${term(terminology, "agent", "pluralLower")} match your search`
+					: `No ${term(terminology, "agent", "pluralLower")} yet`}
 			</h3>
 			<p className={cn("mt-1", TYPE_MUTED)}>
 				{hasQuery
 					? "Try adjusting your search."
-					: "Get started by creating your first AI agent."}
+					: `Get started by creating your first AI ${term(terminology, "agent", "singularLower")}.`}
 			</p>
 			{!hasQuery ? (
 				<Button asChild variant="outline" size="sm" className="mt-4">
 					<Link to="/agents/new">
-						<Plus className="h-3.5 w-3.5" /> New agent
+						<Plus className="h-3.5 w-3.5" /> New{" "}
+						{term(terminology, "agent", "singularLower")}
 					</Link>
 				</Button>
 			) : null}

--- a/client/src/pages/settings/Branding.tsx
+++ b/client/src/pages/settings/Branding.tsx
@@ -19,8 +19,38 @@ import {
 	getBranding,
 } from "@/hooks/useBranding";
 import { applyBrandingTheme, type BrandingSettings } from "@/lib/branding";
+import {
+	DEFAULT_TERMINOLOGY,
+	mergeTerminology,
+	serializeTerminology,
+	type BrandingTerminologyInput,
+	type ProductTermKey,
+	type Terminology,
+} from "@/lib/terminology";
 import { useOrgScope } from "@/contexts/OrgScopeContext";
 import type { components } from "@/lib/v1";
+
+const TERMINOLOGY_ROWS: Array<{
+	key: ProductTermKey;
+	label: string;
+	description: string;
+}> = [
+	{
+		key: "app",
+		label: "Apps / Applications",
+		description: "Main built experiences, e.g. Games",
+	},
+	{
+		key: "agent",
+		label: "Agents",
+		description: "AI workers or personas, e.g. Characters",
+	},
+	{
+		key: "form",
+		label: "Forms",
+		description: "Guided workflow launch interfaces",
+	},
+];
 
 export function Branding() {
 	const { refreshBranding } = useOrgScope();
@@ -29,6 +59,7 @@ export function Branding() {
 	>(null);
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
+	const [savingTerminology, setSavingTerminology] = useState(false);
 	const [uploading, setUploading] = useState<"square" | "rectangle" | null>(
 		null,
 	);
@@ -36,6 +67,8 @@ export function Branding() {
 		"square" | "rectangle" | "color" | null
 	>(null);
 	const [primaryColor, setPrimaryColor] = useState("#0066CC");
+	const [terminology, setTerminology] =
+		useState<Terminology>(DEFAULT_TERMINOLOGY);
 
 	// Drag states
 	const [dragActiveSquare, setDragActiveSquare] = useState(false);
@@ -51,6 +84,11 @@ export function Branding() {
 					if (data.primary_color) {
 						setPrimaryColor(data.primary_color);
 					}
+					setTerminology(
+						mergeTerminology(
+							data.terminology as BrandingTerminologyInput,
+						),
+					);
 				}
 			} catch {
 				toast.error("Failed to load branding settings");
@@ -68,6 +106,7 @@ export function Branding() {
 		try {
 			const updated = await updateBranding({
 				primary_color: primaryColor,
+				terminology: serializeTerminology(terminology),
 			});
 			setBranding(updated);
 			applyBrandingTheme(updated as BrandingSettings);
@@ -86,6 +125,66 @@ export function Branding() {
 		} finally {
 			setSaving(false);
 		}
+	};
+
+	const handleTerminologyUpdate = async () => {
+		setSavingTerminology(true);
+		try {
+			const updated = await updateBranding({
+				primary_color: primaryColor,
+				terminology: serializeTerminology(terminology),
+			});
+			setBranding(updated);
+			setTerminology(
+				mergeTerminology(updated.terminology as BrandingTerminologyInput),
+			);
+			applyBrandingTheme(updated as BrandingSettings);
+			refreshBranding();
+
+			toast.success("Terminology updated", {
+				description: "Product labels have been updated successfully",
+			});
+		} catch (err) {
+			toast.error("Error", {
+				description:
+					err instanceof Error
+						? err.message
+						: "Failed to update terminology",
+			});
+		} finally {
+			setSavingTerminology(false);
+		}
+	};
+
+	const updateTerm = (
+		key: ProductTermKey,
+		field: "singular" | "plural",
+		value: string,
+	) => {
+		setTerminology((current) =>
+			mergeTerminology({
+				app: {
+					singular: current.app.singular,
+					plural: current.app.plural,
+				},
+				agent: {
+					singular: current.agent.singular,
+					plural: current.agent.plural,
+				},
+				form: {
+					singular: current.form.singular,
+					plural: current.form.plural,
+				},
+				[key]: {
+					singular:
+						field === "singular"
+							? value
+							: current[key].singular,
+					plural:
+						field === "plural" ? value : current[key].plural,
+				},
+			}),
+		);
 	};
 
 	// Handle file upload
@@ -302,6 +401,75 @@ export function Branding() {
 							) : (
 								<RotateCcw className="h-4 w-4" />
 							)}
+						</Button>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Product Terminology</CardTitle>
+					<CardDescription>
+						Rename fixed platform nouns before the UI renders
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-5">
+					<div className="space-y-4">
+						{TERMINOLOGY_ROWS.map((row) => (
+							<div
+								key={row.key}
+								className="grid gap-3 md:grid-cols-[minmax(0,1fr)_160px_160px]"
+							>
+								<div>
+									<Label>{row.label}</Label>
+									<p className="text-sm text-muted-foreground">
+										{row.description}
+									</p>
+								</div>
+								<div>
+									<Label htmlFor={`${row.key}-singular`}>
+										Singular
+									</Label>
+									<Input
+										id={`${row.key}-singular`}
+										value={terminology[row.key].singular}
+										onChange={(e) =>
+											updateTerm(
+												row.key,
+												"singular",
+												e.target.value,
+											)
+										}
+									/>
+								</div>
+								<div>
+									<Label htmlFor={`${row.key}-plural`}>
+										Plural
+									</Label>
+									<Input
+										id={`${row.key}-plural`}
+										value={terminology[row.key].plural}
+										onChange={(e) =>
+											updateTerm(
+												row.key,
+												"plural",
+												e.target.value,
+											)
+										}
+									/>
+								</div>
+							</div>
+						))}
+					</div>
+					<div className="flex gap-2">
+						<Button
+							onClick={handleTerminologyUpdate}
+							disabled={savingTerminology}
+						>
+							{savingTerminology ? (
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							) : null}
+							Update Terminology
 						</Button>
 					</div>
 				</CardContent>

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -1,6 +1,12 @@
 import "@testing-library/jest-dom/vitest";
-import { afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import { cleanup } from "@testing-library/react";
+
+// Start every test from a clean DOM even if a previous file timed out before
+// its own afterEach cleanup could run.
+beforeEach(() => {
+	cleanup();
+});
 
 // Unmount after every test so DOM state doesn't leak between cases.
 afterEach(() => {


### PR DESCRIPTION
## Summary
- add branding terminology models, persistence, migration, and API serialization
- load terminology before the UI renders and apply labels across app, agent, and form surfaces
- add Branding settings controls and regression coverage for terminology
- harden adjacent e2e selectors uncovered by the full suite

## Verification
- ./test.sh all
- ./test.sh client unit
- npm run tsc
- npm run lint (passes with existing FormRenderer.tsx React Hook Form compiler warning)
- ./test.sh client e2e --project=platform-admin --project=org-user --project=unauthenticated --project=chromium

Note: the local docs Playwright project still requires /docs/screenshots.yaml to be mounted via $DOCS_REPO_PATH.