### PR TITLE
fix: deliver scheduled events to agent subscriptions

### DIFF
--- a/api/src/jobs/schedulers/cron_scheduler.py
+++ b/api/src/jobs/schedulers/cron_scheduler.py
@@ -187,17 +187,26 @@ async def process_schedule_sources() -> dict[str, Any]:
                     # Create deliveries for each subscription
                     deliveries_for_event = 0
                     for sub in subscriptions:
-                        if not sub.workflow_id:
-                            logger.warning(
-                                f"Subscription {sub.id} has no workflow, skipping"
-                            )
-                            continue
+                        target_type = getattr(sub, "target_type", "workflow") or "workflow"
+
+                        if target_type == "agent":
+                            if not sub.agent_id:
+                                logger.warning(
+                                    f"Subscription {sub.id} is agent type but has no agent_id, skipping"
+                                )
+                                continue
+                        else:
+                            if not sub.workflow_id:
+                                logger.warning(
+                                    f"Subscription {sub.id} has no workflow, skipping"
+                                )
+                                continue
 
                         delivery = EventDelivery(
                             id=uuid.uuid4(),
                             event_id=event.id,
                             event_subscription_id=sub.id,
-                            workflow_id=sub.workflow_id,
+                            workflow_id=sub.workflow_id,  # None for agent targets
                             status=EventDeliveryStatus.PENDING,
                         )
                         db.add(delivery)

--- a/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
+++ b/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
@@ -353,3 +353,100 @@ async def test_schedule_skipped_when_active_agent_run_target(db_session, caplog)
     # No new Event row must have been created for this source
     after = await _count_events_for_source(db_session, source.id)
     assert after == 1, "Expected exactly 1 event (the prior one) — agent-target overlap must block"
+
+
+async def _deliveries_for_source(db_session, source_id) -> list[EventDelivery]:
+    rows = (
+        await db_session.execute(
+            select(EventDelivery)
+            .join(Event, Event.id == EventDelivery.event_id)
+            .where(Event.event_source_id == source_id)
+        )
+    ).scalars().all()
+    return list(rows)
+
+
+@pytest.mark.asyncio
+async def test_schedule_creates_delivery_for_agent_subscription(db_session):
+    """Regression: a fired schedule must create a delivery for an AGENT-target
+    subscription.
+
+    Agent subscriptions carry agent_id and leave workflow_id NULL by design. The
+    scheduler previously skipped any subscription without a workflow_id, so no
+    EventDelivery was ever created and the agent never ran (the UI mislabeled it
+    "Subscription added after this event arrived"). Workflows were unaffected.
+    """
+    from src.models.orm.agents import Agent
+
+    agent = Agent(
+        id=uuid4(),
+        name="sched-agent",
+        system_prompt="you are a test agent",
+        created_by="test",
+    )
+    source, ss, sub = _make_source_and_subscription(target_type="agent")
+    sub.agent_id = agent.id  # agent target: agent_id set, workflow_id stays None
+    db_session.add(agent)
+    db_session.add(source)
+    db_session.add(ss)
+    db_session.add(sub)
+    await db_session.commit()
+
+    mock_sub_repo = AsyncMock()
+    mock_sub_repo.get_active_for_event = AsyncMock(return_value=[sub])
+    mock_processor = AsyncMock()
+    mock_processor.queue_event_deliveries = AsyncMock(return_value=1)
+
+    from src.jobs.schedulers.cron_scheduler import process_schedule_sources
+
+    with (
+        patch(PATH_DB_CTX, return_value=_DbCtx(db_session)),
+        patch(PATH_IS_VALID, return_value=True),
+        patch(PATH_SUB_REPO, return_value=mock_sub_repo),
+        patch(PATH_PROCESSOR, return_value=mock_processor),
+    ):
+        await process_schedule_sources()
+
+    deliveries = await _deliveries_for_source(db_session, source.id)
+    assert len(deliveries) == 1, "agent subscription should produce exactly one delivery"
+    assert deliveries[0].event_subscription_id == sub.id
+    assert deliveries[0].workflow_id is None  # agent target carries no workflow_id
+
+
+@pytest.mark.asyncio
+async def test_schedule_creates_delivery_for_workflow_subscription(db_session):
+    """Workflow-target subscriptions still get a delivery (no regression)."""
+    from src.models.orm.workflows import Workflow
+
+    workflow = Workflow(
+        id=uuid4(),
+        name="sched-wf",
+        function_name="sched_wf",
+        path="workflows/sched_wf.py",
+    )
+    source, ss, sub = _make_source_and_subscription(target_type="workflow")
+    sub.workflow_id = workflow.id
+    db_session.add(workflow)
+    db_session.add(source)
+    db_session.add(ss)
+    db_session.add(sub)
+    await db_session.commit()
+
+    mock_sub_repo = AsyncMock()
+    mock_sub_repo.get_active_for_event = AsyncMock(return_value=[sub])
+    mock_processor = AsyncMock()
+    mock_processor.queue_event_deliveries = AsyncMock(return_value=1)
+
+    from src.jobs.schedulers.cron_scheduler import process_schedule_sources
+
+    with (
+        patch(PATH_DB_CTX, return_value=_DbCtx(db_session)),
+        patch(PATH_IS_VALID, return_value=True),
+        patch(PATH_SUB_REPO, return_value=mock_sub_repo),
+        patch(PATH_PROCESSOR, return_value=mock_processor),
+    ):
+        await process_schedule_sources()
+
+    deliveries = await _deliveries_for_source(db_session, source.id)
+    assert len(deliveries) == 1
+    assert deliveries[0].workflow_id == sub.workflow_id


### PR DESCRIPTION
## Summary

Scheduled (cron) events never triggered **agent** targets — only workflows. The event UI showed the agent subscription as undelivered with the message "Subscription added after this event arrived." Clicking "Send" manually worked, which narrowed it to the scheduled path.

Root cause: `cron_scheduler.py` filtered subscriptions on `if not sub.workflow_id: continue`. Agent subscriptions carry `agent_id` and leave `workflow_id` NULL by design, so every agent subscription was silently skipped ("has no workflow, skipping"). No `EventDelivery` row was created → nothing queued → agent never ran. The "Subscription added after this event arrived" text is a hardcoded UI string for any active subscription with no delivery row — there is no actual timestamp comparison.

## Fix

Branch on `target_type` in the cron scheduler exactly like the two paths that already handle agents correctly:
- `services/events/processor.py` (webhook path)
- `routers/events.py` (manual "Send")

Accept agent subscriptions, validate `agent_id`, create the delivery with `workflow_id=None`, and let `queue_event_deliveries` route it to `_queue_agent_run` (which already keys off `subscription.target_type == "agent"`). Workflow subscriptions are unchanged.

## Tests

Added regression tests in `tests/unit/jobs/schedulers/test_cron_scheduler.py`:
- a fired schedule creates a delivery for an **agent**-target subscription (this test fails on the pre-fix code — verified by stashing the fix)
- a fired schedule still creates a delivery for a **workflow**-target subscription (no regression)

## Verification
- `./test.sh tests/unit/jobs/schedulers/` → 11 passed
- `ruff check` → clean
- `pyright` (with locks installed) → 0 errors

Fixes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)