### PR TITLE
Fix failing Register tests after Application Name change (#379)

### DIFF
--- a/client/src/pages/Register.test.tsx
+++ b/client/src/pages/Register.test.tsx
@@ -26,6 +26,12 @@ vi.mock("@/components/branding/Logo", () => ({
 	Logo: () => null,
 }));
 
+// Register reads the product name via useApplicationName, which depends on
+// OrgScopeContext. Stub it so the page renders without the full provider tree.
+vi.mock("@/lib/applicationName", () => ({
+	useApplicationName: () => "Bifrost",
+}));
+
 vi.mock("@/services/passkeys", () => ({
 	registerInviteWithPasskey: vi.fn(),
 }));


### PR DESCRIPTION
Follow-up to #379 (which merged with `main` red).

## Problem
#379 added a direct `useApplicationName()` call to `Register` (and Login/Setup/AuthTransition), which depends on `OrgScopeContext`. `Register.test.tsx` renders `<Register>` via `renderWithProviders`, which does **not** supply `OrgScopeProvider`, so `useOrgScope()` throws and the 3 Register tests fail on `main`.

The merge queue merged #379 on a run that didn't include this fix, so `main` is currently red on **Client Unit Tests**.

## Fix
Mock `@/lib/applicationName` in `Register.test.tsx`, matching the existing `Logo` mock in the same file. One file, +6 lines.

Only `Register.test.tsx` was affected — no other test renders `<Login>`, `<Setup>`, `<AuthTransition>`, or `<AppRouter>` directly (verified). Full client suite green locally (172 files / 1242 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)