### PR TITLE
CLI deploy polish: instrument deploy phases, mention files in push --help

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -1770,7 +1770,7 @@ def handle_push(args: list[str]) -> int:
       bifrost push <path> [--mirror] [--validate]
 
     Args:
-      path: Local directory to push (defaults to ".")
+      path: Local file or directory to push (defaults to ".")
       --mirror: Make target match source exactly (delete files not present locally)
       --validate: Validate after push (for apps)
     """
@@ -1781,7 +1781,7 @@ Usage: bifrost push [path] [options]
 Push local files to Bifrost platform.
 
 Arguments:
-  path                  Local directory to push (default: current directory)
+  path                  Local file or directory to push (default: current directory)
 
 Options:
   --mirror              Make target match source exactly (delete files not present locally)
@@ -1798,6 +1798,7 @@ Use 'bifrost watch' for continuous file watching.
 Examples:
   bifrost push apps/my-app
   bifrost push apps/my-app --mirror
+  bifrost push workflows/my_workflow.py
   bifrost push .
 """.strip())
         return 0

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -1407,7 +1407,7 @@ def deploy_cmd(
         solution_logo_b64 = base64.b64encode(logo_file.read_bytes()).decode("ascii")
         solution_logo_content_type = _LOGO_CONTENT_TYPES.get(logo_file.suffix.lower())
 
-    click.echo("Collecting solution files...")
+    click.echo("Scanning solution files...")
     python_files = _collect_python_files(workspace)
     workflows = _collect_workflows(workspace)
     tables = _collect_tables(workspace)
@@ -1419,6 +1419,10 @@ def deploy_cmd(
     connection_schemas = _collect_connection_schemas(workspace)
     events = _collect_events(workspace)
     readme = _collect_readme(workspace)
+    click.echo(
+        f"  found {len(python_files)} python file(s), {len(workflows)} workflow(s), "
+        f"{len(apps)} app(s), {len(forms)} form(s), {len(agents)} agent(s)."
+    )
 
     async def _run() -> int:
         client = BifrostClient.get_instance(require_auth=True)
@@ -1466,6 +1470,12 @@ def deploy_cmd(
         if not descriptor.global_repo_access:
             from bifrost.solution_vendoring import vendor_shared_deps
 
+            # Vendoring scans imports and reads each referenced _repo/ module
+            # over the network one at a time, so it can take a few seconds on a
+            # solution with a deep shared-module graph. Announce it up front so
+            # the wait isn't a silent gap before the bundle summary.
+            click.echo("Vendoring shared dependencies...")
+
             async def _repo_read(path: str) -> str | None:
                 resp = await client.post("/api/files/read", json={
                     "path": path, "location": "workspace", "mode": "cloud",
@@ -1476,8 +1486,10 @@ def deploy_cmd(
 
             vendored = await vendor_shared_deps(python_files, _repo_read)
             if vendored:
-                click.echo(f"Vendored {len(vendored)} shared dependency file(s).")
+                click.echo(f"  vendored {len(vendored)} shared dependency file(s).")
                 bundle_python = {**python_files, **vendored}
+            else:
+                click.echo("  no shared dependencies to vendor.")
 
         summary = summarize_bundle(bundle_python, apps, len(vendored))
         click.echo(summary.message, err=summary.warn)

--- a/api/tests/unit/test_cli_solution_deploy_phases.py
+++ b/api/tests/unit/test_cli_solution_deploy_phases.py
@@ -1,0 +1,108 @@
+"""`bifrost solution deploy` — the progress phases the CLI prints.
+
+Deploy used to go quiet between collecting files and the bundle summary, with
+the network-bound vendoring step hidden. These tests pin the visible phases so
+that gap stays instrumented:
+
+  Scanning solution files...  ->  found N ... file(s)
+  Vendoring shared dependencies...  ->  (vendored M | no shared dependencies)
+  Bundle: ...
+  Uploading bundle...  ->  Deploying install ...
+
+BifrostClient is mocked so no network/DB is touched. Deploying with --global and
+the default (vendoring-on) descriptor drives the no-shared-deps branch: the
+mocked /api/files/read returns nothing, so vendoring resolves to zero files.
+"""
+from __future__ import annotations
+
+import pathlib
+from unittest import mock
+
+import yaml
+from click.testing import CliRunner
+
+from bifrost.commands.solution import solution_group
+from bifrost.solution_descriptor import DESCRIPTOR_FILENAME
+
+INSTALL_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _resp(payload, status=200):
+    r = mock.MagicMock()
+    r.status_code = status
+    r.json.return_value = payload
+    r.text = str(payload)
+    return r
+
+
+def _client():
+    async def get(path, **_kwargs):  # type: ignore[no-untyped-def]
+        if path == "/api/solutions":
+            return _resp({"solutions": []})
+        if "/deploy-jobs/" in path:
+            return _resp({"status": "succeeded", "error": None, "install_id": INSTALL_ID})
+        return _resp({}, status=404)
+
+    async def post(path, json=None, **_kwargs):  # type: ignore[no-untyped-def]  # noqa: ARG001
+        if path == "/api/solutions":
+            return _resp({"id": INSTALL_ID}, status=201)
+        if path == "/api/files/read":
+            # Nothing resolvable in _repo/ -> nothing to vendor.
+            return _resp({"content": None}, status=404)
+        if path.endswith("/deploy"):
+            return _resp({"deploy_job_id": "job-1"}, status=202)
+        return _resp({}, status=404)
+
+    c = mock.AsyncMock()
+    c.get = get
+    c.post = post
+    c.organization = {"id": "00000000-0000-0000-0000-000000000000"}
+    return c
+
+
+def _scaffold(tmp_path: pathlib.Path) -> pathlib.Path:
+    ws = tmp_path / "sol"
+    ws.mkdir()
+    (ws / DESCRIPTOR_FILENAME).write_text(
+        yaml.safe_dump(
+            {
+                "slug": "demo",
+                "name": "Demo",
+                "version": "0.1.0",
+                "global_repo_access": False,
+            },
+            sort_keys=False,
+        )
+    )
+    (ws / "workflows").mkdir()
+    (ws / "workflows" / "hello.py").write_text("def run():\n    return 1\n")
+    return ws
+
+
+def _invoke(ws: pathlib.Path):
+    with mock.patch(
+        "bifrost.client.BifrostClient.get_instance", return_value=_client()
+    ):
+        return CliRunner().invoke(
+            solution_group, ["deploy", str(ws), "--global"], catch_exceptions=False
+        )
+
+
+def test_deploy_prints_each_phase(tmp_path) -> None:
+    result = _invoke(_scaffold(tmp_path))
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Each phase is announced before its (possibly slow) work runs.
+    assert "Scanning solution files..." in out
+    assert "found" in out and "python file(s)" in out
+    assert "Vendoring shared dependencies..." in out
+    assert "Bundle:" in out
+    assert "Uploading bundle..." in out
+    assert "Deploying install" in out
+
+
+def test_deploy_reports_when_nothing_to_vendor(tmp_path) -> None:
+    result = _invoke(_scaffold(tmp_path))
+    assert result.exit_code == 0, result.output
+    # The vendoring announcement always resolves to a result line, even at zero.
+    assert "no shared dependencies to vendor." in result.output


### PR DESCRIPTION
Follow-up polish on the Solution deploy UX work from #388, addressing two pieces of feedback.

## 1. `bifrost push --help` now mentions files
Single-file push already works (`cli.py` branches on `resolved.is_file()`), but the help text and docstring still said "Local **directory** to push." Now reads "Local **file or directory**" and includes a `bifrost push workflows/my_workflow.py` example.

## 2. Solution deploy phases are instrumented
Deploy went quiet between collecting files and the bundle summary. The local file scan and — more importantly — the **network-bound vendoring loop** (one sequential `/api/files/read` per referenced shared module) were both invisible, which made deploy feel like it stalled.

Now each phase is announced *before* its work runs:

```
Scanning solution files...
  found 1 python file(s), 1 workflow(s), 0 app(s), 0 form(s), 0 agent(s).
Vendoring shared dependencies...
  no shared dependencies to vendor.          (or "vendored N …")
Bundle: …
Uploading bundle...
Deploying install … (job …)...
```

The vendoring line always resolves to a result line instead of dangling.

## Tests
- New `test_cli_solution_deploy_phases.py` drives `solution deploy` end-to-end with a mocked client, asserting every phase string including the no-vendor branch.
- 26 related CLI/deploy/solution unit tests green; ruff clean; no new pyright errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)