### PR TITLE
Fix app-relative location paths for published apps

### DIFF
--- a/api/src/services/app_bundler/__init__.py
+++ b/api/src/services/app_bundler/__init__.py
@@ -535,10 +535,10 @@ class BundlerService:
             n for _, n in user_components if n in imported_names
         )
         deprecated_icons = sorted(lucide_names)
-        # React Router navigation primitives: with the bundled runtime the
-        # host sets `basename` on BrowserRouter, so raw React Router
-        # Link/NavLink/Navigate/useNavigate/navigate handle the /apps/<slug>
-        # prefix automatically. Users should import them from 'react-router-dom'.
+        # React Router navigation primitives: app bundles resolve
+        # react-router-dom through the host import-map stub. The host stub wraps
+        # app-sensitive APIs (navigation + useLocation), while leaving route
+        # matching primitives raw.
         #
         # Must stay in sync with `client/src/lib/bifrost-runtime.ts`'s
         # react-router-dom re-exports. Only runtime values (components / hooks /
@@ -626,20 +626,16 @@ class BundlerService:
 
         # React Router navigation primitives.
         #
-        # Link / NavLink / Navigate / useNavigate / navigate route through the
-        # platform wrappers in `app-code-platform/navigation.tsx` — they prepend
-        # the app base path (`/apps/<slug>/preview` or `/apps/<slug>`) so bare
-        # `<Link to="/other">` inside a bundled app resolves correctly under the
-        # host's shared BrowserRouter. They live on `globalThis.__bifrost_platform`
-        # just like the rest of the platform scope, populated by BundledAppShell
-        # before the bundle imports.
+        # Link / NavLink / Navigate / useNavigate / navigate / useLocation route
+        # through the platform wrappers. Navigation APIs prepend the app base
+        # path (`/apps/<slug>/preview` or `/apps/<slug>`), and useLocation strips
+        # that base path back off so app code sees routes like `/other`.
         #
-        # Everything else (Routes, Route, Outlet, useLocation, etc.) re-exports
-        # directly from "react-router-dom" (resolved via import map to the host's
-        # copy).
+        # Everything else (Routes, Route, Outlet, etc.) re-exports directly
+        # from "react-router-dom" (resolved via import map to the host's copy).
         #
         # Only emit re-exports for names user code actually imported.
-        wrapped_router_names = {"Link", "NavLink", "Navigate", "useNavigate", "navigate"}
+        wrapped_router_names = {"Link", "NavLink", "Navigate", "useNavigate", "navigate", "useLocation"}
         router_re_exported = router_primitives & imported_names
         raw_router_names = router_re_exported - wrapped_router_names
         wrapped_router_re_exported = router_re_exported & wrapped_router_names
