### PR TITLE
Add Application Name branding setting + logo size guidance

### DIFF
--- a/api/alembic/versions/20260615_add_branding_application_name.py
+++ b/api/alembic/versions/20260615_add_branding_application_name.py
@@ -1,0 +1,28 @@
+"""add branding application_name
+
+Revision ID: 20260615_brand_appname
+Revises: 20260604_brand_terms
+Create Date: 2026-06-15
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260615_brand_appname"
+down_revision: Union[str, Sequence[str]] = "20260604_brand_terms"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "branding",
+        sa.Column("application_name", sa.String(length=40), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("branding", "application_name")

--- a/api/src/models/contracts/common.py
+++ b/api/src/models/contracts/common.py
@@ -38,8 +38,12 @@ class BrandingTerminology(BaseModel):
 
 class BrandingSettings(BaseModel):
     """Global platform branding configuration"""
+    application_name: str | None = Field(
+        default=None,
+        description="Product name shown in the UI (login, browser tab, header). Raw stored value; None when unset.",
+    )
     square_logo_url: str | None = Field(default=None, description="Square logo URL (for icons, 1:1 ratio)")
-    rectangle_logo_url: str | None = Field(default=None, description="Rectangle logo URL (for headers, 16:9 ratio)")
+    rectangle_logo_url: str | None = Field(default=None, description="Horizontal logo URL (for headers, ~4:1 ratio)")
     primary_color: str | None = Field(default=None, description="Primary brand color (hex format, e.g., #FF5733)")
     terminology: BrandingTerminology = Field(
         default_factory=BrandingTerminology,
@@ -63,6 +67,12 @@ class BrandingSettings(BaseModel):
 
 class BrandingUpdateRequest(BaseModel):
     """Request model for updating branding settings - logos use POST /logo/{type}"""
+    application_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=40,
+        description="Product name shown in the UI. Omit to leave unchanged; use the reset endpoint to clear.",
+    )
     primary_color: str | None = Field(default=None, description="Primary color (hex code, e.g., #0066CC)")
     terminology: BrandingTerminology | None = Field(
         default=None,

--- a/api/src/models/orm/branding.py
+++ b/api/src/models/orm/branding.py
@@ -20,6 +20,7 @@ class GlobalBranding(Base):
     __tablename__ = "branding"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    application_name: Mapped[str | None] = mapped_column(String(40), default=None)
     square_logo_data: Mapped[bytes | None] = mapped_column(LargeBinary, default=None)
     square_logo_content_type: Mapped[str | None] = mapped_column(
         String(50), default=None

--- a/api/src/repositories/branding.py
+++ b/api/src/repositories/branding.py
@@ -6,6 +6,7 @@ No organization scoping - single global branding record.
 """
 
 import logging
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +14,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.models import GlobalBranding
 
 logger = logging.getLogger(__name__)
+
+# Sentinel distinguishing "argument omitted" (leave field unchanged) from an
+# explicit None (clear the field). The legacy logo/color args use the
+# None-means-skip convention, which cannot express clearing; application_name
+# needs both update-with-value and clear-to-None, so it uses this sentinel.
+_UNSET: Any = object()
 
 
 class BrandingRepository:
@@ -45,6 +52,7 @@ class BrandingRepository:
         rectangle_logo_content_type: str | None = None,
         primary_color: str | None = None,
         terminology: dict | None = None,
