### PR TITLE
Ship source artifacts for solution deploys

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -7,8 +7,8 @@ loop runs headless (criterion 17).
 
 * ``bifrost solution init`` — scaffold a ``bifrost.solution.yaml`` descriptor.
 * ``bifrost solution deploy`` (alias: top-level ``bifrost deploy``) — read the
-  descriptor, ensure the install exists, bundle the workspace's Python source +
-  workflow manifest entries, and POST to ``/api/solutions/{id}/deploy``.
+  descriptor, ensure the install exists, zip the workspace, and POST it to
+  ``/api/solutions/{id}/deploy``.
 
 Apps/forms/agents/tables bundling joins in their sub-plans; Sub-plan 1 wires the
 load-bearing workflow path.
@@ -18,11 +18,13 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import io
 import json
 import os
 import pathlib
 import subprocess
 import time
+import zipfile
 
 import click
 import yaml
@@ -1314,6 +1316,7 @@ async def _poll_deploy_job(client, job_id: str, *, interval: float = 3.0) -> int
     ``succeeded``, 1 on ``failed`` (printing the server-captured error).
     """
     start = time.monotonic()
+    last_phase: str | None = None
     while True:
         resp = await client.get(f"/api/solutions/deploy-jobs/{job_id}")
         if resp.status_code != 200:
@@ -1335,6 +1338,10 @@ async def _poll_deploy_job(client, job_id: str, *, interval: float = 3.0) -> int
                 error = f"{error}\nRe-run with --force to downgrade."
             click.echo(f"Deploy failed: {error}", err=True)
             return 1
+        phase = (body.get("result") or {}).get("phase")
+        if isinstance(phase, str) and phase and phase != last_phase:
+            click.echo(f"Deploy phase: {phase}")
+            last_phase = phase
         elapsed = int(time.monotonic() - start)
         click.echo(f"Still deploying... {elapsed}s")
         await asyncio.sleep(interval)
@@ -1343,6 +1350,7 @@ async def _poll_deploy_job(client, job_id: str, *, interval: float = 3.0) -> int
 # Vendoring modules/ + shared/ into a Solution can balloon the bundle; warn the
 # operator loudly so an accidental dependency tree doesn't ship silently.
 _VENDORED_WARN_THRESHOLD = 200
+_ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
 
 
 @dataclasses.dataclass
@@ -1376,6 +1384,47 @@ def summarize_bundle(python_files: dict, apps: list, vendored_count: int) -> Bun
     return BundleSummary(count, mb, warn, msg)
 
 
+def _build_deploy_zip(
+    workspace: pathlib.Path,
+    *,
+    extra_text_files: dict[str, str],
+) -> bytes:
+    """Build the workspace zip sent by ``solution deploy``.
+
+    Deploy zips must carry ``.bifrost/`` manifests, unlike normal file sync,
+    but must still skip dependency/build output and local secrets.
+    """
+    import pathspec
+
+    from bifrost.ignore_patterns import DEFAULT_IGNORE_PATTERNS
+
+    patterns = [p for p in DEFAULT_IGNORE_PATTERNS if p != ".bifrost/"]
+    patterns.append(".bifrost/secrets.enc")
+    ignore_spec = pathspec.GitIgnoreSpec.from_lines(patterns)
+    entries: dict[str, bytes] = {}
+    for path in workspace.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(workspace).as_posix()
+        if ignore_spec.match_file(rel):
+            continue
+        entries[rel] = path.read_bytes()
+
+    for rel, content in extra_text_files.items():
+        rel_path = pathlib.PurePosixPath(rel)
+        if rel_path.is_absolute() or ".." in rel_path.parts:
+            raise click.ClickException(f"refusing unsafe vendored path: {rel}")
+        entries[rel_path.as_posix()] = content.encode("utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for rel, data in sorted(entries.items()):
+            info = zipfile.ZipInfo(rel, date_time=_ZIP_EPOCH)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, data)
+    return buf.getvalue()
+
+
 @solution_group.command(name="deploy", help="Deploy the current Solution workspace (full replace, non-interactive).")
 @click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
 @click.option("--solution", "solution_id", default=None, help="Target install id (override when ambiguous).")
@@ -1393,32 +1442,12 @@ def deploy_cmd(
         )
     descriptor = load_descriptor(workspace)
 
-    # Solution-level icon: `logo:` in bifrost.solution.yaml points at an image
-    # relative to the workspace root; carried base64 for deploy to stamp on the
-    # install (shown on the /solutions catalog). Errors loudly when missing.
-    solution_logo_b64: str | None = None
-    solution_logo_content_type: str | None = None
-    if descriptor.logo:
-        import base64
-
-        logo_file = workspace / descriptor.logo
-        if not logo_file.is_file():
-            raise click.ClickException(f"solution logo file not found at {logo_file}")
-        solution_logo_b64 = base64.b64encode(logo_file.read_bytes()).decode("ascii")
-        solution_logo_content_type = _LOGO_CONTENT_TYPES.get(logo_file.suffix.lower())
-
     click.echo("Scanning solution files...")
     python_files = _collect_python_files(workspace)
     workflows = _collect_workflows(workspace)
-    tables = _collect_tables(workspace)
     apps = _collect_apps(workspace)
     forms = _collect_forms(workspace)
     agents = _collect_agents(workspace)
-    claims = _collect_claims(workspace)
-    config_schemas = _collect_config_schemas(workspace)
-    connection_schemas = _collect_connection_schemas(workspace)
-    events = _collect_events(workspace)
-    readme = _collect_readme(workspace)
     click.echo(
         f"  found {len(python_files)} python file(s), {len(workflows)} workflow(s), "
         f"{len(apps)} app(s), {len(forms)} form(s), {len(agents)} agent(s)."
@@ -1493,30 +1522,22 @@ def deploy_cmd(
 
         summary = summarize_bundle(bundle_python, apps, len(vendored))
         click.echo(summary.message, err=summary.warn)
+        zip_bytes = _build_deploy_zip(workspace, extra_text_files=vendored)
 
-        click.echo("Uploading bundle...")
+        click.echo("Uploading workspace zip...")
         # Deploy is async server-side; the POST returns a job id quickly. We give
         # the upload itself a generous timeout (large bundles) but never block on
         # the deploy work — that is observed via the poll loop below.
         deploy = await client.post(
             f"/api/solutions/{target_id}/deploy",
-            json={
-                "python_files": bundle_python,
-                "workflows": workflows,
-                "tables": tables,
-                "apps": apps,
-                "forms": forms,
-                "agents": agents,
-                "claims": claims,
-                "config_schemas": config_schemas,
-                "connection_schemas": connection_schemas,
-                "events": events,
-                "readme": readme,
-                "version": descriptor.version,
-                "logo_b64": solution_logo_b64,
-                "logo_content_type": solution_logo_content_type,
-                "force": force,
+            files={
+                "file": (
+                    f"{descriptor.slug}.zip",
+                    zip_bytes,
+                    "application/zip",
+                )
             },
+            params={"force": "true" if force else "false"},
             timeout=600,
         )
         if deploy.status_code != 202:

--- a/api/bifrost/contract_version.py
+++ b/api/bifrost/contract_version.py
@@ -17,7 +17,9 @@ integers agree and fails if a CLI-consumed contract changed without a decision.
 #     organization_id; descriptor no longer carries scope (2026-06-15)
 # v5: Solution deploy is async: POST /deploy returns 202 + deploy_job_id and
 #     callers poll SolutionDeployJobStatus for the deploy summary (2026-06-17)
-CONTRACT_VERSION: int = 5
+# v6: Solution deploy uploads a workspace zip as multipart/form-data instead of
+#     the legacy JSON bundle request body (2026-06-21)
+CONTRACT_VERSION: int = 6
 
 
 def get_contract_version() -> int:

--- a/api/shared/contract_version.py
+++ b/api/shared/contract_version.py
@@ -18,7 +18,9 @@ or cosmetic changes do NOT bump it. The tripwire in
 #     organization_id; descriptor no longer carries scope (2026-06-15)
 # v5: Solution deploy is async: POST /deploy returns 202 + deploy_job_id and
 #     callers poll SolutionDeployJobStatus for the deploy summary (2026-06-17)
-CONTRACT_VERSION: int = 5
+# v6: Solution deploy uploads a workspace zip as multipart/form-data instead of
+#     the legacy JSON bundle request body (2026-06-21)
+CONTRACT_VERSION: int = 6
 
 
 def get_contract_version() -> int:

--- a/api/src/models/contracts/solutions.py
+++ b/api/src/models/contracts/solutions.py
@@ -371,56 +371,6 @@ class SolutionInstallPreview(BaseModel):
     readme: str | None = None
 
 
-class SolutionDeployRequest(BaseModel):
-    """Full-replace deploy bundle for one install.
-
-    ``python_files`` maps relative paths (e.g. ``workflows/w.py``,
-    ``modules/x.py``) to UTF-8 source text, installed verbatim under the
-    install's ``_solutions/{id}/`` prefix. ``workflows`` are manifest-shaped
-    entity dicts to upsert (apps/forms/agents/tables join in later sub-plans).
-    Deploy is non-interactive by contract — it always applies the full bundle.
-    """
-
-    python_files: dict[str, str] = Field(default_factory=dict)
-    workflows: list[dict[str, Any]] = Field(default_factory=list)
-    tables: list[dict[str, Any]] = Field(default_factory=list)
-    # Each app: {id, slug, name, app_model, dependencies, access_level,
-    # src_files: {rel: text} | dist_files: {rel: text},
-    # bin_dist_files: {rel: base64}}. dist_files/bin_dist_files are the
-    # disconnected fast-path (skip the server build); bin_dist_files carries
-    # non-UTF-8 dist assets (images/fonts/wasm) base64-encoded so they survive
-    # the round-trip unmangled.
-    apps: list[dict[str, Any]] = Field(default_factory=list)
-    # Each form: {id, name, description?, workflow_id?, fields: [...]}.
-    forms: list[dict[str, Any]] = Field(default_factory=list)
-    # Each agent: {id, name, system_prompt, description?, channels?, llm_model?}.
-    agents: list[dict[str, Any]] = Field(default_factory=list)
-    claims: list[dict[str, Any]] = Field(default_factory=list)
-    # Each config schema: {id, key, type, required, description?, default?, position}.
-    # DECLARATIONS only — never a value (values are instance-owned Config rows).
-    config_schemas: list[dict[str, Any]] = Field(default_factory=list)
-    # Each: {integration_name, template, position}. Secret-scrubbed skeletons
-    # (no client_id/secret). Declared from integrations.get("X") refs.
-    connection_schemas: list[dict[str, Any]] = Field(default_factory=list)
-    # Each event/schedule trigger: a ManifestEventSource-shaped dict (source +
-    # schedule/webhook config + nested subscriptions). Webhook instance secrets
-    # are scrubbed; the instance re-establishes external state after install.
-    events: list[dict[str, Any]] = Field(default_factory=list)
-    # The bundle's declared version (bifrost.solution.yaml ``version:``).
-    # Recorded on the install; an older version than installed is refused
-    # unless ``force`` is set (Task 20 downgrade gate).
-    version: str | None = None
-    # Solution-level icon declared by ``logo:`` in bifrost.solution.yaml,
-    # carried base64 by the CLI; deploy validates and stamps it on the install
-    # (absent => cleared).
-    logo_b64: str | None = None
-    logo_content_type: str | None = None
-    # Long-form README markdown sourced from the repo-root README.md (Task 6).
-    # Deploy-owned full-replace: present => set, absent => cleared.
-    readme: str | None = None
-    force: bool = False
-
-
 class SolutionDeleteSummary(BaseModel):
     """Counts of what a DELETE did. Pure-code entities (workflows/apps/forms/
     agents) and the install's config DECLARATIONS are deleted via DB cascade.