@@ -772,5 +768,3 @@ def _has_default_export(src: str) -> bool:
     synthesized `bifrost` package.
     """
     return bool(_DEFAULT_EXPORT_RE.search(src))
-
-

--- a/client/e2e/apps-preview.admin.spec.ts
+++ b/client/e2e/apps-preview.admin.spec.ts
@@ -27,10 +27,13 @@ export default function Layout() {
 `;
 
 const indexTsx = (heading: string) => `import { Link } from "bifrost";
+import { useLocation } from "react-router-dom";
 export default function Home() {
+	const location = useLocation();
 	return (
 		<div>
 			<h1 data-testid="demo-heading">${heading}</h1>
+			<div data-testid="location-path">{location.pathname}</div>
 			<Link to="/other" data-testid="to-other">Go to Other</Link>
 		</div>
 	);
@@ -38,10 +41,13 @@ export default function Home() {
 `;
 
 const OTHER_TSX = `import { Link } from "bifrost";
+import { useLocation } from "react-router-dom";
 export default function Other() {
+	const location = useLocation();
 	return (
 		<div>
 			<h1 data-testid="other-heading">OTHER PAGE</h1>
+			<div data-testid="location-path">{location.pathname}</div>
 			<Link to="/" data-testid="to-home">Back to Home</Link>
 		</div>
 	);
@@ -121,6 +127,7 @@ test.describe("Apps Preview", () => {
 		await expect(page.getByTestId("demo-heading")).toHaveText("HELLO V1", {
 			timeout: 15_000,
 		});
+		await expect(page.getByTestId("location-path")).toHaveText("/");
 
 		// --- Step 2: push V2, preview updates WITHOUT reload ---
 		const writeResp = await api.post("/api/files/write", {
@@ -134,6 +141,7 @@ test.describe("Apps Preview", () => {
 		await expect(page.getByTestId("demo-heading")).toHaveText("HELLO V2", {
 			timeout: 15_000,
 		});
+		await expect(page.getByTestId("location-path")).toHaveText("/");
 
 		// --- Step 3: navigate to /other via in-app Link, then back ---
 		await page.getByTestId("to-other").click();
@@ -143,12 +151,14 @@ test.describe("Apps Preview", () => {
 		await expect(page.getByTestId("other-heading")).toHaveText(
 			"OTHER PAGE",
 		);
+		await expect(page.getByTestId("location-path")).toHaveText("/other");
 
 		await page.getByTestId("to-home").click();
 		await expect(page).toHaveURL(
 			new RegExp(`/apps/${APP_SLUG}/preview/?$`),
 		);
 		await expect(page.getByTestId("demo-heading")).toHaveText("HELLO V2");
+		await expect(page.getByTestId("location-path")).toHaveText("/");
 
 		// No console errors / pageerrors during the hot-reload + navigation
 		// flow. This also catches "provider context missing" regressions, which
@@ -167,6 +177,7 @@ test.describe("Apps Preview", () => {
 		await expect(page.getByTestId("demo-heading")).toHaveText("HELLO V2", {
 			timeout: 15_000,
 		});
+		await expect(page.getByTestId("location-path")).toHaveText("/");
 
 		// Also verify navigation works in live mode.
 		await page.getByTestId("to-other").click();
@@ -176,6 +187,7 @@ test.describe("Apps Preview", () => {
 		await expect(page.getByTestId("other-heading")).toHaveText(
 			"OTHER PAGE",
 		);
+		await expect(page.getByTestId("location-path")).toHaveText("/other");
 
 		expect(tracker.errors, tracker.errors.join("\n")).toEqual([]);
 	});

--- a/client/src/lib/app-code-platform/index.ts
+++ b/client/src/lib/app-code-platform/index.ts
@@ -22,6 +22,7 @@ export { useWorkflowQuery } from "./useWorkflowQuery";
 export { useWorkflowMutation } from "./useWorkflowMutation";
 
 // Router utilities
+export { useLocation } from "./useLocation";
 export { useParams } from "./useParams";
 export { useSearchParams } from "./useSearchParams";
 export {

--- a/client/src/lib/app-code-platform/scope.test.ts
+++ b/client/src/lib/app-code-platform/scope.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-router-dom", () => ({
+	Outlet: vi.fn(),
+	useLocation: vi.fn(),
+	useMatch: vi.fn(),
+	useOutletContext: vi.fn(),
+	useResolvedPath: vi.fn(),
+}));
+
+import { useLocation as useRouterLocation } from "react-router-dom";
+import { useAppBuilderStore } from "@/stores/app-builder.store";
+import { createPlatformScope } from "./scope";
+
+const mockedUseRouterLocation = vi.mocked(useRouterLocation);
+
+function setRouterPath(pathname: string) {
+	mockedUseRouterLocation.mockReturnValue({
+		pathname,
+		search: "?tab=current",
+		hash: "#details",
+		state: { from: "test" },
+		key: "abc123",
+	});
+}
+
+function renderScopedLocation() {
+	const scope = createPlatformScope();
+	const useScopedLocation = scope.useLocation as typeof useRouterLocation;
+	return renderHook(() => useScopedLocation());
+}
+
+afterEach(() => {
+	useAppBuilderStore.getState().setAppContext("", false);
+	vi.clearAllMocks();
+});
+
+describe("createPlatformScope useLocation", () => {
+	it("returns app-relative pathnames for preview routes", () => {
+		useAppBuilderStore.getState().setAppContext("demo-app", true);
+		setRouterPath("/apps/demo-app/preview/reports/margins");
+
+		const { result } = renderScopedLocation();
+
+		expect(result.current).toMatchObject({
+			pathname: "/reports/margins",
+			search: "?tab=current",
+			hash: "#details",
+			state: { from: "test" },
+			key: "abc123",
+		});
+	});
+
+	it("returns app-relative pathnames for published routes", () => {
+		useAppBuilderStore.getState().setAppContext("demo-app", false);
+		setRouterPath("/apps/demo-app/reports/margins");
+
+		const { result } = renderScopedLocation();
+
+		expect(result.current.pathname).toBe("/reports/margins");
+	});
+});

--- a/client/src/lib/app-code-platform/scope.ts
+++ b/client/src/lib/app-code-platform/scope.ts
@@ -6,12 +6,12 @@
  */
 
 import {
-	useLocation,
 	useMatch,
 	useResolvedPath,
 	Outlet,
 	useOutletContext,
 } from "react-router-dom";
+import { useLocation } from "./useLocation";
 import { useWorkflowQuery } from "./useWorkflowQuery";
 import { useWorkflowMutation } from "./useWorkflowMutation";
 import { useParams } from "./useParams";

--- a/client/src/lib/app-code-platform/useLocation.ts
+++ b/client/src/lib/app-code-platform/useLocation.ts
@@ -1,0 +1,25 @@
+import {
+	useLocation as useRouterLocation,
+	type Location,
+} from "react-router-dom";
+import { useAppBuilderStore } from "@/stores/app-builder.store";
+
+export function appRelativePathname(pathname: string, basePath: string): string {
+	if (!basePath || basePath === "/") return pathname;
+	if (pathname === basePath) return "/";
+	if (!pathname.startsWith(`${basePath}/`)) return pathname;
+	return pathname.slice(basePath.length);
+}
+
+export function useLocation(): Location {
+	const location = useRouterLocation();
+	const basePath = useAppBuilderStore((state) => state.getBasePath());
+	const pathname = appRelativePathname(location.pathname, basePath);
+
+	if (pathname === location.pathname) return location;
+
+	return {
+		...location,
+		pathname,
+	};
+}

--- a/client/src/lib/bifrost-runtime.ts
+++ b/client/src/lib/bifrost-runtime.ts
@@ -35,10 +35,9 @@ export {
 	useTransition,
 } from "react";
 
-// React Router primitives EXCEPT Link / NavLink / Navigate / useNavigate — those
-// are re-exported from the platform module below so app basename handling stays
-// consistent during the transition. Phase 5 drops the wrappers entirely and uses
-// raw react-router-dom.
+// React Router primitives EXCEPT Link / NavLink / Navigate / useNavigate /
+// useLocation — those are re-exported from the platform module below so app
+// basename handling stays consistent during the transition.
 export {
 	BrowserRouter,
 	HashRouter,
@@ -51,7 +50,6 @@ export {
 	useHref,
 	useLinkClickHandler,
 	useInRouterContext,
-	useLocation,
 	useMatch,
 	useNavigationType,
 	useOutlet,
@@ -108,6 +106,7 @@ export * from "lucide-react";
 // Platform hooks & components
 export { useWorkflowQuery } from "./app-code-platform/useWorkflowQuery";
 export { useWorkflowMutation } from "./app-code-platform/useWorkflowMutation";
+export { useLocation } from "./app-code-platform/useLocation";
 export { useParams } from "./app-code-platform/useParams";
 export { useSearchParams } from "./app-code-platform/useSearchParams";
 export { navigate, useNavigate } from "./app-code-platform/navigate";

--- a/client/src/lib/esm-react-shim.ts
+++ b/client/src/lib/esm-react-shim.ts
@@ -25,6 +25,18 @@ import * as ReactJSXDevRuntime from "react/jsx-dev-runtime";
 import * as ReactRouterDOM from "react-router-dom";
 import * as LucideReact from "lucide-react";
 import { $ as platformScope } from "./app-code-runtime";
+import { Link, NavLink, Navigate } from "./app-code-platform/navigation";
+import { useLocation } from "./app-code-platform/useLocation";
+import { useNavigate } from "./app-code-platform/navigate";
+
+const appReactRouterDOM = {
+	...ReactRouterDOM,
+	Link,
+	NavLink,
+	Navigate,
+	useLocation,
+	useNavigate,
+} as unknown as typeof ReactRouterDOM;
 
 declare global {
 	interface Window {
@@ -33,7 +45,7 @@ declare global {
 		__bifrost_react_dom_client: typeof ReactDOMClient;
 		__bifrost_react_jsx_runtime: typeof ReactJSXRuntime;
 		__bifrost_react_jsx_dev_runtime: typeof ReactJSXDevRuntime;
-		__bifrost_react_router_dom: typeof ReactRouterDOM;
+		__bifrost_react_router_dom: typeof appReactRouterDOM;
 		__bifrost_lucide_react: typeof LucideReact;
 		__bifrost_platform: typeof platformScope;
 	}
@@ -51,7 +63,7 @@ export function initReactShim(): void {
 	g.__bifrost_react_dom_client = ReactDOMClient;
 	g.__bifrost_react_jsx_runtime = ReactJSXRuntime;
 	g.__bifrost_react_jsx_dev_runtime = ReactJSXDevRuntime;
-	g.__bifrost_react_router_dom = ReactRouterDOM;
+	g.__bifrost_react_router_dom = appReactRouterDOM;
 	g.__bifrost_lucide_react = LucideReact;
 	g.__bifrost_platform = platformScope;
 }


### PR DESCRIPTION
## Summary
- Normalize app `useLocation().pathname` to app-relative paths for both preview and published app mounts.
- Route bundled-app `react-router-dom` imports through the app-aware router shim for navigation and location hooks.
- Extend app preview/publish E2E coverage to assert main and sub routes see the same app-relative paths in preview and live.

## Test Plan
- `npm run tsc`
- `ruff check src/services/app_bundler/__init__.py`
- `./test.sh client unit src/lib/app-code-platform/scope.test.ts`
- `./test.sh client e2e e2e/apps-preview.admin.spec.ts`
