### PR TITLE
Add editable workflow tool names

### DIFF
--- a/api/bifrost/contracts/workflows.py
+++ b/api/bifrost/contracts/workflows.py
@@ -18,6 +18,12 @@ class WorkflowUpdateRequest(BaseModel):
     access_level: str | None = Field(default=None)
     clear_roles: bool = Field(default=False)
     role_ids: list[str] | None = Field(default=None)
+    name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=200,
+        description="MCP tool name for this workflow. Defaults to the Python function name on registration.",
+    )
     display_name: str | None = Field(default=None, max_length=200)
     description: str | None = Field(default=None, max_length=2000)
     category: str | None = Field(default=None, max_length=100)

--- a/api/bifrost/decorators.py
+++ b/api/bifrost/decorators.py
@@ -144,7 +144,7 @@ def workflow(
             ...
 
     Args:
-        name: Workflow name (defaults to function name)
+        name: Initial MCP tool name (defaults to function name)
         description: Description (defaults to first line of docstring)
         category: Category for organization (default: "General")
         tags: Optional list of tags for filtering

--- a/api/bifrost/manifest.py
+++ b/api/bifrost/manifest.py
@@ -66,7 +66,7 @@ class ManifestRole(BaseModel):
 class ManifestWorkflow(BaseModel):
     """Workflow entry in manifest."""
     id: str = Field(description="Workflow UUID")
-    name: str = Field(default="", description="Workflow display name")
+    name: str = Field(default="", description="MCP tool name; defaults to function_name on registration")
     path: str = Field(description="Relative path to Python file (e.g. 'workflows/onboard.py')")
     function_name: str = Field(description="Python function name decorated with @workflow/@tool/@data_provider")
     type: str = Field(default="workflow", description="workflow | tool | data_provider")

--- a/api/bifrost/workflows.py
+++ b/api/bifrost/workflows.py
@@ -32,7 +32,7 @@ class workflows:
         Returns:
             list[WorkflowMetadata]: List of workflow metadata with attributes:
                 - id: str - Workflow UUID
-                - name: str - Workflow name (snake_case)
+                - name: str - MCP tool name (defaults to function name)
                 - description: str | None - Human-readable description
                 - category: str - Category for organization
                 - tags: list[str] - Tags for categorization

--- a/api/src/models/contracts/workflows.py
+++ b/api/src/models/contracts/workflows.py
@@ -54,9 +54,14 @@ class WorkflowMetadata(BaseModel):
     id: str = Field(..., description="Workflow UUID")
 
     # Required fields
-    name: str = Field(..., min_length=1, max_length=200, description="Human-readable workflow name")
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        description="MCP tool name for this workflow. Defaults to the Python function name on registration.",
+    )
     function_name: str | None = Field(default=None, description="Python function name (for CodeLens registration status)")
-    display_name: str | None = Field(default=None, description="Optional display name for UI (falls back to name if not set)")
+    display_name: str | None = Field(default=None, description="Optional UI display name (falls back to the tool name if not set)")
     description: str | None = Field(default=None, description="Human-readable description")
 
     # Type discriminator - distinguishes workflow/tool/data_provider
@@ -175,7 +180,7 @@ class RegisterWorkflowRequest(BaseModel):
 class RegisterWorkflowResponse(BaseModel):
     """Response model for workflow registration."""
     id: str = Field(..., description="Workflow UUID")
-    name: str = Field(..., description="Workflow name (from decorator or function name)")
+    name: str = Field(..., description="MCP tool name, defaulted from function_name on registration")
     function_name: str = Field(..., description="Python function name")
     path: str = Field(..., description="File path")
     type: str = Field(..., description="Executable type: workflow, tool, or data_provider")
@@ -297,10 +302,16 @@ class WorkflowUpdateRequest(BaseModel):
     )
 
     # New fields for UI management