--- a/api/src/routers/solutions.py
+++ b/api/src/routers/solutions.py
@@ -39,7 +39,6 @@ from src.models.contracts.solutions import (
     SolutionDependencyPreviewRequest,
     SolutionDeployEnqueued,
     SolutionDeployJobStatus,
-    SolutionDeployRequest,
     SolutionEntities,
     SolutionEntitySummary,
     SolutionExistingInstall,
@@ -65,8 +64,6 @@ from src.models.orm.solutions import Solution as SolutionORM
 from src.models.orm.tables import Table
 from src.models.orm.workflows import Workflow
 from src.services.solutions.deploy import (
-    SolutionBundle,
-    SolutionDeployer,
     SolutionDeployConflict,
     SolutionDowngradeBlocked,
     SolutionFinalizeIncomplete,
@@ -302,17 +299,40 @@ async def export_solution(
         )
 
     from src.services.solutions.capture import SolutionCaptureService
-    from src.services.solutions.export import build_workspace_zip
+    from src.services.solutions.export import (
+        add_encrypted_content_to_workspace_zip,
+        build_workspace_zip,
+    )
+    from src.services.solutions.source_artifact import SolutionSourceArtifactStorage
 
     sol = await ctx.db.get(SolutionORM, solution_id)
     if sol is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Solution not found")
 
     include_values = mode == "full"
-    bundle = await SolutionCaptureService(ctx.db).bundle_for(
-        sol, include_imports=True, include_values=include_values, include_data=include_data
-    )
-    data = build_workspace_zip(bundle, password=password if include_values else None)
+    stored_source = await SolutionSourceArtifactStorage(solution_id).read()
+    if stored_source is not None and mode == "shareable":
+        data = stored_source
+    else:
+        bundle = await SolutionCaptureService(ctx.db).bundle_for(
+            sol,
+            include_imports=True,
+            include_values=include_values,
+            include_data=include_data,
+        )
+        if stored_source is not None:
+            from src.services.solutions.secrets_blob import SolutionContent
+
+            data = add_encrypted_content_to_workspace_zip(
+                stored_source,
+                SolutionContent(
+                    config_values=bundle.config_values,
+                    table_data=bundle.table_data,
+                ),
+                password=password or "",
+            )
+        else:
+            data = build_workspace_zip(bundle, password=password if include_values else None)
     filename = f"{sol.slug}-{sol.version or 'unversioned'}.zip"
     return Response(
         content=data,
@@ -710,6 +730,7 @@ async def delete_solution(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Solution not found")
 
     from src.services.solutions.app_build import SolutionAppBuilder
+    from src.services.solutions.source_artifact import SolutionSourceArtifactStorage
     from src.services.solutions.storage import SolutionStorage
     from src.services.solutions.write_lock import (
         SolutionWriteLockHeld,
@@ -875,6 +896,7 @@ async def delete_solution(
             storage = SolutionStorage(solution_id)
             for rel in await storage.list(""):
                 await storage.delete(rel)
+            await SolutionSourceArtifactStorage(solution_id).delete()
             builder = SolutionAppBuilder()
             for app_id in app_ids:
                 await builder.delete_dist(app_id)
@@ -886,7 +908,13 @@ async def delete_solution(
     return summary
 
 
-async def _run_deploy_job(job_id: UUID, solution_id: UUID, body: SolutionDeployRequest) -> None:
+async def _run_deploy_job(
+    job_id: UUID,
+    solution_id: UUID,
+    zip_data: bytes,
+    *,
+    force: bool,
+) -> None:
     """Execute the deploy under a fresh session (background task).
 
     Flips the job ``running`` → ``succeeded`` / ``failed``. Deploy errors that
@@ -897,6 +925,10 @@ async def _run_deploy_job(job_id: UUID, solution_id: UUID, body: SolutionDeployR
     >100s) work no longer blocks the request and times out the CLI (Task 7).
     """
     from src.core.database import get_db_context
+    from src.services.solutions.zip_install import (
+        UnmetDependency,
+        deploy_zip_to_solution,
+    )
     from src.services.solutions.write_lock import (
         SolutionWriteLockHeld,
         solution_write_lock,
@@ -915,6 +947,9 @@ async def _run_deploy_job(job_id: UUID, solution_id: UUID, body: SolutionDeployR
             job.error = error
             job.result = result
 
+    async def _set_phase(phase: str) -> None:
+        await _set_status("running", result={"phase": phase})
+
     await _set_status("running")
     deploy_result: dict | None = None
     try:
@@ -923,30 +958,12 @@ async def _run_deploy_job(job_id: UUID, solution_id: UUID, body: SolutionDeployR
                 solution = await db.get(SolutionORM, solution_id)
                 if solution is None:
                     raise SolutionDeployConflict("Solution not found")
-                deployer = SolutionDeployer(db)
-                result = await deployer.deploy(
-                    SolutionBundle(
-                        solution=solution,
-                        python_files=body.python_files,
-                        workflows=body.workflows,
-                        tables=body.tables,
-                        apps=body.apps,
-                        forms=body.forms,
-                        agents=body.agents,
-                        claims=body.claims,
-                        config_schemas=body.config_schemas,
-                        connection_schemas=body.connection_schemas,
-                        events=body.events,
-                        version=body.version,
-                        logo_b64=body.logo_b64,
-                        logo_content_type=body.logo_content_type,
-                        readme=body.readme,
-                    ),
-                    force=body.force,
-                )
+                await _set_phase("parsing workspace zip and building app dist")
+                result = await deploy_zip_to_solution(db, solution, zip_data, force=force)
                 await db.commit()
                 # S3 only after the DB is durable — a failed commit changes no running
                 # code (P1-c). Still inside the lock so finalize can't race another deploy.
+                await _set_phase("storing source artifact and runtime files")
                 await result.finalize_s3()
                 deploy_result = {
                     "solution_id": str(solution_id),
@@ -982,6 +999,7 @@ async def _run_deploy_job(job_id: UUID, solution_id: UUID, body: SolutionDeployR
         SolutionDowngradeBlocked,
         SolutionDeployConflict,
         SolutionWorkflowNameMismatch,
+        UnmetDependency,
     ) as exc:
         # Caller errors (downgrade without force, invalid bundle, workflow-name
         # mismatch). Surfaced as the job error string for the poller to read.
@@ -1001,10 +1019,11 @@ async def _run_deploy_job(job_id: UUID, solution_id: UUID, body: SolutionDeployR
 )
 async def deploy_solution(
     solution_id: UUID,
-    body: SolutionDeployRequest,
+    file: Annotated[UploadFile, File(description="Solution workspace zip")],
     ctx: Context,
     user: CurrentSuperuser,
     background_tasks: BackgroundTasks,
+    force: bool = False,
 ) -> SolutionDeployEnqueued:
     solution = await ctx.db.get(SolutionORM, solution_id)
     if solution is None:
@@ -1018,6 +1037,17 @@ async def deploy_solution(
             detail="This install is git-connected; deploy is disabled (auto-pull is the only writer).",
         )
 
+    from src.services.solutions.zip_install import preview_zip
+
+    data = await file.read()
+    try:
+        preview = preview_zip(data)
+    except (ValueError, zipfile.BadZipFile) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid solution zip: {exc}",
+        ) from exc
+
     # Capture round-trip guard: an entity captured (UI/CLI) into this install but
     # not yet pulled into source has a pending_captures row. If such an entity is
     # absent from the incoming full-replace manifest, the reconcile sweep would
@@ -1026,17 +1056,17 @@ async def deploy_solution(
     # demonstrably seen it), and proceeds unchanged. force=True bypasses the block.
     # These are immediate caller-input errors, so they stay synchronous (the
     # caller gets a 409 from the request, not a failed job).
-    if not body.force:
+    if not force:
         from src.models.orm.pending_capture import PendingCaptureORM
         from src.services.solutions.pending import unpulled_blockers
 
         manifest_ids: dict[str, set[str]] = {
-            "table": {str(t["id"]) for t in body.tables if t.get("id")},
-            "form": {str(f["id"]) for f in body.forms if f.get("id")},
-            "agent": {str(a["id"]) for a in body.agents if a.get("id")},
-            "config": {str(c["key"]) for c in body.config_schemas if c.get("key")},
-            "event": {str(e["id"]) for e in body.events if e.get("id")},
-            "claim": {str(c["id"]) for c in body.claims if c.get("id")},
+            "table": {str(t["id"]) for t in preview.tables if t.get("id")},
+            "form": {str(f["id"]) for f in preview.forms if f.get("id")},
+            "agent": {str(a["id"]) for a in preview.agents if a.get("id")},
+            "config": {str(c["key"]) for c in preview.config_schemas if c.get("key")},
+            "event": {str(e["id"]) for e in preview.events if e.get("id")},
+            "claim": {str(c["id"]) for c in preview.claims if c.get("id")},
         }
         pending_rows = (
             await ctx.db.execute(
@@ -1064,7 +1094,7 @@ async def deploy_solution(
     await ctx.db.commit()
     await ctx.db.refresh(job)
 
-    background_tasks.add_task(_run_deploy_job, job.id, solution_id, body)
+    background_tasks.add_task(_run_deploy_job, job.id, solution_id, data, force=force)
     return SolutionDeployEnqueued(deploy_job_id=job.id)
 
 

--- a/api/src/services/solutions/deploy.py
+++ b/api/src/services/solutions/deploy.py
@@ -324,6 +324,13 @@ class SolutionDeployer:
         solution = bundle.solution
         sid = solution.id
 
+        # Source portability artifact: the exact workspace shape export/install
+        # consume. Build it from the author-time bundle before per-install UUID
+        # remapping, then store it only after the DB commit in finalize_s3.
+        from src.services.solutions.export import build_workspace_zip
+
+        source_artifact = build_workspace_zip(bundle)
+
         # ── Module-closure backstop — before ANY writes ──────────────────────
         # Primary gate is in zip_install (returns a clean 422). This backstop
         # covers the OTHER deploy callers (the direct /deploy endpoint and
@@ -452,6 +459,10 @@ class SolutionDeployer:
                 from src.core.cache import invalidate_all_config
 
                 await invalidate_all_config(install_org_id_str)
+            await _retry_idempotent(
+                "store source artifact", sid,
+                lambda: self._write_source_artifact(sid, source_artifact),
+            )
             await _retry_idempotent(
                 "write python source", sid,
                 lambda: self._write_python(sid, rb.python_files),
@@ -720,6 +731,11 @@ class SolutionDeployer:
             )
 
     # ── 1. Python source → SolutionStorage (full replace + cache sync) ───────
+    async def _write_source_artifact(self, sid: UUID, source_zip: bytes) -> None:
+        from src.services.solutions.source_artifact import SolutionSourceArtifactStorage
+
+        await SolutionSourceArtifactStorage(sid).write(source_zip)
+
     async def _write_python(self, sid: UUID, python_files: dict[str, str]) -> None:
         """Full-replace this install's Python source and keep the module cache
         consistent.

--- a/api/src/services/solutions/export.py
+++ b/api/src/services/solutions/export.py
@@ -1,9 +1,11 @@
 """
-Solution export — rebuild the workspace zip live from owned entities.
+Solution export — serialize Solution workspace zips.
 
-``GET /api/solutions/{id}/export`` calls
+``POST /api/solutions/{id}/export`` calls
 :func:`build_workspace_zip` on every request so the zip always reflects
-current ownership. No zip is cached to S3; the bundle is serialized on demand.
+current ownership unless the install has a deploy-time source artifact. In that
+case shareable export returns the stored artifact, and full export overlays the
+encrypted runtime payload onto that artifact.
 
 The zip is the same shape ``preview_zip``/``install_zip`` consume:
 ``bifrost.solution.yaml`` + ``.bifrost/*.yaml`` manifests + Python source +
@@ -22,6 +24,7 @@ import yaml
 
 if TYPE_CHECKING:
     from src.services.solutions.deploy import SolutionBundle
+    from src.services.solutions.secrets_blob import SolutionContent
 
 # Reverse of the CLI's logo suffix → content-type map (deploy re-validates).
 _LOGO_EXTENSIONS = {
@@ -213,5 +216,41 @@ def build_workspace_zip(bundle: "SolutionBundle", *, password: str | None = None
                     password=password,
                 ),
             )
+
+    return buf.getvalue()
+
+
+def add_encrypted_content_to_workspace_zip(
+    source_zip: bytes,
+    content: "SolutionContent",
+    *,
+    password: str,
+) -> bytes:
+    """Return ``source_zip`` plus a fresh encrypted runtime-content blob.
+
+    The stored source artifact is immutable deploy input. A full backup export
+    should not rebuild that source from DB state; it should copy the artifact and
+    overlay the runtime payload as ``.bifrost/secrets.enc`` in the response zip.
+    If the source already contains that member, replace it so repeated full
+    exports never produce duplicate zip entries.
+    """
+    from src.services.solutions.secrets_blob import encode_secrets_blob
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(io.BytesIO(source_zip), "r") as src, zipfile.ZipFile(
+        buf, "w", zipfile.ZIP_DEFLATED
+    ) as dst:
+
+        def put(path: str, data: bytes | str) -> None:
+            info = zipfile.ZipInfo(path, date_time=_ZIP_EPOCH)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            dst.writestr(info, data)
+
+        for name in src.namelist():
+            if name == ".bifrost/secrets.enc":
+                continue
+            put(name, src.read(name))
+
+        put(".bifrost/secrets.enc", encode_secrets_blob(content, password=password))
 
     return buf.getvalue()

--- a/api/src/services/solutions/git_sync.py
+++ b/api/src/services/solutions/git_sync.py
@@ -31,7 +31,6 @@ from src.models.orm.solutions import Solution
 from src.services.solutions.deploy import (
     DeployResult,
     SolutionBundle,
-    SolutionDeployer,
     SolutionFinalizeIncomplete,
 )
 
@@ -187,13 +186,16 @@ async def deploy_from_workspace(
             f"checkout at {workspace} has no {_DESCRIPTOR_FILENAME}; "
             f"refusing to full-replace install {solution.id} from a non-Solution repo"
         )
-    bundle = read_workspace_bundle(solution, workspace)
     # force=True: for a connected install the repo's main IS the single writer
     # (one-writer invariant) and auto-pull has no operator in the loop to pass
     # --force — a revert on main (older descriptor version) must still apply,
     # not strand the install behind the downgrade gate. Versions are recorded
     # either way.
-    return await SolutionDeployer(db).deploy(bundle, force=True)
+    from bifrost.commands.solution import _build_deploy_zip
+    from src.services.solutions.zip_install import deploy_zip_to_solution
+
+    data = _build_deploy_zip(workspace, extra_text_files={})
+    return await deploy_zip_to_solution(db, solution, data, force=True)
 
 
 async def sync(db: AsyncSession, solution: Solution) -> None:

--- a/api/src/services/solutions/source_artifact.py
+++ b/api/src/services/solutions/source_artifact.py
@@ -1,0 +1,63 @@
+"""Stored source artifact for a deployed Solution install.
+
+The artifact is the portable workspace zip that produced the install. Runtime
+outputs still live elsewhere: Python execution files under ``_solutions/`` and
+app dist under ``_apps/``. Keeping the zip in a separate prefix prevents the
+Python full-replace writer from deleting it.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from uuid import UUID
+
+from src.config import Settings, get_settings
+from src.services.repo_storage import _get_shared_session
+
+SOURCE_ARTIFACTS_ROOT = "_solution_artifacts"
+SOURCE_ARTIFACT_NAME = "source.zip"
+
+
+class SolutionSourceArtifactStorage:
+    """S3 storage for one install's source workspace zip."""
+
+    def __init__(self, solution_id: UUID | str, settings: Settings | None = None):
+        self.solution_id = str(solution_id)
+        self.prefix = f"{SOURCE_ARTIFACTS_ROOT}/{self.solution_id}/"
+        self._settings = settings or get_settings()
+        self._bucket: str = self._settings.s3_bucket or ""
+
+    @asynccontextmanager
+    async def _get_client(self):
+        session = _get_shared_session()
+        async with session.create_client(
+            "s3",
+            endpoint_url=self._settings.s3_endpoint_url,
+            aws_access_key_id=self._settings.s3_access_key,
+            aws_secret_access_key=self._settings.s3_secret_key,
+            region_name=self._settings.s3_region,
+        ) as client:
+            yield client
+
+    def _key(self) -> str:
+        return f"{self.prefix}{SOURCE_ARTIFACT_NAME}"
+
+    async def write(self, data: bytes) -> None:
+        async with self._get_client() as client:
+            await client.put_object(Bucket=self._bucket, Key=self._key(), Body=data)
+
+    async def read(self) -> bytes | None:
+        async with self._get_client() as client:
+            try:
+                response = await client.get_object(Bucket=self._bucket, Key=self._key())
+                return await response["Body"].read()
+            except client.exceptions.NoSuchKey:
+                return None
+            except Exception as exc:  # noqa: BLE001 - aiobotocore backends vary
+                if "NoSuchKey" in str(type(exc).__name__) or "404" in str(exc):
+                    return None
+                raise
+
+    async def delete(self) -> None:
+        async with self._get_client() as client:
+            await client.delete_object(Bucket=self._bucket, Key=self._key())

--- a/api/src/services/solutions/zip_install.py
+++ b/api/src/services/solutions/zip_install.py
@@ -48,6 +48,7 @@ from src.models.enums import ConfigType
 from src.models.orm.solution_config_schema import SolutionConfigSchema
 from src.models.orm.solutions import Solution
 from src.services.solutions.deploy import (
+    DeployResult,
     SolutionBundle,
     SolutionDeployer,
     solution_entity_id,
@@ -538,6 +539,41 @@ async def install_zip(
 
     await db.refresh(solution)
     return solution
+
+
+async def deploy_zip_to_solution(
+    db: AsyncSession,
+    solution: Solution,
+    data: bytes,
+    *,
+    force: bool = False,
+) -> DeployResult:
+    """Deploy an existing install from a workspace zip.
+
+    This is the deploy half of ``install_zip`` without install resolution,
+    config-value application, commits, or S3 finalize. Callers own the write
+    lock, transaction commit, and ``DeployResult.finalize_s3()`` timing.
+    """
+    with tempfile.TemporaryDirectory(prefix="bifrost-zip-deploy-") as tmp:
+        _safe_extract(data, tmp)
+        workspace = Path(tmp)
+        preview = _parse_workspace(workspace)
+        if not preview.slug or not preview.name:
+            raise ValueError(
+                "zip is not a Solution workspace (missing bifrost.solution.yaml slug/name)"
+            )
+        bundle = _build_bundle(solution, preview, workspace)
+
+        from src.services.solutions.dependency_walker import check_install_needs
+
+        needs = check_install_needs(bundle.python_files)
+        if needs:
+            items = ", ".join(
+                f"{n.ref} ({n.detail})" if n.detail else n.ref for n in needs
+            )
+            raise UnmetDependency(f"Solution has unmet dependencies: {items}")
+
+        return await SolutionDeployer(db).deploy(bundle, force=force)
 
 
 async def _assert_no_unforced_collisions(

--- a/api/tests/e2e/conftest.py
+++ b/api/tests/e2e/conftest.py
@@ -17,6 +17,8 @@ Note: pytest_plugins moved to tests/conftest.py (root) as required by pytest.
 """
 
 import os
+import re
+import uuid
 
 import pytest
 import httpx
@@ -28,6 +30,7 @@ from tests.helpers.polling import poll_until  # noqa: F401
 # E2E test API URL (from docker-compose.test.yml)
 # Default to api:8000 since tests run inside Docker network
 E2E_API_URL = os.getenv("TEST_API_URL", "http://api:8000")
+_SOLUTION_DEPLOY_RE = re.compile(r"^/api/solutions/([^/]+)/deploy$")
 
 
 def pytest_configure(config):
@@ -75,6 +78,82 @@ def e2e_api_url():
     return E2E_API_URL
 
 
+def _legacy_deploy_body_to_zip(client: httpx.Client, solution_id: str, headers, body: dict) -> bytes:
+    """Package legacy test deploy JSON as the production workspace zip."""
+    from src.models.orm.solutions import Solution
+    from src.services.solutions.deploy import SolutionBundle
+    from src.services.solutions.export import build_workspace_zip
+
+    listed = client.get("/api/solutions", headers=headers)
+    assert listed.status_code == 200, (
+        f"solution lookup failed: {listed.status_code} {listed.text}"
+    )
+    solution = None
+    for item in listed.json().get("solutions", []):
+        if str(item.get("id")) == solution_id:
+            solution = item
+            break
+    assert solution is not None, f"solution {solution_id} not found"
+
+    org_id = solution.get("organization_id")
+    sol = Solution(
+        id=uuid.UUID(solution_id),
+        slug=solution["slug"],
+        name=solution["name"],
+        version=solution.get("version"),
+        organization_id=uuid.UUID(org_id) if org_id else None,
+        global_repo_access=bool(solution.get("global_repo_access", False)),
+    )
+    bundle = SolutionBundle(
+        solution=sol,
+        python_files=body.get("python_files", {}),
+        workflows=body.get("workflows", []),
+        tables=body.get("tables", []),
+        apps=body.get("apps", []),
+        forms=body.get("forms", []),
+        agents=body.get("agents", []),
+        claims=body.get("claims", []),
+        config_schemas=body.get("config_schemas", []),
+        connection_schemas=body.get("connection_schemas", []),
+        events=body.get("events", []),
+        version=body.get("version"),
+        logo_b64=body.get("logo_b64"),
+        logo_content_type=body.get("logo_content_type"),
+        readme=body.get("readme"),
+    )
+    return build_workspace_zip(bundle)
+
+
+class _E2EClient:
+    def __init__(self, client: httpx.Client) -> None:
+        self._client = client
+
+    def __getattr__(self, name: str):
+        return getattr(self._client, name)
+
+    def post(self, path: str, *args, **kwargs):
+        match = _SOLUTION_DEPLOY_RE.match(path)
+        if match and "json" in kwargs and "files" not in kwargs:
+            body = kwargs.pop("json") or {}
+            solution_id = match.group(1)
+            headers = kwargs.get("headers")
+            zip_bytes = _legacy_deploy_body_to_zip(self._client, solution_id, headers, body)
+            params = dict(kwargs.pop("params", {}) or {})
+            if body.get("force"):
+                params["force"] = "true"
+            if params:
+                kwargs["params"] = params
+            upload_headers = dict(headers or {})
+            for key in list(upload_headers):
+                if key.lower() == "content-type":
+                    upload_headers.pop(key)
+            kwargs["headers"] = upload_headers
+            kwargs["files"] = {
+                "file": ("deploy.zip", zip_bytes, "application/zip"),
+            }
+        return self._client.post(path, *args, **kwargs)
+
+
 @pytest.fixture(scope="session")
 def e2e_client():
     """
@@ -83,7 +162,7 @@ def e2e_client():
     Provides a configured httpx client for making requests to the API.
     """
     with httpx.Client(base_url=E2E_API_URL, timeout=60.0) as client:
-        yield client
+        yield _E2EClient(client)
 
 
 _UNSET = object()

--- a/api/tests/unit/test_cli_solution_deploy_phases.py
+++ b/api/tests/unit/test_cli_solution_deploy_phases.py
@@ -7,7 +7,7 @@ that gap stays instrumented:
   Scanning solution files...  ->  found N ... file(s)
   Vendoring shared dependencies...  ->  (vendored M | no shared dependencies)
   Bundle: ...
-  Uploading bundle...  ->  Deploying install ...
+  Uploading workspace zip...  ->  Deploying install ...
 
 BifrostClient is mocked so no network/DB is touched. Deploying with --global and
 the default (vendoring-on) descriptor drives the no-shared-deps branch: the
@@ -35,7 +35,7 @@ def _resp(payload, status=200):
     return r
 
 
-def _client():
+def _client(captured: dict | None = None):
     async def get(path, **_kwargs):  # type: ignore[no-untyped-def]
         if path == "/api/solutions":
             return _resp({"solutions": []})
@@ -43,7 +43,9 @@ def _client():
             return _resp({"status": "succeeded", "error": None, "install_id": INSTALL_ID})
         return _resp({}, status=404)
 
-    async def post(path, json=None, **_kwargs):  # type: ignore[no-untyped-def]  # noqa: ARG001
+    async def post(path, json=None, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ARG001
+        if captured is not None:
+            captured.setdefault("posts", []).append((path, {"json": json, **kwargs}))
         if path == "/api/solutions":
             return _resp({"id": INSTALL_ID}, status=201)
         if path == "/api/files/read":
@@ -79,9 +81,9 @@ def _scaffold(tmp_path: pathlib.Path) -> pathlib.Path:
     return ws
 
 
-def _invoke(ws: pathlib.Path):
+def _invoke(ws: pathlib.Path, captured: dict | None = None):
     with mock.patch(
-        "bifrost.client.BifrostClient.get_instance", return_value=_client()
+        "bifrost.client.BifrostClient.get_instance", return_value=_client(captured)
     ):
         return CliRunner().invoke(
             solution_group, ["deploy", str(ws), "--global"], catch_exceptions=False
@@ -97,7 +99,7 @@ def test_deploy_prints_each_phase(tmp_path) -> None:
     assert "found" in out and "python file(s)" in out
     assert "Vendoring shared dependencies..." in out
     assert "Bundle:" in out
-    assert "Uploading bundle..." in out
+    assert "Uploading workspace zip..." in out
     assert "Deploying install" in out
 
 
@@ -106,3 +108,28 @@ def test_deploy_reports_when_nothing_to_vendor(tmp_path) -> None:
     assert result.exit_code == 0, result.output
     # The vendoring announcement always resolves to a result line, even at zero.
     assert "no shared dependencies to vendor." in result.output
+
+
+def test_deploy_uploads_workspace_zip_not_json_bundle(tmp_path) -> None:
+    captured: dict = {}
+    result = _invoke(_scaffold(tmp_path), captured)
+    assert result.exit_code == 0, result.output
+
+    deploy_calls = [
+        kwargs for path, kwargs in captured["posts"] if path.endswith("/deploy")
+    ]
+    assert len(deploy_calls) == 1
+    call = deploy_calls[0]
+    assert call["json"] is None
+    assert "files" in call
+    upload = call["files"]["file"]
+    assert upload[0].endswith(".zip")
+    assert upload[2] == "application/zip"
+
+    import io
+    import zipfile
+
+    with zipfile.ZipFile(io.BytesIO(upload[1])) as zf:
+        names = set(zf.namelist())
+    assert "bifrost.solution.yaml" in names
+    assert "workflows/hello.py" in names

--- a/api/tests/unit/test_contract_version.py
+++ b/api/tests/unit/test_contract_version.py
@@ -64,7 +64,6 @@ from src.models.contracts.organizations import (  # noqa: E402
 from src.models.contracts.solutions import (  # noqa: E402
     SolutionDeployEnqueued,
     SolutionDeployJobStatus,
-    SolutionDeployRequest,
 )
 from src.models.contracts.tables import TableCreate, TableUpdate  # noqa: E402
 from src.models.contracts.users import RoleCreate, RoleUpdate  # noqa: E402
@@ -109,7 +108,6 @@ _COMMAND_DTOS: list[type] = [
     EventSourceUpdate,
     EventSubscriptionCreate,
     EventSubscriptionUpdate,
-    SolutionDeployRequest,
     SolutionDeployEnqueued,
     SolutionDeployJobStatus,
 ]
@@ -158,7 +156,11 @@ EXPECTED_CONTRACT_FINGERPRINT = (
     # Solution deploy now returns 202 + deploy_job_id and the CLI polls
     # SolutionDeployJobStatus for the prior summary shape (2026-06-17).
     # CONTRACT_VERSION bumped to 5.
-    "4d84dfc7b2ae64d8be2aba15ca782467b5b92de256507bcbc4228fb36a336ec3"
+    #
+    # Solution deploy now uploads a workspace zip as multipart/form-data instead
+    # of the legacy JSON bundle request body (2026-06-21).
+    # CONTRACT_VERSION bumped to 6.
+    "574232b44f09b26868559f4346a4bf9f364473d2affe4780fbdef1a767fdb5d6"
 )
 
 

--- a/api/tests/unit/test_deploy_cli_poll.py
+++ b/api/tests/unit/test_deploy_cli_poll.py
@@ -61,3 +61,25 @@ def test_poll_surfaces_failure(capsys):
     captured = capsys.readouterr()
     assert rc == 1
     assert "diverged" in (captured.out + captured.err)
+
+
+def test_poll_prints_phase_changes(capsys):
+    class PhaseClient:
+        def __init__(self) -> None:
+            self.payloads = [
+                {"status": "running", "result": {"phase": "storing source artifact"}},
+                {"status": "running", "result": {"phase": "building app dist"}},
+                {"status": "running", "result": {"phase": "building app dist"}},
+                {"status": "succeeded", "result": {}},
+            ]
+
+        async def get(self, path: str, **kwargs):  # noqa: ANN003
+            return _FakeResponse(self.payloads.pop(0))
+
+    rc = _run(_poll_deploy_job(PhaseClient(), "job-3", interval=0.0))
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "storing source artifact" in out
+    assert "building app dist" in out
+    assert out.count("building app dist") == 1

--- a/api/tests/unit/test_solution_deploy_s3_after_commit.py
+++ b/api/tests/unit/test_solution_deploy_s3_after_commit.py
@@ -17,7 +17,9 @@ import pytest
 
 from src.models.orm.solutions import Solution
 from src.services.solutions.deploy import SolutionBundle, SolutionDeployer
+from src.services.solutions.source_artifact import SolutionSourceArtifactStorage
 from src.services.solutions.storage import SolutionStorage
+from src.services.solutions.zip_install import deploy_zip_to_solution
 
 
 @pytest.fixture(autouse=True)
@@ -71,3 +73,73 @@ class TestS3AfterCommit:
         )
         # finalize_s3 must be present and awaitable even for an empty bundle.
         await result.finalize_s3()
+
+    async def test_deploy_defers_source_artifact_until_finalize(self, db_session) -> None:
+        db = db_session
+        sol = await _install(db)
+        artifact = SolutionSourceArtifactStorage(sol.id)
+
+        result = await SolutionDeployer(db).deploy(
+            SolutionBundle(
+                solution=sol,
+                python_files={"workflows/w1.py": "def run():\n    return 1\n"},
+                workflows=[
+                    {
+                        "id": str(uuid.uuid4()),
+                        "name": "run",
+                        "function_name": "run",
+                        "path": "workflows/w1.py",
+                    }
+                ],
+            )
+        )
+        await db.flush()
+
+        assert await artifact.read() is None
+
+        await result.finalize_s3()
+        source_zip = await artifact.read()
+        assert source_zip is not None
+        assert b"workflows/w1.py" in source_zip
+
+    async def test_deploy_zip_to_solution_defers_artifact_until_finalize(
+        self,
+        db_session,
+        tmp_path,
+    ) -> None:
+        db = db_session
+        sol = await _install(db)
+        wf_id = uuid.uuid4()
+        (tmp_path / "bifrost.solution.yaml").write_text(
+            f"slug: {sol.slug}\nname: S3DEF\nversion: 0.1.0\n"
+        )
+        (tmp_path / "workflows").mkdir()
+        (tmp_path / "workflows" / "w.py").write_text("def run():\n    return 1\n")
+        (tmp_path / ".bifrost").mkdir()
+        (tmp_path / ".bifrost" / "workflows.yaml").write_text(
+            "workflows:\n"
+            f"  {wf_id}:\n"
+            f"    id: {wf_id}\n"
+            "    name: run\n"
+            "    function_name: run\n"
+            "    path: workflows/w.py\n"
+        )
+
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in sorted(tmp_path.rglob("*")):
+                if path.is_file():
+                    zf.write(path, path.relative_to(tmp_path).as_posix())
+
+        result = await deploy_zip_to_solution(db, sol, buf.getvalue())
+        await db.flush()
+        artifact = SolutionSourceArtifactStorage(sol.id)
+        assert await artifact.read() is None
+
+        await result.finalize_s3()
+        source_zip = await artifact.read()
+        assert source_zip is not None
+        assert b"workflows/w.py" in source_zip

--- a/api/tests/unit/test_solution_export.py
+++ b/api/tests/unit/test_solution_export.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 
 import base64
 import io
+import uuid
 import zipfile
 
+import pytest
+
+from src.core.auth import ExecutionContext
+from src.core.principal import UserPrincipal
 from src.models.orm.solutions import Solution
+from src.routers.solutions import export_solution
 from src.services.solutions.deploy import SolutionBundle
-from src.services.solutions.export import build_workspace_zip
+from src.services.solutions.export import (
+    add_encrypted_content_to_workspace_zip,
+    build_workspace_zip,
+)
+from src.services.solutions.secrets_blob import SolutionContent, decode_secrets_blob
+from src.services.solutions.source_artifact import SolutionSourceArtifactStorage
 from src.services.solutions.zip_install import preview_zip
 
 _PNG = base64.b64encode(b"\x89PNG\r\n\x1a\nfakepng").decode("ascii")
@@ -87,6 +98,16 @@ def _bundle() -> SolutionBundle:
             }
         ],
     )
+
+
+def _admin(db) -> tuple[ExecutionContext, UserPrincipal]:
+    user = UserPrincipal(
+        user_id=uuid.uuid4(),
+        email="admin@example.com",
+        organization_id=None,
+        is_superuser=True,
+    )
+    return ExecutionContext(user=user, org_id=None, db=db), user
 
 
 def test_export_round_trips_through_preview() -> None:
@@ -173,3 +194,114 @@ def test_export_descriptor_omits_scope_regardless_of_org() -> None:
     with zipfile.ZipFile(io.BytesIO(build_workspace_zip(b))) as z:
         descriptor = yaml.safe_load(z.read("bifrost.solution.yaml"))
     assert "scope" not in descriptor
+
+
+def test_full_export_overlays_encrypted_content_without_rebuilding_source() -> None:
+    source_zip = build_workspace_zip(_bundle())
+
+    data = add_encrypted_content_to_workspace_zip(
+        source_zip,
+        SolutionContent(
+            config_values={"API_KEY": "secret-value"},
+            table_data={"things": [{"title": "stored row"}]},
+        ),
+        password="pw",
+    )
+
+    assert data != source_zip
+    with zipfile.ZipFile(io.BytesIO(data)) as z:
+        names = set(z.namelist())
+        assert "apps/dash/src/App.tsx" in names
+        assert "workflows/main.py" in names
+        blob = z.read(".bifrost/secrets.enc").decode()
+
+    content = decode_secrets_blob(blob, password="pw")
+    assert content.config_values == {"API_KEY": "secret-value"}
+    assert content.table_data == {"things": [{"title": "stored row"}]}
+
+
+def test_full_export_replaces_any_existing_encrypted_content() -> None:
+    source_zip = add_encrypted_content_to_workspace_zip(
+        build_workspace_zip(_bundle()),
+        SolutionContent(config_values={"OLD": "value"}),
+        password="old",
+    )
+
+    data = add_encrypted_content_to_workspace_zip(
+        source_zip,
+        SolutionContent(config_values={"NEW": "value"}),
+        password="new",
+    )
+
+    with zipfile.ZipFile(io.BytesIO(data)) as z:
+        assert z.namelist().count(".bifrost/secrets.enc") == 1
+        blob = z.read(".bifrost/secrets.enc").decode()
+    content = decode_secrets_blob(blob, password="new")
+    assert content.config_values == {"NEW": "value"}
+
+
+@pytest.mark.e2e
+async def test_shareable_export_returns_stored_source_artifact(db_session) -> None:
+    sol = Solution(
+        id=uuid.uuid4(),
+        slug=f"stored-{uuid.uuid4().hex[:8]}",
+        name="Stored Source",
+        organization_id=None,
+    )
+    db_session.add(sol)
+    await db_session.flush()
+    source_bundle = _bundle()
+    source_bundle.python_files["workflows/main.py"] = "def run():\n    return 'artifact'\n"
+    source_zip = build_workspace_zip(source_bundle)
+    await SolutionSourceArtifactStorage(sol.id).write(source_zip)
+
+    ctx, user = _admin(db_session)
+    response = await export_solution(sol.id, ctx, user, mode="shareable")
+
+    assert response.body == source_zip
+
+
+@pytest.mark.e2e
+async def test_full_export_overlays_live_payload_on_stored_source(
+    db_session,
+    monkeypatch,
+) -> None:
+    from src.services.solutions.capture import SolutionCaptureService
+
+    sol = Solution(
+        id=uuid.uuid4(),
+        slug=f"full-{uuid.uuid4().hex[:8]}",
+        name="Full Source",
+        organization_id=None,
+    )
+    db_session.add(sol)
+    await db_session.flush()
+    source_bundle = _bundle()
+    source_bundle.python_files["workflows/main.py"] = "def run():\n    return 'artifact'\n"
+    await SolutionSourceArtifactStorage(sol.id).write(build_workspace_zip(source_bundle))
+
+    async def _fake_bundle_for(self, *_args, **_kwargs):  # noqa: ANN001
+        live_bundle = _bundle()
+        live_bundle.python_files["workflows/main.py"] = "def run():\n    return 'live-db'\n"
+        live_bundle.config_values = {"API_KEY": "secret-value"}
+        live_bundle.table_data = {"things": [{"title": "row"}]}
+        return live_bundle
+
+    monkeypatch.setattr(SolutionCaptureService, "bundle_for", _fake_bundle_for)
+
+    ctx, user = _admin(db_session)
+    response = await export_solution(
+        sol.id,
+        ctx,
+        user,
+        mode="full",
+        include_data=True,
+        password="pw",
+    )
+
+    with zipfile.ZipFile(io.BytesIO(response.body)) as z:
+        assert z.read("workflows/main.py").decode() == "def run():\n    return 'artifact'\n"
+        blob = z.read(".bifrost/secrets.enc").decode()
+    content = decode_secrets_blob(blob, password="pw")
+    assert content.config_values == {"API_KEY": "secret-value"}
+    assert content.table_data == {"things": [{"title": "row"}]}

--- a/api/tests/unit/test_solution_resolve_install.py
+++ b/api/tests/unit/test_solution_resolve_install.py
@@ -4,8 +4,11 @@ a slug (success-criteria §3.4, Codex G5)."""
 from __future__ import annotations
 
 import json
+import io
+import zipfile
 
 import pytest
+import yaml
 
 from bifrost.commands.solution import _AmbiguousInstall, _resolve_target_install
 
@@ -138,7 +141,7 @@ class _Resp:
 
 
 class _DeployFakeClient:
-    """Resolves the install by slug and records the deploy request body.
+    """Resolves the install by slug and records the deploy upload.
 
     Deploy is async: the POST returns 202 + a job id, then the CLI polls the
     deploy-jobs status endpoint. ``deploy_resp`` overrides the POST response (to
@@ -154,7 +157,8 @@ class _DeployFakeClient:
         job_status: str = "succeeded",
         job_error: str = "boom",
     ):
-        self.deploy_body: dict | None = None
+        self.deploy_files: dict | None = None
+        self.deploy_params: dict | None = None
         self._deploy_resp = deploy_resp or _Resp(
             202, body={"deploy_job_id": "job-1"}
         )
@@ -184,7 +188,8 @@ class _DeployFakeClient:
 
     async def post(self, path, **kwargs):
         if path == "/api/solutions/inst-1/deploy":
-            self.deploy_body = kwargs.get("json")
+            self.deploy_files = kwargs.get("files")
+            self.deploy_params = kwargs.get("params")
             return self._deploy_resp
         raise AssertionError(f"unexpected POST {path}")
 
@@ -203,6 +208,13 @@ def _deploy_workspace(tmp_path, monkeypatch, fake, descriptor_text: str):
     return CliRunner(), solution_group
 
 
+def _deploy_descriptor(fake: _DeployFakeClient) -> dict:
+    assert fake.deploy_files is not None
+    file_tuple = fake.deploy_files["file"]
+    with zipfile.ZipFile(io.BytesIO(file_tuple[1])) as zf:
+        return yaml.safe_load(zf.read("bifrost.solution.yaml"))
+
+
 def test_deploy_body_includes_descriptor_version(tmp_path, monkeypatch):
     fake = _DeployFakeClient()
     runner, grp = _deploy_workspace(
@@ -210,9 +222,8 @@ def test_deploy_body_includes_descriptor_version(tmp_path, monkeypatch):
     )
     result = runner.invoke(grp, ["deploy"])
     assert result.exit_code == 0, result.output
-    assert fake.deploy_body is not None
-    assert fake.deploy_body["version"] == "1.2.3"
-    assert fake.deploy_body["force"] is False
+    assert _deploy_descriptor(fake)["version"] == "1.2.3"
+    assert fake.deploy_params == {"force": "false"}
 
 
 def test_deploy_force_flag_sets_force_true(tmp_path, monkeypatch):
@@ -222,8 +233,7 @@ def test_deploy_force_flag_sets_force_true(tmp_path, monkeypatch):
     )
     result = runner.invoke(grp, ["deploy", "--force"])
     assert result.exit_code == 0, result.output
-    assert fake.deploy_body is not None
-    assert fake.deploy_body["force"] is True
+    assert fake.deploy_params == {"force": "true"}
 
 
 def test_deploy_no_descriptor_version_sends_null(tmp_path, monkeypatch):
@@ -232,8 +242,7 @@ def test_deploy_no_descriptor_version_sends_null(tmp_path, monkeypatch):
     runner, grp = _deploy_workspace(tmp_path, monkeypatch, fake, "slug: s\nname: S\n")
     result = runner.invoke(grp, ["deploy"])
     assert result.exit_code == 0, result.output
-    assert fake.deploy_body is not None
-    assert fake.deploy_body.get("version") is None
+    assert "version" not in _deploy_descriptor(fake)
 
 
 def test_deploy_downgrade_prints_detail_and_force_hint(tmp_path, monkeypatch):

--- a/api/tests/unit/test_solution_source_artifact_lifecycle.py
+++ b/api/tests/unit/test_solution_source_artifact_lifecycle.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+
+from src.core.auth import ExecutionContext
+from src.core.principal import UserPrincipal
+from src.models.orm.solutions import Solution
+from src.routers.solutions import delete_solution
+from src.services.solutions.source_artifact import SolutionSourceArtifactStorage
+
+pytestmark = pytest.mark.e2e
+
+
+def _admin(db) -> tuple[ExecutionContext, UserPrincipal]:
+    user = UserPrincipal(
+        user_id=uuid.uuid4(),
+        email="admin@example.com",
+        organization_id=None,
+        is_superuser=True,
+    )
+    return ExecutionContext(user=user, org_id=None, db=db), user
+
+
+async def test_delete_solution_removes_source_artifact(db_session, monkeypatch) -> None:
+    sol = Solution(
+        id=uuid.uuid4(),
+        slug=f"src-artifact-{uuid.uuid4().hex[:8]}",
+        name="Source Artifact",
+        organization_id=None,
+    )
+    db_session.add(sol)
+    await db_session.flush()
+    artifact = SolutionSourceArtifactStorage(sol.id)
+    await artifact.write(b"PK\x05\x06" + b"\x00" * 18)
+    assert await artifact.read() is not None
+
+    @asynccontextmanager
+    async def _unlocked(_solution_id):
+        yield
+
+    monkeypatch.setattr("src.services.solutions.write_lock.solution_write_lock", _unlocked)
+
+    ctx, user = _admin(db_session)
+    await delete_solution(sol.id, ctx, user)
+
+    assert await artifact.read() is None

--- a/client/src/components/jsx-app/BundledAppShell.test.tsx
+++ b/client/src/components/jsx-app/BundledAppShell.test.tsx
@@ -266,7 +266,7 @@ describe("BundledAppShell — app_model render branch", () => {
 			<BundledAppShell appId="app-A" appSlug="aaa" isPreview />,
 		);
 		const rootA = await screen.findByTestId("solution-v2-app-root");
-		expect(rootA.dataset.bifrostEntry).toContain("A-entry.js");
+		await waitFor(() => expect(rootA.dataset.bifrostEntry).toContain("A-entry.js"));
 
 		// Navigate to app B; B's manifest fetch is PENDING (never resolves here).
 		mockAuthFetch.mockImplementationOnce(() => new Promise<Response>(() => {}));

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -3725,22 +3725,22 @@ export interface paths {
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        get: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        get: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        put: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        put: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        post: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        post: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         /**
          * Execute workflow via API key
          * @description Execute an endpoint-enabled workflow using an API key for authentication
          */
-        delete: operations["execute_endpoint_api_endpoints__workflow_id__put"];
+        delete: operations["execute_endpoint_api_endpoints__workflow_id__get"];
         options?: never;
         head?: never;
         patch?: never;
@@ -10688,6 +10688,14 @@ export interface components {
              * @enum {string}
              */
             cost_basis: "history" | "fallback";
+        };
+        /** Body_deploy_solution_api_solutions__solution_id__deploy_post */
+        Body_deploy_solution_api_solutions__solution_id__deploy_post: {
+            /**
+             * File
+             * @description Solution workspace zip
+             */
+            file: string;
         };
         /** Body_export_solution_api_solutions__solution_id__export_post */
         Body_export_solution_api_solutions__solution_id__export_post: {
@@ -20900,71 +20908,6 @@ export interface components {
             updated_at: string;
         };
         /**
-         * SolutionDeployRequest
-         * @description Full-replace deploy bundle for one install.
-         *
-         *     ``python_files`` maps relative paths (e.g. ``workflows/w.py``,
-         *     ``modules/x.py``) to UTF-8 source text, installed verbatim under the
-         *     install's ``_solutions/{id}/`` prefix. ``workflows`` are manifest-shaped
-         *     entity dicts to upsert (apps/forms/agents/tables join in later sub-plans).
-         *     Deploy is non-interactive by contract — it always applies the full bundle.
-         */
-        SolutionDeployRequest: {
-            /** Python Files */
-            python_files?: {
-                [key: string]: string;
-            };
-            /** Workflows */
-            workflows?: {
-                [key: string]: unknown;
-            }[];
-            /** Tables */
-            tables?: {
-                [key: string]: unknown;
-            }[];
-            /** Apps */
-            apps?: {
-                [key: string]: unknown;
-            }[];
-            /** Forms */
-            forms?: {
-                [key: string]: unknown;
-            }[];
-            /** Agents */
-            agents?: {
-                [key: string]: unknown;
-            }[];
-            /** Claims */
-            claims?: {
-                [key: string]: unknown;
-            }[];
-            /** Config Schemas */
-            config_schemas?: {
-                [key: string]: unknown;
-            }[];
-            /** Connection Schemas */
-            connection_schemas?: {
-                [key: string]: unknown;
-            }[];
-            /** Events */
-            events?: {
-                [key: string]: unknown;
-            }[];
-            /** Version */
-            version?: string | null;
-            /** Logo B64 */
-            logo_b64?: string | null;
-            /** Logo Content Type */
-            logo_content_type?: string | null;
-            /** Readme */
-            readme?: string | null;
-            /**
-             * Force
-             * @default false
-             */
-            force: boolean;
-        };
-        /**
          * SolutionEntities
          * @description Everything one install owns + its config declaration/value status.
          */
@@ -29517,7 +29460,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -29550,7 +29493,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -29583,7 +29526,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -29616,7 +29559,7 @@ export interface operations {
             };
         };
     };
-    execute_endpoint_api_endpoints__workflow_id__put: {
+    execute_endpoint_api_endpoints__workflow_id__get: {
         parameters: {
             query?: never;
             header: {
@@ -36104,7 +36047,9 @@ export interface operations {
     };
     deploy_solution_api_solutions__solution_id__deploy_post: {
         parameters: {
-            query?: never;
+            query?: {
+                force?: boolean;
+            };
             header?: never;
             path: {
                 solution_id: string;
@@ -36113,7 +36058,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SolutionDeployRequest"];
+                "multipart/form-data": components["schemas"]["Body_deploy_solution_api_solutions__solution_id__deploy_post"];
             };
         };
         responses: {


### PR DESCRIPTION
## Summary
- Route solution deploys through workspace zip uploads and reuse zip install parsing for CLI and git-connected deploys.
- Store the deploy-time source zip as the solution export artifact, and overlay live encrypted data for full exports.
- Add deploy phase streaming, source artifact cleanup, contract v6, and focused regression coverage.

## Test Plan
- ./test.sh tests/unit/test_contract_version.py -q
- ./test.sh tests/unit/test_cli_solution_deploy_phases.py tests/unit/test_solution_deploy_s3_after_commit.py tests/unit/test_solution_export.py tests/unit/test_solution_source_artifact_lifecycle.py -q
- ./test.sh tests/unit/test_solution_export.py tests/unit/test_solution_source_artifact_lifecycle.py tests/unit/test_solution_deploy_s3_after_commit.py tests/unit/test_deploy_cli_poll.py tests/unit/test_cli_solution_deploy_phases.py tests/unit/test_cli_solution_export.py tests/unit/test_solution_git_sync.py -q
- cd api && ../.venv/bin/ruff check .
- cd api && ../.venv/bin/pyright
- COMPOSE_PROJECT_NAME=bifrost-debug-d3e15c1d docker compose -f docker-compose.debug.yml exec -T client sh -lc "npm run generate:types:docker"
- COMPOSE_PROJECT_NAME=bifrost-debug-d3e15c1d docker compose -f docker-compose.debug.yml exec -T client sh -lc "npm run tsc"
- Debug stack E2E: CLI deploy zip, shareable export, full export with password, install exported zip, app source export, and runtime app dist fetch.

## Notes
- Client lint is still blocked by the existing ESLint 9 flat-config issue: `npm run lint` cannot find `eslint.config.(js|mjs|cjs)`.
- No linked issue.