+        application_name: str | None = _UNSET,
     ) -> GlobalBranding:
         """
         Create or update global branding configuration (upsert).
@@ -56,6 +64,8 @@ class BrandingRepository:
             rectangle_logo_content_type: Rectangle logo MIME type (e.g., 'image/png')
             primary_color: Hex color code (e.g., '#0066CC')
             terminology: Fixed product terminology overrides
+            application_name: Product name. Omit to leave unchanged; pass None to
+                clear it back to the default.
 
         Returns:
             Created or updated GlobalBranding record
@@ -76,6 +86,8 @@ class BrandingRepository:
                 existing.primary_color = primary_color
             if terminology is not None:
                 existing.terminology = terminology
+            if application_name is not _UNSET:
+                existing.application_name = application_name
 
             await self.session.flush()
             await self.session.refresh(existing)
@@ -90,6 +102,7 @@ class BrandingRepository:
                 rectangle_logo_content_type=rectangle_logo_content_type,
                 primary_color=primary_color,
                 terminology=terminology,
+                application_name=None if application_name is _UNSET else application_name,
             )
             self.session.add(branding)
             await self.session.flush()

--- a/api/src/routers/branding.py
+++ b/api/src/routers/branding.py
@@ -31,6 +31,7 @@ MAX_LOGO_SIZE = 5 * 1024 * 1024  # 5MB
 def _branding_response(branding: GlobalBranding | None) -> BrandingSettings:
     if not branding:
         return BrandingSettings(
+            application_name=None,
             square_logo_url=None,
             rectangle_logo_url=None,
             primary_color=None,
@@ -38,6 +39,7 @@ def _branding_response(branding: GlobalBranding | None) -> BrandingSettings:
         )
 
     return BrandingSettings(
+        application_name=branding.application_name,
         primary_color=branding.primary_color,
         terminology=BrandingTerminology.model_validate(branding.terminology or {}),
         square_logo_url="/api/branding/logo/square" if branding.square_logo_data else None,
@@ -103,13 +105,20 @@ async def update_branding(
     branding_repo = BrandingRepository(ctx.db)
 
     terminology = request.terminology.model_dump(exclude_none=True) if request.terminology else None
+    # application_name defaults to None in the request DTO ("leave unchanged");
+    # only forward it to the repo when a value was provided. Clearing is done via
+    # DELETE /application-name.
+    extra: dict = {}
+    if request.application_name is not None:
+        extra["application_name"] = request.application_name
     branding = await branding_repo.set_branding(
         primary_color=request.primary_color,
         terminology=terminology,
+        **extra,
     )
 
     await ctx.db.commit()
-    logger.info(f"Primary color updated by {user.email}")
+    logger.info(f"Branding updated by {user.email}")
 
     return _branding_response(branding)
 
@@ -319,6 +328,35 @@ async def reset_color(
 
 
 @router.delete(
+    "/application-name",
+    response_model=BrandingSettings,
+    summary="Reset application name to default",
+    description="Remove custom application name and revert to default (superuser only)",
+)
+async def reset_application_name(
+    ctx: Context,
+    user: CurrentActiveUser,
+) -> BrandingSettings:
+    """Reset application name to default."""
+    if not user.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only superusers can reset branding",
+        )
+
+    from src.repositories.branding import BrandingRepository
+    branding_repo = BrandingRepository(ctx.db)
+
+    # Clear application name (pass explicit None to clear, not the unchanged sentinel)
+    branding = await branding_repo.set_branding(application_name=None)
+
+    await ctx.db.commit()
+    logger.info(f"Application name reset to default by {user.email}")
+
+    return _branding_response(branding)
+
+
+@router.delete(
     "",
     response_model=BrandingSettings,
     summary="Reset all branding to defaults",
@@ -345,6 +383,7 @@ async def reset_all_branding(
     logger.info(f"All branding reset to defaults by {user.email}")
 
     return BrandingSettings(
+        application_name=None,
         primary_color=None,
         square_logo_url=None,
         rectangle_logo_url=None,

--- a/api/tests/e2e/api/test_misc.py
+++ b/api/tests/e2e/api/test_misc.py
@@ -127,6 +127,58 @@ class TestBranding:
             f"Org user should not update branding: {response.status_code}"
         )
 
+    def test_update_and_clear_application_name(self, e2e_client, platform_admin):
+        """Superuser can set the application name, read it back, and clear it."""
+        # Set a custom application name
+        response = e2e_client.put(
+            "/api/branding",
+            headers=platform_admin.headers,
+            json={"application_name": "Acme Portal"},
+        )
+        assert response.status_code in [200, 201], f"Update failed: {response.text}"
+        assert response.json()["application_name"] == "Acme Portal"
+
+        # Public GET reflects it (login screen reads this pre-auth)
+        public = e2e_client.get("/api/branding")
+        assert public.status_code == 200
+        assert public.json()["application_name"] == "Acme Portal"
+
+        # A color-only update must NOT clear the application name
+        color_only = e2e_client.put(
+            "/api/branding",
+            headers=platform_admin.headers,
+            json={"primary_color": "#123456"},
+        )
+        assert color_only.status_code in [200, 201], color_only.text
+        assert color_only.json()["application_name"] == "Acme Portal"
+
+        # Clearing via the dedicated endpoint reverts to null (default)
+        cleared = e2e_client.delete(
+            "/api/branding/application-name",
+            headers=platform_admin.headers,
+        )
+        assert cleared.status_code == 200, cleared.text
+        assert cleared.json()["application_name"] is None
+
+    def test_application_name_rejects_overlong(self, e2e_client, platform_admin):
+        """Application name longer than 40 chars is rejected (422)."""
+        response = e2e_client.put(
+            "/api/branding",
+            headers=platform_admin.headers,
+            json={"application_name": "x" * 41},
+        )
+        assert response.status_code == 422, f"Expected 422: {response.text}"
+
+    def test_application_name_org_user_denied(self, e2e_client, org1_user):
+        """Org user cannot clear the application name (403)."""
+        response = e2e_client.delete(
+            "/api/branding/application-name",
+            headers=org1_user.headers,
+        )
+        assert response.status_code == 403, (
+            f"Org user should not reset application name: {response.status_code}"
+        )
+
     def test_upload_square_logo_superuser(self, e2e_client, platform_admin):
         """Superuser can upload square logo."""
         import os

--- a/api/tests/unit/test_branding_repository.py
+++ b/api/tests/unit/test_branding_repository.py
@@ -1,0 +1,47 @@
+"""Unit tests for BrandingRepository.set_branding application_name handling.
+
+Exercises the three application_name states the sentinel must distinguish:
+set-a-value, leave-unchanged (omitted), and clear-to-None.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.repositories.branding import BrandingRepository
+
+
+@pytest.mark.asyncio
+async def test_set_application_name_creates_and_persists(db_session: AsyncSession):
+    repo = BrandingRepository(db_session)
+
+    branding = await repo.set_branding(application_name="Acme Portal")
+    assert branding.application_name == "Acme Portal"
+
+    # Re-read to confirm it persisted on the single global row
+    reloaded = await repo.get_branding()
+    assert reloaded is not None
+    assert reloaded.application_name == "Acme Portal"
+
+
+@pytest.mark.asyncio
+async def test_omitting_application_name_leaves_it_unchanged(db_session: AsyncSession):
+    repo = BrandingRepository(db_session)
+    await repo.set_branding(application_name="Acme Portal")
+
+    # Update a different field without passing application_name; it must survive.
+    branding = await repo.set_branding(primary_color="#123456")
+    assert branding.primary_color == "#123456"
+    assert branding.application_name == "Acme Portal"
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_clears_application_name(db_session: AsyncSession):
+    repo = BrandingRepository(db_session)
+    await repo.set_branding(application_name="Acme Portal")
+
+    branding = await repo.set_branding(application_name=None)
+    assert branding.application_name is None
+
+    reloaded = await repo.get_branding()
+    assert reloaded is not None
+    assert reloaded.application_name is None

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,11 @@
-import { Suspense } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Suspense, useEffect } from "react";
+import {
+	BrowserRouter,
+	Routes,
+	Route,
+	useLocation,
+	matchPath,
+} from "react-router-dom";
 import { Layout } from "@/components/layout/Layout";
 import { ContentLayout } from "@/components/layout/ContentLayout";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
@@ -14,6 +20,7 @@ import { useEditorStore } from "@/stores/editorStore";
 import { useQuickAccessStore } from "@/stores/quickAccessStore";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { OrgScopeProvider, useOrgScope } from "@/contexts/OrgScopeContext";