+    name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=200,
+        description="MCP tool name for this workflow. Defaults to the Python function name on registration."
+    )
     display_name: str | None = Field(
         default=None,
         max_length=200,
-        description="User-facing display name (defaults to code name if not set)"
+        description="Optional UI display name (falls back to the tool name if not set)"
     )
     description: str | None = Field(
         default=None,

--- a/api/src/models/orm/workflows.py
+++ b/api/src/models/orm/workflows.py
@@ -43,9 +43,9 @@ class Workflow(Base):
     __tablename__ = "workflows"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    name: Mapped[str] = mapped_column(String(255), index=True)  # Code-defined name (from decorator)
+    name: Mapped[str] = mapped_column(String(255), index=True)  # MCP tool name, defaulted from function_name
     function_name: Mapped[str] = mapped_column(String(255))  # Actual Python function name
-    display_name: Mapped[str | None] = mapped_column(String(255), default=None)  # User-editable display name (defaults to name if NULL)
+    display_name: Mapped[str | None] = mapped_column(String(255), default=None)  # UI display name; falls back to name
     description: Mapped[str | None] = mapped_column(Text, default=None)
     category: Mapped[str] = mapped_column(String(100), default="General")
 
@@ -146,5 +146,4 @@ class Workflow(Base):
         # Unique constraint on (path, function_name) for ON CONFLICT upserts
         UniqueConstraint("path", "function_name", name="workflows_path_function_key"),
     )
-
 

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -1327,7 +1327,8 @@ async def update_workflow(
     - organization_id: Set to null for global scope, or an org UUID for org-scoped
     - access_level: 'authenticated' or 'role_based'
     - clear_roles: If true, clear all role assignments
-    - display_name: User-facing display name (can be set to null to use code name)
+    - name: MCP tool name (defaults to the Python function name on registration)
+    - display_name: User-facing display name (can be set to null to fall back to name)
     - timeout_seconds: Max execution time (0-86400 seconds, where 0 disables the timeout)
     - execution_mode: 'sync' or 'async'
     - time_saved: Minutes saved per execution (for ROI reporting)
@@ -1430,6 +1431,22 @@ async def update_workflow(
             # Also set to role_based access level (effectively no access)
             workflow.access_level = "role_based"
             logger.info(f"Cleared all role assignments for workflow '{log_safe(workflow.name)}'")
+
+        # Update MCP tool name if provided. ``function_name`` remains the
+        # source-code identity used for path::function references.
+        if "name" in request.model_fields_set:
+            if request.name is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="name cannot be null",
+                )
+            new_name = request.name.strip()
+            if not new_name:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="name cannot be empty",
+                )
+            workflow.name = new_name
 
         # Update display_name if provided
         if "display_name" in request.model_fields_set:

--- a/api/src/sdk/decorators.py
+++ b/api/src/sdk/decorators.py
@@ -72,7 +72,7 @@ def workflow(
             ...
 
     Args:
-        name: Workflow name (defaults to function name)
+        name: Initial MCP tool name (defaults to function name)
         description: Description (defaults to first line of docstring)
         category: Category for organization (default: "General")
         tags: Optional list of tags for filtering

--- a/api/src/services/mcp_server/tools/workflow.py
+++ b/api/src/services/mcp_server/tools/workflow.py
@@ -434,6 +434,7 @@ async def update_workflow(
     access_level: str | None = None,
     clear_roles: bool | None = None,
     role_ids: list[str] | None = None,
+    name: str | None = None,
     description: str | None = None,
     category: str | None = None,
     timeout_seconds: int | None = None,
@@ -446,7 +447,8 @@ async def update_workflow(
     ``workflow_ref`` is a UUID, workflow name, or ``path::func``.
     ``role_ids`` bulk-replaces the workflow's role assignments when supplied
     (an empty list clears them); pair with ``clear_roles=True`` only when no
-    list is provided. Fields marked as UI/code-managed in
+    list is provided. ``name`` is the MCP tool name; ``function_name`` is not
+    changed by this tool. Fields marked as UI/code-managed in
     :data:`bifrost.dto_flags.DTO_EXCLUDES` (``display_name``,
     ``tool_description``, ``time_saved``, ``value``, ``cache_ttl_seconds``,
     ``allowed_methods``, ``execution_mode``, ``disable_global_key``) are not
@@ -476,6 +478,7 @@ async def update_workflow(
             "access_level": access_level,
             "clear_roles": clear_roles,
             "role_ids": role_ids,
+            "name": name,
             "description": description,
             "category": category,
             "timeout_seconds": timeout_seconds,

--- a/api/tests/e2e/api-integration/test_mcp_refresh_after_register.py
+++ b/api/tests/e2e/api-integration/test_mcp_refresh_after_register.py
@@ -156,3 +156,97 @@ def {function_name}(message: str) -> dict:
                 headers=admin_h,
                 params={"path": path},
             )
+
+    def test_updated_workflow_name_replaces_mcp_tool_name_immediately(self):
+        suffix = uuid.uuid4().hex[:8]
+        path = f"workflows/test_mcp_rename_{suffix}.py"
+        function_name = f"test_mcp_rename_{suffix}"
+        renamed_tool_name = f"renamed_tool_{suffix}"
+
+        admin_token = create_test_jwt(is_superuser=True)
+        admin_h = _admin_headers(admin_token)
+        mcp_h = _mcp_headers(admin_token)
+
+        agent_id: str | None = None
+        workflow_id: str | None = None
+        try:
+            file_content = f'''
+from bifrost import tool
+
+@tool
+def {function_name}(message: str) -> dict:
+    """Echoes the message for MCP rename refresh regression coverage."""
+    return {{"message": message}}
+'''
+            write_resp = requests.put(
+                f"{TEST_API_URL}/api/files/editor/content",
+                headers=admin_h,
+                json={"path": path, "content": file_content, "encoding": "utf-8"},
+            )
+            assert write_resp.status_code in (200, 201), write_resp.text
+
+            reg_resp = requests.post(
+                f"{TEST_API_URL}/api/workflows/register",
+                headers=admin_h,
+                json={"path": path, "function_name": function_name},
+            )
+            assert reg_resp.status_code == 201, reg_resp.text
+            reg = reg_resp.json()
+            workflow_id = reg["id"]
+            assert reg["name"] == function_name
+            assert reg["type"] == "tool", reg
+
+            agent_resp = requests.post(
+                f"{TEST_API_URL}/api/agents",
+                headers=admin_h,
+                json={
+                    "name": f"MCP Rename Test Agent {suffix}",
+                    "system_prompt": "Test agent for MCP rename regression",
+                    "channels": ["chat"],
+                    "tool_ids": [workflow_id],
+                },
+            )
+            assert agent_resp.status_code == 201, agent_resp.text
+            agent_id = agent_resp.json()["id"]
+
+            patch_resp = requests.patch(
+                f"{TEST_API_URL}/api/workflows/{workflow_id}",
+                headers=admin_h,
+                json={"name": renamed_tool_name},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            assert patch_resp.json()["name"] == renamed_tool_name
+
+            list_resp = requests.post(
+                f"{TEST_API_URL}/mcp",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list",
+                    "params": {},
+                },
+                headers=mcp_h,
+            )
+            assert list_resp.status_code == 200, list_resp.text
+            payload = list_resp.json()
+            assert "result" in payload, payload
+            tool_names = [t["name"] for t in payload["result"]["tools"]]
+
+            assert renamed_tool_name in tool_names
+            assert function_name not in tool_names
+        finally:
+            if agent_id:
+                requests.delete(
+                    f"{TEST_API_URL}/api/agents/{agent_id}",
+                    headers=admin_h,
+                )
+            if workflow_id:
+                requests.delete(
+                    f"{TEST_API_URL}/api/workflows/{workflow_id}",
+                    headers=admin_h,
+                )
+            requests.delete(
+                f"{TEST_API_URL}/api/files/editor",
+                headers=admin_h,
+                params={"path": path},
+            )

--- a/api/tests/e2e/platform/test_cli_workflows.py
+++ b/api/tests/e2e/platform/test_cli_workflows.py
@@ -185,6 +185,33 @@ class TestCliWorkflows:
         finally:
             _invoke(["--json", "delete", wf_id, "--force"])
 
+    def test_update_name_changes_tool_name_surface(
+        self, cli_client, _invoke, e2e_client, platform_admin
+    ) -> None:
+        """``workflows update <ref> --name ...`` patches the MCP tool name."""
+        fn = f"cli_wf_tool_name_{uuid4().hex[:8]}"
+        wf = _register_workflow(e2e_client, platform_admin, function_name=fn)
+        wf_id = wf["id"]
+        new_name = f"renamed_cli_tool_{uuid4().hex[:8]}"
+
+        try:
+            result = _invoke(
+                [
+                    "--json",
+                    "update",
+                    wf_id,
+                    "--name",
+                    new_name,
+                ]
+            )
+            assert result.exit_code == 0, result.output
+            payload = json.loads(result.output)
+            assert str(payload["id"]) == wf_id
+            assert payload["name"] == new_name
+            assert payload["function_name"] == fn
+        finally:
+            _invoke(["--json", "delete", wf_id, "--force"])
+
     def test_update_by_path_func_ref(
         self, cli_client, _invoke, e2e_client, platform_admin
     ) -> None:

--- a/api/tests/unit/test_sync_ops.py
+++ b/api/tests/unit/test_sync_ops.py
@@ -872,3 +872,36 @@ class TestManifestFieldCoverage:
         assert isinstance(result, list), (
             "_ops_to_issues([]) should return a list"
         )
+
+
+class TestManifestWorkflowImport:
+    """Workflow manifest import preserves the editable tool-name field."""
+
+    def test_resolve_workflow_uses_manifest_name_not_manifest_key(self) -> None:
+        from uuid import UUID
+
+        from bifrost.manifest import ManifestWorkflow
+        from src.models.orm.workflows import Workflow
+        from src.services.manifest_import import ManifestResolver
+        from src.services.sync_ops import Upsert
+
+        wf_id = UUID("11111111-1111-1111-1111-111111111111")
+        mwf = ManifestWorkflow(
+            id=str(wf_id),
+            name="custom_tool_name",
+            path="workflows/custom.py",
+            function_name="python_function_name",
+        )
+        resolver = ManifestResolver(AsyncMock())
+
+        ops = resolver._resolve_workflow(
+            "custom_tool_name",
+            mwf,
+            {"wf_by_natural": {}, "wf_ids": set()},
+        )
+
+        assert len(ops) == 1
+        assert isinstance(ops[0], Upsert)
+        assert ops[0].model is Workflow
+        assert ops[0].values["name"] == "custom_tool_name"
+        assert ops[0].values["function_name"] == "python_function_name"

--- a/client/src/components/workflows/WorkflowEditDialog.test.tsx
+++ b/client/src/components/workflows/WorkflowEditDialog.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test-utils";
+
+const mockUpdateWorkflow = vi.fn();
+const mockAssignRoles = vi.fn();
+const mockRemoveRole = vi.fn();
+const mockWorkflowRolesRefetch = vi.fn();
+
+vi.mock("@/hooks/useRoles", () => ({
+	useRoles: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/useWorkflows", () => ({
+	useUpdateWorkflow: () => ({ mutateAsync: mockUpdateWorkflow }),
+}));
+
+vi.mock("@/hooks/useWorkflowRoles", () => ({
+	useWorkflowRoles: () => ({
+		data: { role_ids: [] },
+		refetch: mockWorkflowRolesRefetch,
+	}),
+	useAssignRolesToWorkflow: () => ({ mutateAsync: mockAssignRoles }),
+	useRemoveRoleFromWorkflow: () => ({ mutateAsync: mockRemoveRole }),
+}));
+
+vi.mock("@/hooks/useWorkflowKeys", () => ({
+	useWorkflowKeys: () => ({ data: [], refetch: vi.fn() }),
+	useCreateWorkflowKey: () => ({ mutateAsync: vi.fn() }),
+	useRevokeWorkflowKey: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/components/forms/OrganizationSelect", () => ({
+	OrganizationSelect: ({
+		value,
+		onChange,
+	}: {
+		value?: string | null;
+		onChange: (value: string | null) => void;
+	}) => (
+		<select
+			aria-label="Organization Scope"
+			value={value ?? "global"}
+			onChange={(event) =>
+				onChange(event.currentTarget.value === "global" ? null : event.currentTarget.value)
+			}
+		>
+			<option value="global">Global</option>
+		</select>
+	),
+}));
+
+import { WorkflowEditDialog } from "./WorkflowEditDialog";
+import type { components } from "@/lib/v1";
+
+type Workflow = components["schemas"]["WorkflowMetadata"];
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+	return {
+		id: "workflow-1",
+		name: "current_tool_name",
+		function_name: "python_function_name",
+		display_name: null,
+		description: null,
+		type: "tool",
+		organization_id: null,
+		access_level: "authenticated",
+		category: "General",
+		tags: [],
+		parameters: [],
+		execution_mode: "sync",
+		timeout_seconds: 1800,
+		retry_policy: null,
+		endpoint_enabled: false,
+		allowed_methods: ["POST"],
+		disable_global_key: false,
+		public_endpoint: false,
+		is_tool: false,
+		tool_description: null,
+		cache_ttl_seconds: 300,
+		time_saved: 0,
+		value: 0,
+		used_by_count: 0,
+		source_file_path: "workflows/example.py",
+		relative_file_path: "workflows/example.py",
+		created_at: "2026-06-05T00:00:00Z",
+		...overrides,
+	} as Workflow;
+}
+
+beforeEach(() => {
+	mockUpdateWorkflow.mockReset();
+	mockUpdateWorkflow.mockResolvedValue({});
+	mockAssignRoles.mockReset();
+	mockAssignRoles.mockResolvedValue({});
+	mockRemoveRole.mockReset();
+	mockRemoveRole.mockResolvedValue({});
+	mockWorkflowRolesRefetch.mockReset();
+	mockWorkflowRolesRefetch.mockResolvedValue({ data: { role_ids: [] } });
+});
+
+describe("WorkflowEditDialog", () => {
+	it("submits an edited workflow tool name separately from the function name", async () => {
+		const onOpenChange = vi.fn();
+		const { user } = renderWithProviders(
+			<WorkflowEditDialog
+				workflow={makeWorkflow()}
+				open={true}
+				onOpenChange={onOpenChange}
+			/>,
+		);
+
+		const toolNameInput = screen.getByLabelText(/tool name/i);
+		expect(toolNameInput).toHaveValue("current_tool_name");
+
+		await user.clear(toolNameInput);
+		await user.type(toolNameInput, "renamed_tool_name");
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => expect(mockUpdateWorkflow).toHaveBeenCalledTimes(1));
+		expect(mockUpdateWorkflow.mock.calls[0]).toMatchObject([
+			"workflow-1",
+			{
+				name: "renamed_tool_name",
+				display_name: null,
+			},
+		]);
+		expect(onOpenChange).toHaveBeenCalledWith(false);
+	});
+
+	it("resets the workflow tool name to the function name when cleared", async () => {
+		const { user } = renderWithProviders(
+			<WorkflowEditDialog
+				workflow={makeWorkflow()}
+				open={true}
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		const toolNameInput = screen.getByLabelText(/tool name/i);
+		await user.clear(toolNameInput);
+		await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => expect(mockUpdateWorkflow).toHaveBeenCalledTimes(1));
+		expect(mockUpdateWorkflow.mock.calls[0]).toMatchObject([
+			"workflow-1",
+			{
+				name: "python_function_name",
+			},
+		]);
+	});
+});

--- a/client/src/components/workflows/WorkflowEditDialog.tsx
+++ b/client/src/components/workflows/WorkflowEditDialog.tsx
@@ -127,6 +127,7 @@ export function WorkflowEditDialog({
 	const [rolesOpen, setRolesOpen] = useState(false);
 
 	// General tab state
+	const [workflowName, setWorkflowName] = useState("");
 	const [displayName, setDisplayName] = useState("");
 	const [description, setDescription] = useState("");
 	const [category, setCategory] = useState("");
@@ -186,6 +187,7 @@ export function WorkflowEditDialog({
 			setAccessLevel((workflow.access_level as WorkflowAccessLevel) || "role_based");
 
 			// General
+			setWorkflowName(workflow.name ?? "");
 			setDisplayName(workflow.display_name ?? "");
 			setDescription(workflow.description ?? "");
 			setCategory(workflow.category ?? "General");
@@ -240,10 +242,14 @@ export function WorkflowEditDialog({
 
 		setIsSaving(true);
 		try {
+			const resolvedWorkflowName =
+				workflowName.trim() || workflow.function_name || workflow.name;
+
 			// Build update payload with all changed fields
 			await updateWorkflow.mutateAsync(workflow.id, {
 				organization_id: organizationId,
 				access_level: accessLevel,
+				name: resolvedWorkflowName,
 				display_name: displayName || null,
 				description: description || null,
 				category: category || "General",
@@ -423,6 +429,19 @@ export function WorkflowEditDialog({
 						{/* General Tab */}
 						<TabsContent value="general" className="mt-0 space-y-4">
 							<div className="space-y-2">
+								<Label htmlFor="workflow-name">Tool Name</Label>
+								<Input
+									id="workflow-name"
+									value={workflowName}
+									onChange={(e) => setWorkflowName(e.target.value)}
+									placeholder={workflow?.function_name ?? "workflow_name"}
+								/>
+								<p className="text-xs text-muted-foreground">
+									Used when this workflow is exposed as an MCP tool. Leave empty to reset to the Python function name.
+								</p>
+							</div>
+
+							<div className="space-y-2">
 								<Label htmlFor="display-name">Display Name</Label>
 								<Input
 									id="display-name"
@@ -431,7 +450,7 @@ export function WorkflowEditDialog({
 									placeholder={workflow?.name ?? "Workflow name"}
 								/>
 								<p className="text-xs text-muted-foreground">
-									User-facing name. Leave empty to use the code name.
+									Optional UI label. Leave empty to use the tool name.
 								</p>
 							</div>
 

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -3705,22 +3705,22 @@ export interface paths {
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        get: operations["execute_endpoint_api_endpoints__workflow_id__get"];
+        get: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        put: operations["execute_endpoint_api_endpoints__workflow_id__get"];
+        put: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        post: operations["execute_endpoint_api_endpoints__workflow_id__get"];
+        post: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        delete: operations["execute_endpoint_api_endpoints__workflow_id__get"];
+        delete: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -18577,7 +18577,7 @@ export interface components {
             id: string;
             /**
              * Name
-             * @description Workflow name (from decorator or function name)
+             * @description MCP tool name, defaulted from function_name on registration
              */
             name: string;
             /**
@@ -21302,7 +21302,7 @@ export interface components {
             id: string;
             /**
              * Name
-             * @description Human-readable workflow name
+             * @description MCP tool name for this workflow. Defaults to the Python function name on registration.
              */
             name: string;
             /**
@@ -21312,7 +21312,7 @@ export interface components {
             function_name?: string | null;
             /**
              * Display Name
-             * @description Optional display name for UI (falls back to name if not set)
+             * @description Optional UI display name (falls back to the tool name if not set)
              */
             display_name?: string | null;
             /**
@@ -21591,8 +21591,13 @@ export interface components {
              */
             role_ids?: string[] | null;
             /**
+             * Name
+             * @description MCP tool name for this workflow. Defaults to the Python function name on registration.
+             */
+            name?: string | null;
+            /**
              * Display Name
-             * @description User-facing display name (defaults to code name if not set)
+             * @description Optional UI display name (falls back to the tool name if not set)
              */
             display_name?: string | null;
             /**
@@ -27917,7 +27922,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__get: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {
@@ -27950,7 +27955,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__get: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {
@@ -27983,7 +27988,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__get: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {
@@ -28016,7 +28021,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__get: {
+    execute_endpoint_api_endpoints__workflow_id__delete: {
         parameters: {
             query?: never;
             header: {


### PR DESCRIPTION
## Summary
- Treat workflow `name` explicitly as the MCP tool name, defaulting from the Python function name on registration.
- Add workflow tool-name updates across REST, CLI/MCP update tooling, manifest round-trip, generated OpenAPI types, and the workflow edit dialog.
- Keep clear UI behavior: empty Tool Name resets to the Python function name, while Display Name remains an optional UI label.

## Tests
- `./test.sh client unit src/components/workflows/WorkflowEditDialog.test.tsx`
- `npm run tsc -- --noEmit`
- `npm run lint -- src/components/workflows/WorkflowEditDialog.tsx src/components/workflows/WorkflowEditDialog.test.tsx src/hooks/useWorkflows.ts` (passes with existing `FormRenderer.tsx` React Hook Form compiler warning)
- `python3 -m py_compile ...changed Python files...`
- `ruff check ...changed Python files...`
- `git diff --check`
- `OPENAPI_URL=http://bifrost-debug-workflow-tool-name-153-48.netbird.cloud/openapi.json npm run generate:types`

## Notes
- Full Docker-backed backend test suite was not run locally because the test stack was failing earlier on RabbitMQ `.erlang.cookie` permissions; CI should provide the clean-stack signal.
