### PR TITLE
test: move real-process/IO unit tests off the every-PR fast lane

### DIFF
--- a/api/tests/unit/execution/test_template_process.py
+++ b/api/tests/unit/execution/test_template_process.py
@@ -16,6 +16,16 @@ from src.services.execution.template_process import TemplateProcess
 
 logger = logging.getLogger(__name__)
 
+# These tests fork real OS processes (see module docstring — fork behavior
+# can't be mocked), so they cost seconds each, not milliseconds. They are
+# integration tests living in the unit tree. Mark the whole module `slow` so
+# the every-PR unit lane (`./test.sh unit`, which runs `-m "not slow"`) skips
+# them; they still run in `./test.sh all` and nightly. This file alone was
+# ~90s of the ~140s unit-suite cost. Fork EXECUTION is also covered end-to-end
+# by tests/e2e/platform/test_fork_pool.py; these cover the TemplateProcess
+# primitive directly, so the coverage is retained, just at the right cadence.
+pytestmark = pytest.mark.slow
+
 
 def _wait_for_pid_to_die(pid: int, timeout: float = 5.0) -> None:
     """

--- a/api/tests/unit/services/test_github_sync.py
+++ b/api/tests/unit/services/test_github_sync.py
@@ -4,6 +4,8 @@ Unit tests for GitHub Sync Service.
 Tests the GitHubSyncService data models and exceptions.
 """
 
+import pytest
+
 from src.models.contracts.github import (
     OrphanInfo,
     PreflightIssue,
@@ -163,6 +165,10 @@ class TestSyncExceptions:
         assert str(error) == "Sync failed"
 
 
+# Memory-profiling tests: each builds many large files and measures RSS, so
+# they cost seconds, not milliseconds. Marked `slow` so the every-PR unit lane
+# skips them; they still run in `./test.sh all` and nightly.
+@pytest.mark.slow
 class TestMemoryUsageDuringFileScan:
     """
     Memory profiling tests for file scanning operations.

--- a/api/tests/unit/test_import_hygiene.py
+++ b/api/tests/unit/test_import_hygiene.py
@@ -9,6 +9,13 @@ import json
 import subprocess
 import sys
 
+import pytest
+
+# Each test spawns a fresh Python interpreter via subprocess to inspect a
+# module's import closure — that's ~1.5s per case. Marked `slow` so the
+# every-PR unit lane skips them; they still run in `./test.sh all` and nightly.
+pytestmark = pytest.mark.slow
+
 HEAVY = {"fastapi", "starlette", "uvicorn", "anthropic", "openai", "mcp", "numpy", "pgvector"}
 # The spawn-entry and template modules must be stdlib-thin, not merely heavy-free:
 THIN_EXTRA = {"sqlalchemy", "pydantic", "redis", "httpx", "aio_pika", "apscheduler", "src.worker.app"}

--- a/test.sh
+++ b/test.sh
@@ -252,7 +252,12 @@ run_pytest() {
     return "${PIPESTATUS[0]}"
 }
 
-cmd_unit() { run_pytest tests/ --ignore=tests/e2e/ -v "$@"; }
+# `unit` is the fast every-PR lane: it deselects `@pytest.mark.slow` tests
+# (real-process forks, memory-profiling, subprocess import scans — seconds each,
+# not the ms a unit test should cost). Those still run in `all` and nightly, so
+# no coverage is dropped — just moved off the per-PR critical path. A caller can
+# re-include them ad hoc with `./test.sh unit -m slow` or `-m ""`.
+cmd_unit() { run_pytest tests/ --ignore=tests/e2e/ -m "not slow" -v "$@"; }
 cmd_e2e()  { run_pytest tests/e2e/ -v "$@"; }
 cmd_all()  { run_pytest tests/ -v "$@"; }
 


### PR DESCRIPTION
From the test cost/value audit (`docs/plans/2026-06-10-test-cost-value-audit.md`).

## Finding
50% of the unit suite's wall-clock was in **4 tests**, all in `test_template_process.py` — which forks **real OS processes** (its docstring: *"uses real multiprocessing since fork behavior can't be mocked"*). `test_fork_latency_under_100ms` took **27 seconds**. That one file was ~90s of the ~140s unit cost. These are integration tests living in the unit tree.

## Change
Mark the genuinely-slow unit tests `@pytest.mark.slow` (marker already defined in `pytest.ini`) and make `./test.sh unit` run `-m "not slow"`:
- `test_template_process.py` (module) — real fork/multiprocessing
- `test_github_sync.py::TestMemoryUsageDuringFileScan` — RSS-measuring memory profiles
- `test_import_hygiene.py` (module) — subprocess-spawns fresh interpreters per case

## No coverage dropped
They still run in `./test.sh all` and nightly; fork *execution* is also covered by `test_fork_pool.py` (these cover the `TemplateProcess` primitive directly). **Verified empirically:**
- `./test.sh unit` → 4051 passed, **19 deselected**, ~50s (was ~140s)
- `./test.sh unit -m slow` → **19 passed** (the moved tests, all green)

## Honest scope note
The per-PR unit lane runs in parallel under the e2e ceiling, so the **CI wall-clock** win is modest (~30-45s) — the value here is a fast, honest unit lane for local iteration. The real CI wall-clock lever (test-stack warming + a third e2e shard, ~12→9 min) is a separate infra follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)