+import { useApplicationName } from "@/lib/applicationName";
 import {
 	KeyboardProvider,
 	useCmdCtrlShortcut,
@@ -201,6 +208,8 @@ const MCPConnectionEdit = lazyWithReload(() =>
 
 function AppRoutes() {
 	const { brandingLoaded } = useOrgScope();
+	const applicationName = useApplicationName();
+	const location = useLocation();
 	const isQuickAccessOpen = useQuickAccessStore((state) => state.isOpen);
 	const openQuickAccess = useQuickAccessStore(
 		(state) => state.openQuickAccess,
@@ -222,6 +231,22 @@ function AppRoutes() {
 			openEditor();
 		}
 	});
+
+	// Base browser-tab title. index.html ships the default literal for first
+	// paint; once branding resolves, reflect the (possibly custom) product name.
+	// The app-runner and app-preview routes drive their own
+	// "<App> | <product>" title via useDocumentChrome (AppRouter), so skip those
+	// paths here to avoid clobbering them. The app *editor* route
+	// (apps/:id/edit/*) does NOT set its own title, so it must NOT be skipped.
+	const isAppRunnerRoute =
+		(matchPath("/apps/:applicationId/preview/*", location.pathname) !==
+			null ||
+			matchPath("/apps/:applicationId/*", location.pathname) !== null) &&
+		matchPath("/apps/:applicationId/edit/*", location.pathname) === null;
+	useEffect(() => {
+		if (isAppRunnerRoute) return;
+		document.title = applicationName;
+	}, [applicationName, isAppRunnerRoute]);
 
 	// Wait for branding colors to load before rendering
 	// Logo component handles its own skeleton loading state

--- a/client/src/components/auth/AuthTransition.tsx
+++ b/client/src/components/auth/AuthTransition.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 
 import { Logo } from "@/components/branding/Logo";
 import { Card, CardContent } from "@/components/ui/card";
+import { useApplicationName } from "@/lib/applicationName";
 
 /**
  * Full-card "we're finishing up" state for auth flows.
@@ -13,6 +14,7 @@ import { Card, CardContent } from "@/components/ui/card";
  * slow connection, which reads as "nothing happened".
  */
 export function AuthTransition({ message }: { message: string }) {
+	const applicationName = useApplicationName();
 	return (
 		<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-primary/5 p-4">
 			<Card className="w-full max-w-md border-primary/10 shadow-xl shadow-primary/5">
@@ -23,7 +25,11 @@ export function AuthTransition({ message }: { message: string }) {
 						transition={{ duration: 0.3 }}
 						className="flex justify-center"
 					>
-						<Logo type="square" className="h-16 w-16" alt="Bifrost" />
+						<Logo
+							type="square"
+							className="h-16 w-16"
+							alt={applicationName}
+						/>
 					</motion.div>
 					<Loader2 className="h-6 w-6 animate-spin text-primary" />
 					<p className="text-sm text-muted-foreground">{message}</p>

--- a/client/src/components/branding/Logo.tsx
+++ b/client/src/components/branding/Logo.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useOrgScope } from "@/contexts/OrgScopeContext";
 import { Skeleton } from "@/components/ui/skeleton";
+import { resolveApplicationName } from "@/lib/applicationName";
 
 interface LogoProps {
 	type: "square" | "rectangle";
@@ -17,9 +18,17 @@ interface LogoProps {
  * Shows skeleton loader while branding is being loaded
  */
 export function Logo({ type, className = "", alt = "Logo" }: LogoProps) {
-	const { squareLogoUrl, rectangleLogoUrl, brandingLoaded, logoLoaded } =
-		useOrgScope();
+	const {
+		squareLogoUrl,
+		rectangleLogoUrl,
+		applicationName,
+		brandingLoaded,
+		logoLoaded,
+	} = useOrgScope();
 	const [error, setError] = useState(false);
+
+	// Product name shown in the default (no custom logo) header wordmark.
+	const productName = resolveApplicationName(applicationName);
 
 	// Default logo - fallback to standard logo.svg
 	const defaultLogo = "/logo.svg";
@@ -67,7 +76,7 @@ export function Logo({ type, className = "", alt = "Logo" }: LogoProps) {
 			<div className="flex items-center gap-2">
 				<img src={defaultLogo} alt={alt} className="h-8 w-8" />
 				<span className="hidden sm:inline-block font-semibold">
-					Bifrost Integrations
+					{productName}
 				</span>
 			</div>
 		);

--- a/client/src/contexts/OrgScopeContext.tsx
+++ b/client/src/contexts/OrgScopeContext.tsx
@@ -30,6 +30,7 @@ interface OrgScopeContextType {
 	logoLoaded: boolean;
 	squareLogoUrl: string | null;
 	rectangleLogoUrl: string | null;
+	applicationName: string | null;
 	terminology: Terminology;
 	refreshBranding: () => void;
 }
@@ -60,6 +61,7 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 	const [rectangleLogoUrl, setRectangleLogoUrl] = useState<string | null>(
 		null,
 	);
+	const [applicationName, setApplicationName] = useState<string | null>(null);
 	const [terminology, setTerminology] =
 		useState<Terminology>(DEFAULT_TERMINOLOGY);
 	const [refreshTrigger, setRefreshTrigger] = useState(0);
@@ -87,6 +89,7 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 			setLogoLoaded(false);
 			setSquareLogoUrl(null);
 			setRectangleLogoUrl(null);
+			setApplicationName(null);
 			setTerminology(DEFAULT_TERMINOLOGY);
 
 			try {
@@ -147,6 +150,7 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 				// Store logo URLs in context
 				setSquareLogoUrl(sqUrl || null);
 				setRectangleLogoUrl(rectUrl || null);
+				setApplicationName(branding.application_name || null);
 				setTerminology(nextTerminology);
 
 				// Apply branding theme (colors to CSS) - no need to fetch again
@@ -180,10 +184,11 @@ export function OrgScopeProvider({ children }: { children: ReactNode }) {
 			logoLoaded,
 			squareLogoUrl,
 			rectangleLogoUrl,
+			applicationName,
 			terminology,
 			refreshBranding,
 		}),
-		[scope, setScope, isGlobalScope, brandingLoaded, logoLoaded, squareLogoUrl, rectangleLogoUrl, terminology, refreshBranding],
+		[scope, setScope, isGlobalScope, brandingLoaded, logoLoaded, squareLogoUrl, rectangleLogoUrl, applicationName, terminology, refreshBranding],
 	);
 
 	return (

--- a/client/src/hooks/useBranding.ts
+++ b/client/src/hooks/useBranding.ts
@@ -29,6 +29,8 @@ export interface BrandingState {
 	squareLogoUrl: string | null;
 	/** URL for rectangle logo (header) */
 	rectangleLogoUrl: string | null;
+	/** Custom product name, or null when unset (falls back to the default) */
+	applicationName: string | null;
 	/** Refresh branding data (e.g., after upload) */
 	refreshBranding: () => void;
 }
@@ -159,6 +161,30 @@ export async function resetColor(): Promise<BrandingSettings_API> {
 }
 
 /**
+ * Reset application name to default (superuser only)
+ */
+export async function resetApplicationName(): Promise<BrandingSettings_API> {
+	const { data, error } = await apiClient.DELETE(
+		"/api/branding/application-name",
+		{},
+	);
+
+	if (error) {
+		throw new Error(
+			`Failed to reset application name: ${
+				typeof error === "object" &&
+				error !== null &&
+				"message" in error
+					? (error as { message?: string }).message
+					: "Unknown error"
+			}`,
+		);
+	}
+
+	return data;
+}
+
+/**
  * Reset all branding to defaults (superuser only)
  */
 export async function resetAllBranding(): Promise<BrandingSettings_API> {
@@ -265,6 +291,7 @@ export function useBranding(): BrandingState {
 		logoLoaded,
 		squareLogoUrl,
 		rectangleLogoUrl,
+		applicationName: branding?.application_name || null,
 		refreshBranding,
 	};
 }

--- a/client/src/lib/applicationName.test.ts
+++ b/client/src/lib/applicationName.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import {
+	DEFAULT_APPLICATION_NAME,
+	resolveApplicationName,
+	useApplicationName,
+} from "./applicationName";
+
+// Mock the org-scope context so the hook can be exercised without a provider.
+const mockUseOrgScope = vi.fn();
+vi.mock("@/contexts/OrgScopeContext", () => ({
+	useOrgScope: () => mockUseOrgScope(),
+}));
+
+describe("resolveApplicationName", () => {
+	it("returns the custom name when set", () => {
+		expect(resolveApplicationName("Acme Portal")).toBe("Acme Portal");
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(resolveApplicationName("  Acme  ")).toBe("Acme");
+	});
+
+	it.each([null, undefined, "", "   "])(
+		"falls back to the default for %p",
+		(value) => {
+			expect(resolveApplicationName(value as string | null)).toBe(
+				DEFAULT_APPLICATION_NAME,
+			);
+		},
+	);
+});
+
+describe("useApplicationName", () => {
+	it("returns the custom branding name when present", () => {
+		mockUseOrgScope.mockReturnValue({ applicationName: "Acme Portal" });
+		const { result } = renderHook(() => useApplicationName());
+		expect(result.current).toBe("Acme Portal");
+	});
+
+	it("returns the default when branding has no name", () => {
+		mockUseOrgScope.mockReturnValue({ applicationName: null });
+		const { result } = renderHook(() => useApplicationName());
+		expect(result.current).toBe(DEFAULT_APPLICATION_NAME);
+	});
+});

--- a/client/src/lib/applicationName.ts
+++ b/client/src/lib/applicationName.ts
@@ -1,0 +1,31 @@
+import { useOrgScope } from "@/contexts/OrgScopeContext";
+
+/**
+ * The literal product name used wherever no custom Application Name branding
+ * is set. Defined once so the fallback string lives in a single place.
+ */
+export const DEFAULT_APPLICATION_NAME = "Bifrost";
+
+/**
+ * Resolve a custom application name against the default.
+ *
+ * Returns the trimmed custom name when one is set, otherwise
+ * {@link DEFAULT_APPLICATION_NAME}. Kept as a pure function (separate from the
+ * hook) so it can be unit-tested and reused outside React.
+ */
+export function resolveApplicationName(
+	applicationName: string | null | undefined,
+): string {
+	const trimmed = applicationName?.trim();
+	return trimmed ? trimmed : DEFAULT_APPLICATION_NAME;
+}
+
+/**
+ * Hook returning the product name to display in the UI — the custom branding
+ * Application Name when set, otherwise the default ("Bifrost"). Backed by the
+ * public branding fetch in OrgScopeContext, so it resolves on pre-auth screens.
+ */
+export function useApplicationName(): string {
+	const { applicationName } = useOrgScope();
+	return resolveApplicationName(applicationName);
+}

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -2166,6 +2166,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/workflows/{workflow_id}/remap": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Remap workflow references
+         * @description Move references from one workflow ID to another active workflow ID
+         */
+        post: operations["remap_workflow_references_api_workflows__workflow_id__remap_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/workflows/{workflow_id}/recreate": {
         parameters: {
             query?: never;
@@ -2481,6 +2501,26 @@ export interface paths {
          * @description Remove custom primary color and revert to default (superuser only)
          */
         delete: operations["reset_color_api_branding_color_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/branding/application-name": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Reset application name to default
+         * @description Remove custom application name and revert to default (superuser only)
+         */
+        delete: operations["reset_application_name_api_branding_application_name_delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -3705,22 +3745,22 @@ export interface paths {
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        get: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
+        get: operations["execute_endpoint_api_endpoints__workflow_id__post"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        put: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
+        put: operations["execute_endpoint_api_endpoints__workflow_id__post"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        post: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
+        post: operations["execute_endpoint_api_endpoints__workflow_id__post"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        delete: operations["execute_endpoint_api_endpoints__workflow_id__delete"];
+        delete: operations["execute_endpoint_api_endpoints__workflow_id__post"];
         options?: never;
         head?: never;
         patch?: never;
@@ -8445,6 +8485,83 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sdk/modules/{path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fetch Module
+         * @description Fetch a workspace module by path.
+         *
+         *     Returns the module source and hash exactly as the module cache would.
+         *     On miss (module not found in Redis or S3), returns 404.
+         *
+         *     This endpoint is called by the child process's virtual import hook when
+         *     Redis is cold (i.e. after a Redis restart that evicted cached modules).
+         *     The child authenticates with its pre-minted engine token.
+         *
+         *     Args:
+         *         path: Module path relative to workspace root (e.g. "features/api.py").
+         */
+        get: operations["fetch_module_api_sdk_modules__path__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sdk/modules-index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fetch Module Index
+         * @description Fetch the set of all known workspace module paths.
+         *
+         *     Returns JSON: {"paths": ["features/api.py", ...]}.
+         *     Used by the child's VirtualModuleFinder to rebuild the module index when
+         *     the Redis SET is cold.
+         */
+        get: operations["fetch_module_index_api_sdk_modules_index_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sdk/requirements": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fetch Requirements
+         * @description Fetch requirements.txt content.
+         *
+         *     Returns JSON: {"content": "...", "hash": "..."} or 404 if none exists.
+         *     Used by the child's install_requirements() when Redis is cold.
+         */
+        get: operations["fetch_requirements_api_sdk_requirements_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/": {
         parameters: {
             query?: never;
@@ -10132,13 +10249,18 @@ export interface components {
          */
         BrandingSettings: {
             /**
+             * Application Name
+             * @description Product name shown in the UI (login, browser tab, header). Raw stored value; None when unset.
+             */
+            application_name?: string | null;
+            /**
              * Square Logo Url
              * @description Square logo URL (for icons, 1:1 ratio)
              */
             square_logo_url?: string | null;
             /**
              * Rectangle Logo Url
-             * @description Rectangle logo URL (for headers, 16:9 ratio)
+             * @description Horizontal logo URL (for headers, ~4:1 ratio)
              */
             rectangle_logo_url?: string | null;
             /**
@@ -10173,6 +10295,11 @@ export interface components {
          * @description Request model for updating branding settings - logos use POST /logo/{type}
          */
         BrandingUpdateRequest: {
+            /**
+             * Application Name
+             * @description Product name shown in the UI. Omit to leave unchanged; use the reset endpoint to clear.
+             */
+            application_name?: string | null;
             /**
              * Primary Color
              * @description Primary color (hex code, e.g., #0066CC)
@@ -18623,6 +18750,45 @@ export interface components {
             job_id: string;
         };
         /**
+         * RemapWorkflowRequest
+         * @description Request to move references from one workflow row to another.
+         */
+        RemapWorkflowRequest: {
+            /**
+             * Target Workflow Id
+             * @description Active workflow UUID that should receive the references
+             */
+            target_workflow_id: string;
+        };
+        /**
+         * RemapWorkflowResponse
+         * @description Response after remapping workflow references.
+         */
+        RemapWorkflowResponse: {
+            /**
+             * Success
+             * @description Whether remap succeeded
+             */
+            success: boolean;
+            /**
+             * Source Workflow Id
+             * @description UUID references were moved from
+             */
+            source_workflow_id: string;
+            /**
+             * Target Workflow Id
+             * @description UUID references were moved to
+             */
+            target_workflow_id: string;
+            /**
+             * Updated
+             * @description Counts of references updated by category
+             */
+            updated?: {
+                [key: string]: number;
+            };
+        };
+        /**
          * RenderFileResponse
          * @description Single compiled file for rendering (no source).
          */
@@ -24530,7 +24696,7 @@ export interface operations {
                 workflowName?: string | null;
                 /** @description Filter by workflow UUID */
                 workflowId?: string | null;
-                /** @description Filter by execution status */
+                /** @description Filter by execution status (comma-separated values match any) */
                 status?: string | null;
                 /** @description Filter by start date (ISO format) */
                 startDate?: string | null;
@@ -25233,6 +25399,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReplaceWorkflowResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remap_workflow_references_api_workflows__workflow_id__remap_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RemapWorkflowRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RemapWorkflowResponse"];
                 };
             };
             /** @description Validation Error */
@@ -25982,6 +26183,26 @@ export interface operations {
         };
     };
     reset_color_api_branding_color_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrandingSettings"];
+                };
+            };
+        };
+    };
+    reset_application_name_api_branding_application_name_delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -27924,7 +28145,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__delete: {
+    execute_endpoint_api_endpoints__workflow_id__post: {
         parameters: {
             query?: never;
             header: {
@@ -27957,7 +28178,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__delete: {
+    execute_endpoint_api_endpoints__workflow_id__post: {
         parameters: {
             query?: never;
             header: {
@@ -27990,7 +28211,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__delete: {
+    execute_endpoint_api_endpoints__workflow_id__post: {
         parameters: {
             query?: never;
             header: {
@@ -28023,7 +28244,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__delete: {
+    execute_endpoint_api_endpoints__workflow_id__post: {
         parameters: {
             query?: never;
             header: {
@@ -36787,6 +37008,77 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fetch_module_api_sdk_modules__path__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fetch_module_index_api_sdk_modules_index_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    fetch_requirements_api_sdk_requirements_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };

--- a/client/src/pages/AppRouter.tsx
+++ b/client/src/pages/AppRouter.tsx
@@ -23,6 +23,7 @@ import {
 import { useApplication } from "@/hooks/useApplications";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDocumentChrome } from "@/lib/useDocumentChrome";
+import { useApplicationName } from "@/lib/applicationName";
 import { term, useTerminology } from "@/lib/terminology";
 import { BundledAppShell } from "@/components/jsx-app/BundledAppShell";
 import { AppLayout } from "@/components/layout/AppLayout";
@@ -36,6 +37,7 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 	const { applicationId: slugParam } = useParams();
 	const navigate = useNavigate();
 	const terminology = useTerminology();
+	const applicationName = useApplicationName();
 	const { hasRole } = useAuth();
 	const isEmbed = hasRole("EmbedUser");
 
@@ -52,8 +54,8 @@ export function AppRouter({ preview = false }: AppRouterProps) {
 	useDocumentChrome({
 		title: application?.name
 			? preview
-				? `${application.name} (Preview) | Bifrost`
-				: `${application.name} | Bifrost`
+				? `${application.name} (Preview) | ${applicationName}`
+				: `${application.name} | ${applicationName}`
 			: undefined,
 		logo: application?.logo,
 		enabled: !isEmbed,

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -32,6 +32,7 @@ import { motion } from "framer-motion";
 import type { OAuthProvider } from "@/services/auth";
 import { Logo } from "@/components/branding/Logo";
 import { AuthTransition } from "@/components/auth/AuthTransition";
+import { useApplicationName } from "@/lib/applicationName";
 
 type LoginStep = "credentials" | "mfa" | "mfa-setup";
 
@@ -44,6 +45,7 @@ interface MFAState {
 export function Login() {
 	const navigate = useNavigate();
 	const location = useLocation();
+	const applicationName = useApplicationName();
 	const {
 		login,
 		loginWithMfa,
@@ -371,12 +373,12 @@ export function Login() {
 							<Logo
 								type="square"
 								className="h-16 w-16"
-								alt="Bifrost"
+								alt={applicationName}
 							/>
 						</motion.div>
 						<div className="space-y-1">
 							<h1 className="text-2xl font-bold tracking-tight">
-								Bifrost
+								{applicationName}
 							</h1>
 							<CardDescription className="text-base">
 								{step === "credentials" &&

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -22,8 +22,10 @@ import {
 	type OAuthProvider,
 } from "@/services/auth";
 import { registerInviteWithPasskey } from "@/services/passkeys";
+import { useApplicationName } from "@/lib/applicationName";
 
 export function Register() {
+	const applicationName = useApplicationName();
 	const [params] = useSearchParams();
 	const token = params.get("token") ?? "";
 	const [error, setError] = useState<string | null>(null);
@@ -127,7 +129,11 @@ export function Register() {
 						transition={{ delay: 0.1, duration: 0.3 }}
 						className="flex justify-center"
 					>
-						<Logo type="square" className="h-16 w-16" alt="Bifrost" />
+						<Logo
+						type="square"
+						className="h-16 w-16"
+						alt={applicationName}
+					/>
 					</motion.div>
 					<div className="space-y-1">
 						<h1 className="text-2xl font-bold tracking-tight">

--- a/client/src/pages/Setup.tsx
+++ b/client/src/pages/Setup.tsx
@@ -27,6 +27,7 @@ import {
 import { Loader2, Mail, User } from "lucide-react";
 import { motion } from "framer-motion";
 import { Logo } from "@/components/branding/Logo";
+import { useApplicationName } from "@/lib/applicationName";
 import { toast } from "sonner";
 import { AuthSetupSteps } from "@/components/auth/AuthSetupSteps";
 
@@ -34,6 +35,7 @@ type SetupMode = "choose" | "auth";
 
 export function Setup() {
 	const navigate = useNavigate();
+	const applicationName = useApplicationName();
 	const {
 		needsSetup,
 		isLoading: authLoading,
@@ -162,12 +164,12 @@ export function Setup() {
 							<Logo
 								type="square"
 								className="h-16 w-16"
-								alt="Bifrost"
+								alt={applicationName}
 							/>
 						</motion.div>
 						<div className="space-y-1">
 							<CardTitle className="text-2xl font-bold tracking-tight">
-								Welcome to Bifrost
+								Welcome to {applicationName}
 							</CardTitle>
 							<CardDescription className="text-base">
 								{mode === "choose" &&

--- a/client/src/pages/settings/Branding.tsx
+++ b/client/src/pages/settings/Branding.tsx
@@ -10,12 +10,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
-import { Loader2, Upload, Palette, RotateCcw } from "lucide-react";
+import { Loader2, Upload, Palette, RotateCcw, Type } from "lucide-react";
 import {
 	updateBranding,
 	uploadLogo,
 	resetLogo,
 	resetColor,
+	resetApplicationName,
 	getBranding,
 } from "@/hooks/useBranding";
 import { applyBrandingTheme, type BrandingSettings } from "@/lib/branding";
@@ -60,13 +61,15 @@ export function Branding() {
 	const [loading, setLoading] = useState(true);
 	const [saving, setSaving] = useState(false);
 	const [savingTerminology, setSavingTerminology] = useState(false);
+	const [savingApplicationName, setSavingApplicationName] = useState(false);
 	const [uploading, setUploading] = useState<"square" | "rectangle" | null>(
 		null,
 	);
 	const [resetting, setResetting] = useState<
-		"square" | "rectangle" | "color" | null
+		"square" | "rectangle" | "color" | "application-name" | null
 	>(null);
 	const [primaryColor, setPrimaryColor] = useState("#0066CC");
+	const [applicationName, setApplicationName] = useState("");
 	const [terminology, setTerminology] =
 		useState<Terminology>(DEFAULT_TERMINOLOGY);
 
@@ -84,6 +87,7 @@ export function Branding() {
 					if (data.primary_color) {
 						setPrimaryColor(data.primary_color);
 					}
+					setApplicationName(data.application_name ?? "");
 					setTerminology(
 						mergeTerminology(
 							data.terminology as BrandingTerminologyInput,
@@ -153,6 +157,58 @@ export function Branding() {
 			});
 		} finally {
 			setSavingTerminology(false);
+		}
+	};
+
+	const handleApplicationNameUpdate = async () => {
+		const trimmed = applicationName.trim();
+		setSavingApplicationName(true);
+		try {
+			// Empty input clears the custom name back to the default.
+			const updated = trimmed
+				? await updateBranding({ application_name: trimmed })
+				: await resetApplicationName();
+			setBranding(updated);
+			setApplicationName(updated.application_name ?? "");
+			refreshBranding();
+
+			toast.success("Application name updated", {
+				description: trimmed
+					? `Now showing "${trimmed}"`
+					: "Reverted to the default name",
+			});
+		} catch (err) {
+			toast.error("Error", {
+				description:
+					err instanceof Error
+						? err.message
+						: "Failed to update application name",
+			});
+		} finally {
+			setSavingApplicationName(false);
+		}
+	};
+
+	const handleResetApplicationName = async () => {
+		setResetting("application-name");
+		try {
+			const updated = await resetApplicationName();
+			setBranding(updated);
+			setApplicationName(updated.application_name ?? "");
+			refreshBranding();
+
+			toast.success("Application name reset", {
+				description: "Reverted to the default name",
+			});
+		} catch (err) {
+			toast.error("Error", {
+				description:
+					err instanceof Error
+						? err.message
+						: "Failed to reset application name",
+			});
+		} finally {
+			setResetting(null);
 		}
 	};
 
@@ -344,6 +400,67 @@ export function Branding() {
 
 	return (
 		<div className="space-y-6">
+			{/* Application Name */}
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Type className="h-5 w-5" />
+						Application Name
+					</CardTitle>
+					<CardDescription>
+						Shown on the login screen, browser tab, and header.
+						Leave blank to use the default.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div>
+						<Label htmlFor="applicationName">Name</Label>
+						<Input
+							id="applicationName"
+							type="text"
+							value={applicationName}
+							onChange={(e) =>
+								setApplicationName(e.target.value)
+							}
+							placeholder="Bifrost"
+							maxLength={40}
+							className="max-w-sm"
+						/>
+					</div>
+					<div className="flex gap-2">
+						<Button
+							onClick={handleApplicationNameUpdate}
+							disabled={
+								savingApplicationName ||
+								resetting === "application-name"
+							}
+							variant="default"
+						>
+							{savingApplicationName ? (
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							) : null}
+							Update Name
+						</Button>
+						<Button
+							onClick={handleResetApplicationName}
+							disabled={
+								savingApplicationName ||
+								resetting === "application-name"
+							}
+							variant="outline"
+							size="icon"
+							title="Reset to default name"
+						>
+							{resetting === "application-name" ? (
+								<Loader2 className="h-4 w-4 animate-spin" />
+							) : (
+								<RotateCcw className="h-4 w-4" />
+							)}
+						</Button>
+					</div>
+				</CardContent>
+			</Card>
+
 			{/* Primary Color */}
 			<Card>
 				<CardHeader>
@@ -514,6 +631,9 @@ export function Branding() {
 									</Button>
 								)}
 							</div>
+							<p className="text-xs text-muted-foreground">
+								Recommended: 512×512 px
+							</p>
 							<div
 								className={`relative border-2 border-dashed rounded-lg p-6 transition-colors h-48 flex items-center justify-center ${
 									dragActiveSquare
@@ -574,10 +694,10 @@ export function Branding() {
 							</div>
 						</div>
 
-						{/* Rectangle Logo */}
+						{/* Horizontal Logo */}
 						<div className="space-y-3">
 							<div className="flex items-center justify-between">
-								<Label>Rectangle Logo (16:9 ratio)</Label>
+								<Label>Horizontal Logo (~4:1 ratio)</Label>
 								{branding?.rectangle_logo_url && (
 									<Button
 										size="sm"
@@ -599,6 +719,9 @@ export function Branding() {
 									</Button>
 								)}
 							</div>
+							<p className="text-xs text-muted-foreground">
+								Recommended: 800×200 px
+							</p>
 							<div
 								className={`relative border-2 border-dashed rounded-lg p-6 transition-colors h-48 flex items-center justify-center ${
 									dragActiveRectangle

--- a/docs/superpowers/specs/2026-06-15-application-name-branding-design.md
+++ b/docs/superpowers/specs/2026-06-15-application-name-branding-design.md
@@ -1,0 +1,136 @@
+# Application Name branding setting (+ logo size guidance)
+
+**Date:** 2026-06-15
+**Status:** Approved design, pending implementation plan
+
+## Summary
+
+Add a customizable **Application Name** to the existing branding system so the
+product's proper name (today hardcoded as `Bifrost` / `Bifrost Integrations`)
+can be white-labeled on the auth screens, the browser tab title, and the header
+fallback wordmark. Bundle in a small fix to the logo upload UI that adds
+recommended pixel dimensions and corrects an inaccurate aspect-ratio label.
+
+This is an **additive** change to the existing branding infrastructure (DB
+`branding` table, `BrandingRepository`, the `/api/branding` router, the
+`useBranding` hook, and the Branding settings page). No new architecture.
+
+## Motivation
+
+White-labeling currently covers logos, primary color, and renamable nouns
+(`app` / `agent` / `form` via `BrandingTerminology`), but the product's own
+name is hardcoded in several user-facing places. A reseller deploying Bifrost
+under their own brand cannot replace "Bifrost" on the login screen.
+
+## Part A — Logo size guidance (bundled fix)
+
+File: `client/src/pages/settings/Branding.tsx`.
+
+The current labels show only an aspect ratio, and the rectangle one is
+inaccurate — the rectangle logo renders **height-constrained** in the header
+(`Logo.tsx`), not as a 16:9 box.
+
+| Element | Today | After |
+|---------|-------|-------|
+| Square logo label | `Square Logo (1:1 ratio)` | `Square Logo (1:1 ratio)` + helper text `Recommended: 512×512 px` |
+| Rectangle logo label | `Rectangle Logo (16:9 ratio)` | `Horizontal Logo (~4:1 ratio)` + helper text `Recommended: 800×200 px` |
+
+Helper text uses the existing `text-xs text-muted-foreground` style. The
+"Rectangle" → "Horizontal" rename is approved.
+
+The `BrandingSettings.rectangle_logo_url` field description in
+`api/src/models/contracts/common.py` (`"...for headers, 16:9 ratio"`) is also
+corrected to `"...for headers, ~4:1 ratio"`. The DB field name
+(`rectangle_logo_*`) and API logo-type path (`/logo/rectangle`) stay unchanged —
+only display copy changes.
+
+## Part B — Application Name field
+
+### Data model
+
+Single nullable field, mirroring the existing `primary_color` pattern.
+
+- **DB** (`api/src/models/orm/branding.py`, `GlobalBranding`):
+  `application_name: Mapped[str | None] = mapped_column(String(40), default=None)`.
+  New Alembic migration adds the column.
+- **Contracts** (`api/src/models/contracts/common.py`):
+  - `BrandingSettings.application_name: str | None` — the **raw** stored value
+    (`None` when unset). The "Bifrost" fallback is applied only in the frontend
+    helper, never baked into the API response.
+  - `BrandingUpdateRequest.application_name: str | None = Field(default=None, min_length=1, max_length=40)`.
+- **Repository** (`api/src/repositories/branding.py`, `set_branding`): accept and
+  persist `application_name` using the same non-destructive update pattern as
+  `primary_color` (only overwrite when the caller passes a value; the dedicated
+  clear path sets it back to `None`).
+- **Router** (`api/src/routers/branding.py`): thread `application_name` through
+  the `GET` response builder and the `PUT` handler. The existing reset/delete
+  paths set it to `None`.
+
+`application_name` is **empty by default**. When empty, the UI falls back to the
+literal `"Bifrost"` (short) / `"Bifrost Integrations"` (long) exactly as today,
+so existing installs see zero change.
+
+### Frontend plumbing
+
+- `useBranding` (`client/src/hooks/useBranding.ts`) and `OrgScopeContext`
+  (`client/src/contexts/OrgScopeContext.tsx`) expose `applicationName: string | null`
+  alongside the existing logo/color/terminology values. `/api/branding` is a
+  **public** endpoint (no auth required), so the name is available on the
+  pre-auth login/setup screens.
+- New helper `useApplicationName()` returns `applicationName ?? "Bifrost"`.
+  A single fallback constant `DEFAULT_APPLICATION_NAME = "Bifrost"` lives next to
+  it so the literal is defined once. (Spots that historically used the long form
+  "Bifrost Integrations" now use the single custom name when set, and the long
+  literal only as their hardcoded fallback when unset — see table.)
+
+### Replacement sites (in scope)
+
+| Surface | File(s) | Today | After (name set) | After (name unset) |
+|---------|---------|-------|------------------|--------------------|
+| Login h1 | `pages/Login.tsx` | `Bifrost` | `{name}` | `Bifrost` |
+| Setup title | `pages/Setup.tsx` | `Welcome to Bifrost` | `Welcome to {name}` | `Welcome to Bifrost` |
+| Register / AuthTransition / MFA `alt` + any visible name | `pages/Register.tsx`, `components/auth/AuthTransition.tsx`, `pages/MFASetup.tsx` | `Bifrost` | `{name}` | `Bifrost` |
+| Header fallback wordmark | `components/branding/Logo.tsx` | `Bifrost Integrations` | `{name}` | `Bifrost Integrations` |
+| Browser tab title | `lib/useDocumentChrome.ts` | `… | Bifrost`, base `Bifrost Integrations` | `… | {name}`, base `{name}` | unchanged literals |
+
+`alt` attributes that currently read `"Bifrost"` become `{name}` for consistency
+(screen-reader accuracy), using the same fallback.
+
+### Explicitly out of scope
+
+- `client/index.html` static `<title>` stays `Bifrost Integrations` — it is the
+  first paint before JS/branding loads. `useDocumentChrome` overwrites the tab
+  title once branding resolves, so a branded install shows the custom name a beat
+  after load. (Approved.)
+- `VersionUpdateBanner` and secondary mentions on MCP / developer / security
+  pages keep the literal "Bifrost". Not part of this change.
+- `Logo.tsx`'s `defaultLogo` image (`/logo.svg`) is governed by the existing
+  logo-upload feature, not this field.
+
+### Settings UI
+
+In `client/src/pages/settings/Branding.tsx`, add an **Application Name** text
+input at the top of the first branding card (above the logos card), with a
+clear/reset affordance that mirrors the existing primary-color control. Label:
+`Application Name`; helper text: `Shown on the login screen, browser tab, and
+header. Leave blank to use the default.`
+
+## Testing
+
+- **Backend unit** (`api/tests/unit/`): round-trip `application_name` through
+  `BrandingRepository.set_branding` (set, update, clear-to-None); 40-char max and
+  1-char min validation on `BrandingUpdateRequest`.
+- **Backend e2e** (`api/tests/e2e/`): `PUT /api/branding` with `application_name`
+  then `GET` returns it; reset/delete clears it.
+- **Frontend vitest**: `useApplicationName()` returns the name when set and
+  `"Bifrost"` when null; `useDocumentChrome` test updated to assert the suffix
+  uses the resolved name (extend existing `useDocumentChrome.test.ts`).
+- **Type regen**: `npm run generate:types` after the contract change.
+
+## Risks / notes
+
+- The `/api/branding` payload is public; `application_name` is non-sensitive
+  display copy, so exposing it pre-auth is intended.
+- Existing `useDocumentChrome.test.ts` hardcodes `"… | Bifrost"` /
+  `"Bifrost Integrations"`; those assertions move to the resolved-name path with
+  the literal as the unset fallback.


### PR DESCRIPTION
Closes #378

## What
Adds a customizable **Application Name** to the branding system and clarifies the logo upload UI.

### Application Name
- New nullable `application_name` field — full stack: DB column + migration, `BrandingSettings`/`BrandingUpdateRequest` contracts, repository, router `GET`/`PUT` + `DELETE /api/branding/application-name`.
- `set_branding` uses a sentinel so the field can be **set**, **left unchanged**, or **explicitly cleared** — the legacy `None`-means-skip convention (still used for color/logos) can't express clearing.
- Frontend: `applicationName` threaded through `useBranding` + `OrgScopeContext`; new `useApplicationName()` / `resolveApplicationName()` helper falls back to `"Bifrost"`. Wired into Login, Setup, Register, AuthTransition, the header fallback wordmark (`Logo`), the app-tab title (`AppRouter`), and the base browser-tab title (`App`). Settings page gets an Application Name card.
- Empty by default → existing installs see zero change.

### Logo guidance
- Square logo: `Recommended: 512×512 px`.
- Rectangle relabeled **Horizontal Logo (~4:1 ratio)** + `Recommended: 800×200 px`. The old `16:9` was inaccurate — the logo renders height-constrained in the header, not as a 16:9 box. Contract description updated to match.

## Out of scope
`index.html`'s static `<title>` stays the literal default (first paint, pre-JS); it's overwritten once branding loads. `VersionUpdateBanner` and secondary MCP/dev/security mentions keep "Bifrost".

## Testing
- Backend unit (`test_branding_repository.py`): sentinel set/leave-unchanged/clear semantics.
- Backend e2e (`TestBranding`): set→clear round-trip, color-only-PUT doesn't clear, 40-char rejection (422), org-user denied (403).
- Vitest (`applicationName.test.ts`): helper set/unset/fallback + hook.
- `pyright` / `ruff` / `tsc` / `eslint` all clean. Full lifecycle driven against the live API (set/clear/validation/permission verified).

## Design
`docs/superpowers/specs/2026-06-15-application-name-branding-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)