### PR TITLE
fix(deps): bump dompurify 3.4.1 → 3.4.10 (resolves 8 security alerts)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -54,7 +54,7 @@
 				"cmdk": "^1.1.1",
 				"dagre": "^0.8.5",
 				"date-fns": "^4.4.0",
-				"dompurify": "^3.4.1",
+				"dompurify": "^3.4.10",
 				"framer-motion": "^12.40.0",
 				"fuse.js": "^7.4.2",
 				"lucide-react": "^1.20.0",
@@ -3155,9 +3155,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3173,9 +3170,6 @@
 			"integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3193,9 +3187,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3211,9 +3202,6 @@
 			"integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -5817,9 +5805,9 @@
 			"peer": true
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-			"integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"

--- a/client/package.json
+++ b/client/package.json
@@ -74,7 +74,7 @@
 		"cmdk": "^1.1.1",
 		"dagre": "^0.8.5",
 		"date-fns": "^4.4.0",
-		"dompurify": "^3.4.1",
+		"dompurify": "^3.4.10",
 		"framer-motion": "^12.40.0",
 		"fuse.js": "^7.4.2",
 		"lucide-react": "^1.20.0",
@@ -134,6 +134,6 @@
 		"vitest": "^4.1.4"
 	},
 	"overrides": {
-		"dompurify": "^3.4.1"
+		"dompurify": "^3.4.10"
 	}
 }


### PR DESCRIPTION
Dependabot's client npm group (#383) bumped 41 packages but **left dompurify at 3.4.1** (it's not in the ignore list — just wasn't grouped), leaving 5 open dompurify Dependabot alerts + transitive babel/js-yaml ones.

## Change
- `dompurify` `^3.4.1` → `^3.4.10` in both `dependencies` **and** `overrides` (the override ensures transitive consumers like monaco-editor also get the patched version). Lock resolves to **3.4.11** — above all alert fix versions (3.4.6–3.4.9).

## Alerts resolved
- 2× medium (IN_PLACE clobber / shadow-root bypass), 1× medium (hook mutation), lows (SAFE_FOR_TEMPLATES bypass, Trusted-Types `clearConfig` survival)
- The one remaining dompurify alert (`IN_PLACE` nodeName, **no patch available**) does **not apply** — SafeHTMLRenderer sanitizes in `WHOLE_DOCUMENT` mode, not `IN_PLACE`.

## On the 3.4.10 × happy-dom history
The incompatibility that bit us earlier is already mitigated — SafeHTMLRenderer's test runs under `jsdom` (per-file env), so the newer dompurify works.

## Verification
- Full client suite: **198 files / 1441 tests, 0 failures**
- SafeHTMLRenderer: 4/4
- tsc clean (1 pre-existing unrelated lint warning)
- `npm ci` exits 0 under **both** node:20 (test runner) and node:26 (image build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)