### PR TITLE
fix(test): make e2e form-RBAC teardown best-effort (kills the recurring flake)

### DIFF
--- a/api/tests/e2e/platform/test_form_execute_solution_scope_e2e.py
+++ b/api/tests/e2e/platform/test_form_execute_solution_scope_e2e.py
@@ -5,6 +5,7 @@ Also pins the RBAC contract: the handler resolves the workflow on the FORM's
 behalf (is_superuser=True), so a form user with no role on a ``role_based``
 workflow must still reach it — the form's own access gate is authoritative.
 """
+import contextlib
 from uuid import UUID, uuid4
 
 import pytest
@@ -207,9 +208,18 @@ class TestFormExecuteEndpointRbac:
             assert r.status_code == 200, f"expected 200, got {r.status_code}: {r.text}"
             assert r.json().get("execution_id"), r.text
         finally:
-            e2e_client.delete(f"/api/forms/{form_id}", headers=platform_admin.headers)
-            e2e_client.delete(f"/api/roles/{role_id}", headers=platform_admin.headers)
-            e2e_client.delete(f"/api/files/editor?path={path}", headers=platform_admin.headers)
+            # Best-effort cleanup: the assertions above have already run, so a
+            # transient transport blip (httpx connection-reset) or non-2xx while
+            # deleting a fixture must NOT fail an otherwise-passing test. Each
+            # delete is suppressed independently so one failure doesn't skip the
+            # rest. (This teardown flaking is what repeatedly red-ran the merge
+            # queue / release build / Dependabot on a role-DELETE reset.)
+            with contextlib.suppress(Exception):
+                e2e_client.delete(f"/api/forms/{form_id}", headers=platform_admin.headers)
+            with contextlib.suppress(Exception):
+                e2e_client.delete(f"/api/roles/{role_id}", headers=platform_admin.headers)
+            with contextlib.suppress(Exception):
+                e2e_client.delete(f"/api/files/editor?path={path}", headers=platform_admin.headers)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## The flake

`test_non_superuser_form_user_executes_role_based_workflow` (in `tests/e2e/platform/test_form_execute_solution_scope_e2e.py`) ran three **unguarded** cleanup DELETEs in its `finally` block. After all assertions passed, a transient `httpx.ReadError: [Errno 104] Connection reset by peer` / 500 on one of them (observed on `DELETE /api/roles/{id}`) propagated and **failed an otherwise-passing test**.

This single flake repeatedly red-ran:
- the **merge queue** (ejected #347 once),
- the **v1.0.0 release build** (3 retries before it passed), and
- **Dependabot** auto-merge CI (still blocking several dep PRs).

It's the Cluster B `connection-reset/ReadTimeout` family — infra-transient, not a product bug (the test passes locally; the failure is purely in best-effort teardown).

## The fix

Wrap each teardown DELETE in its own `contextlib.suppress(Exception)` so:
- all three deletes are still **attempted** (one failure doesn't skip the rest), and
- a transient blip during cleanup can no longer fail the test.

Test assertions and logic before `finally` are unchanged.

## Verification
- 7 tests in the file pass; `ruff` + `pyright` (CI config) clean.
- Diagnosed + drafted via Codex, reviewed + comment-annotated + verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)