### PR TITLE
docs(plugin): document Solution files in build skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
+  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "version": "1.0.5",
   "author": {
     "name": "Jack Musick",

--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: bifrost:build
-description: Build Bifrost workflows, forms, and apps for both Solution workspaces (v2) and the global _repo workspace (v1). Supports SDK-first (local dev + git) and MCP-only modes.
+description: Build Bifrost workflows, forms, agents, apps, tables, and files for both Solution workspaces (v2) and the global _repo workspace (v1). Supports SDK-first (local dev + git) and MCP-only modes.
 ---
 
 # Bifrost Build
 
-Build Bifrost artifacts — apps, workflows, forms, agents, tables. This hub detects your workspace mode and routes you to the right entry doc.
+Build Bifrost artifacts — apps, workflows, forms, agents, tables, and files. This hub detects your workspace mode and routes you to the right entry doc.
 
 ## Prerequisites
 
@@ -33,7 +33,7 @@ echo "${found:-NOT_FOUND}"
 ```
 
 **Found → Solution workspace (v2).** Read `references/solutions.md` and follow it.
-- Entities (apps, workflows, forms, agents, tables, configs) are deploy-owned. They ship with the solution and are installed/updated by `bifrost solution deploy` — NOT by live CLI mutations. Calling `bifrost forms create` (or any entity create/update) in a solution workspace 409s because deploy owns those records.
+- Entities (apps, workflows, forms, agents, tables, configs) and declared file locations are deploy-owned. They ship with the solution and are installed/updated by `bifrost solution deploy` — NOT by live CLI mutations. Calling `bifrost forms create` (or any entity create/update) in a solution workspace 409s because deploy owns those records.
 - You author app code in `apps/` and Python workflows in `functions/`, then deploy with `bifrost solution deploy`.
 
 **Not found → Global `_repo` workspace (v1).** Read `references/repo.md` and follow it.
@@ -79,7 +79,7 @@ This is mode-agnostic — always do it before creating anything.
 
 ## Global Hard Rules (Both Modes)
 
-- **In a Solution workspace, entities are deploy-owned — never mutate them live.** Creating or updating a form, agent, table, config, app, or workflow via the entity CLI create/update verbs against a solution-managed record 409s (deploy owns them). Author the content in the workspace and ship it with `bifrost solution deploy`. (This rule does NOT apply in the global `_repo` workspace, where live mutation is the normal path — see the mode dispatcher above.)
+- **In a Solution workspace, entities are deploy-owned — never mutate them live.** Creating or updating a form, agent, table, config, app, or workflow via the entity CLI create/update verbs against a solution-managed record 409s (deploy owns them). Author the content in the workspace and ship it with `bifrost solution deploy`. Solution file locations are declared in `.bifrost/files.yaml`; runtime file bytes are user data, not source files to edit under `_solutions/`. (This rule does NOT apply in the global `_repo` workspace, where live mutation is the normal path — see the mode dispatcher above.)
 - **Never run the watch/push/pull/sync/git commands unsolicited.** These are user-driven, have broad blast radius, or launch interactive TUIs. Describe them to the user and ask them to run the command themselves. This applies in both solution and repo mode.
 - **Never call `bifrost api` for third-party integration APIs** (HaloPSA, Pax8, NinjaOne, etc.). `bifrost api` is the Bifrost platform API only. Call integration APIs from within a workflow using the SDK, not the `bifrost api` passthrough.
 - **Check before using `bifrost api GET <path>`.** If you don't know whether a platform endpoint exists, check `generated/openapi-digest.md` or the entity's `--help` flag first. Never guess URL patterns.
@@ -117,6 +117,7 @@ When workflows are exposed as MCP tools (via agents), their `name` becomes the M
 | Create a form | `references/entities.md` |
 | Create/update/delete any CLI entity | `references/entities.md` |
 | Work with tables (read/write structured data) | `references/tables.md` |
+| Work with app/user files | `references/solutions.md` · `references/web-sdk-v2.md` |
 | MCP-only mode (no local source) | `references/mcp-mode.md` |
 | Exact CLI flag for a command | `generated/cli-reference.md` |
 | Does a platform endpoint exist? | `generated/openapi-digest.md` |

--- a/.claude/skills/bifrost-build/references/apps.md
+++ b/.claude/skills/bifrost-build/references/apps.md
@@ -26,6 +26,7 @@ my-solution/
       pages/              # your route pages
   functions/
     hello.py              # @workflow decorated function (solution root, not under the app)
+  .bifrost/files.yaml     # optional Solution runtime file-location declarations
   bifrost.solution.yaml   # Solution descriptor
 ```
 
@@ -71,7 +72,7 @@ root.render(
 (The old `window.__BIFROST_API_URL__` / `window.__BIFROST_TOKEN__` globals AND `document.currentScript?.dataset?.m` are stale — the current boot protocol is the `new URL(import.meta.url)` nonce + registry above. Just keep the scaffolded `main.tsx`.)
 
 Imports in a **v2 standalone app** (this is NOT the v1 surface — see the warning below):
-- **SDK hooks/providers ONLY come from `"bifrost"`**: `import { BifrostProvider, BifrostHeader, useWorkflowQuery, useWorkflowMutation, useWorkflow, useTable, useInfiniteTable, tables } from "bifrost"`. That export list is the whole SDK — see `references/web-sdk-v2.md` / `generated/web-sdk-surface.md`. Nothing else lives in `"bifrost"`.
+- **SDK hooks/providers ONLY come from `"bifrost"`**: `import { BifrostProvider, BifrostHeader, useWorkflowQuery, useWorkflowMutation, useWorkflow, useTable, useInfiniteTable, tables, files, useFiles } from "bifrost"`. That export list is the whole SDK — see `references/web-sdk-v2.md` / `generated/web-sdk-surface.md`. Nothing else lives in `"bifrost"`.
 - **shadcn/ui components** (Button, Card, Dialog, …): `import { Button } from "@/components/ui/button"` — NOT from `"bifrost"`.
 - **React** (useState, lazy, Suspense, …): `import { useState, lazy, Suspense } from "react"` — NOT from `"bifrost"`.
 - **Router**: `import { Link, Outlet, useNavigate } from "react-router-dom"` — NOT from `"bifrost"`.
@@ -184,7 +185,7 @@ Files under `<app>/components/*.tsx` hold app-specific components.
 - One component per file; filename matches the component name (PascalCase).
 - Either default export OR named export matching the filename.
 - Import from siblings with relative paths: `import SearchInput from "./components/SearchInput"`.
-- Import shadcn/ui components from `@/components/ui/<component>`, icons from `"lucide-react"`, router from `"react-router-dom"`, SDK hooks/providers from `"bifrost"`.
+- Import shadcn/ui components from `@/components/ui/<component>`, icons from `"lucide-react"`, router from `"react-router-dom"`, SDK hooks/providers/files from `"bifrost"`.
 
 ```tsx
 // apps/my-app/components/ClientCard.tsx

--- a/.claude/skills/bifrost-build/references/solutions.md
+++ b/.claude/skills/bifrost-build/references/solutions.md
@@ -1,6 +1,6 @@
 # Solution Workspace (v2) — Reference
 
-A Solution is an installable, deployable unit. Every entity it owns — apps, workflows, forms, agents, tables, configs — is **deploy-owned**: the platform writes them at install/deploy time and treats them as read-only afterwards. Live entity mutation (the entity create/update CLI verbs) returns a 409 because deploy owns those records. You author content in the workspace and ship it with `bifrost solution deploy` (full replace).
+A Solution is an installable, deployable unit. Every entity it owns — apps, workflows, forms, agents, tables, configs — is **deploy-owned**: the platform writes them at install/deploy time and treats them as read-only afterwards. Declared file locations are also part of the Solution definition; their runtime file bytes are user data. Live entity mutation (the entity create/update CLI verbs) returns a 409 because deploy owns those records. You author content in the workspace and ship it with `bifrost solution deploy` (full replace).
 
 > **For a full worked path (including v1→v2 migration and first-time setup), use the `bifrost:migrate` skill.**
 
@@ -81,6 +81,23 @@ bifrost solution deploy --org "Target Org"    # a specific org
 
 Full-replace deploy of the workspace — all entities are written (or overwritten) from the workspace content. Org targeting follows the **unified `--org` standard** (see below).
 
+### 5a. Declare Solution file locations
+
+If the Solution needs durable runtime files, declare named locations in `.bifrost/files.yaml`:
+
+```yaml
+locations:
+  - finance
+  - documents
+```
+
+These names become policy-addressable file locations for the install. They are the portable declaration, not the file content itself. Rules:
+
+- Use business/domain names (`finance`, `documents`, `attachments`), not platform internals.
+- Do not declare `workspace`; it is reserved.
+- Do not create or manage `_solutions/` or `_solution_artifacts/` folders yourself. Those are internal storage prefixes for deployed source and export artifacts.
+- Runtime files are read and written through the Files SDK (`files`, `useFiles`) or the Files CLI/API with `--solution <install-id-or-slug>`. They are not source files under `apps/` or `functions/`.
+
 ### 6. Install from a zip
 
 ```bash
@@ -89,7 +106,20 @@ bifrost solution install my-solution.zip --global            # global install
 bifrost solution install my-solution.zip --org "Target Org"  # a specific org
 ```
 
-Installs a packaged solution (drag-and-drop equivalent). Use `--set KEY=VALUE` to supply config values at install time. **`install` with no org flag installs into your own org** (not global) — pass `--global` for a global install.
+Installs a packaged solution (drag-and-drop equivalent). Use `--set KEY=VALUE` to supply config values at install time. Full-backup zips created with encrypted backup content require `--password`, and `--replace-secrets` / `--replace-data` control whether existing install data is overwritten. **`install` with no org flag installs into your own org** (not global) — pass `--global` for a global install.
+
+### 7. Export and backup
+
+```bash
+bifrost solution export <solution-ref> --mode shareable
+bifrost solution export <solution-ref> --mode full --password "$PASSWORD" --include-data
+```
+
+Export modes:
+
+- **Shareable** exports carry code, manifests, schema, declared file locations, and setup requirements. They do not carry secrets, table rows, or runtime file bytes.
+- **Full** exports are backups. With `--password`, they can carry secret/config values; with `--include-data`, they also carry table rows and solution runtime files in the encrypted tier.
+- File payloads in a full backup are encrypted payload members referenced from `.bifrost/secrets.enc`; do not expect plaintext runtime files as ordinary zip members.
 
 ### The unified `--org` standard
 
@@ -121,9 +151,9 @@ Install **kind** is chosen entirely at deploy/install time via the unified `--or
 
 ---
 
-## Getting forms, agents, tables, and configs into a Solution
+## Getting forms, agents, tables, configs, and files into a Solution
 
-A solution owns these entities the same way it owns apps and workflows: deploy writes them, and they are read-only afterwards. There are two ways content arrives in the workspace manifest deploy reads.
+A solution owns these entities the same way it owns apps and workflows: deploy writes them, and they are read-only afterwards. File location declarations are also deploy-owned. There are two ways entity content arrives in the workspace manifest deploy reads.
 
 **Path A — capture an existing entity (the migration road).** This adopts a loose `_repo`/global entity that already exists OUTSIDE the solution (authored earlier in the `_repo` workspace, where live entity create/update is the normal path — see `references/repo.md`). Capture stamps it into the install, then you pull and deploy:
 
@@ -159,6 +189,8 @@ Capture stamps ownership server-side but does **not** write source. `bifrost sol
 
 **Path B — author from scratch.** The `bifrost:migrate` skill scaffolds a complete solution (including its forms/agents/tables) end-to-end; invoke it as a Claude skill (not a CLI command) when starting fresh.
 
+**Files are different from captured entities.** Add file *locations* to `.bifrost/files.yaml`; do not capture individual files into the source manifest. Runtime files are written later by the installed app or workflows. A full backup can carry those file bytes, but normal deploy is intentionally non-destructive for files absent from the bundle.
+
 ### Updating an already-owned entity
 
 Once an entity is solution-managed, the live entity update verbs **409** (deploy owns it). The update path is to **edit its field in the corresponding `.bifrost/*.yaml` and redeploy**:
@@ -189,6 +221,8 @@ Apps built with `bifrost solution scaffold-app` consume the v2 `bifrost` SDK. Ke
 | `useWorkflow` / `useWorkflowQuery` / `useWorkflowMutation` | Execute workflows; query-style for data loads, mutation-style for actions |
 | `useTable` / `useInfiniteTable` | Direct table read with live updates |
 | `tables` | Low-level CRUD (`tables.get`, `tables.insert`, `tables.update`, `tables.delete`) + error classes |
+| `useFiles` | Live file listing for a location/prefix |
+| `files` | Low-level file API (`read`, `write`, `delete`, `list`, `exists`, signed URLs) + error classes |
 
 There is no React, shadcn, or router injection from the SDK — import those from the standard packages. See `references/web-sdk-v2.md` for full signatures and examples.
 
@@ -197,5 +231,7 @@ There is no React, shadcn, or router injection from the SDK — import those fro
 ## Key constraints
 
 - Workflows must use portable `path::function` refs (e.g. `functions/hello.py::main`), not UUIDs or bare names — UUIDs are environment-specific and break portability.
+- Solution file locations live in `.bifrost/files.yaml`; runtime file bytes are user data and only travel in encrypted full backups.
+- `_solutions/` and `_solution_artifacts/` are platform internals. Never create those folders in a Solution workspace.
 - The `bifrost:migrate` skill covers the v1→v2 migration path (slug swap, import rewrite, entity capture, etc.).
 - For table schema and query patterns, see `references/tables.md`. For workflow authoring, see `references/workflows-python.md`.

--- a/.claude/skills/bifrost-build/references/sources.yaml
+++ b/.claude/skills/bifrost-build/references/sources.yaml
@@ -15,7 +15,8 @@ references:
       - api/bifrost/commands/apps.py
       - client/src/lib/app-sdk/*.ts
       - client/src/lib/app-sdk/*.tsx
-    verified_at_sha: 42e04a10b751778c9f628dc040afa6eb9cdab863
+      - api/bifrost/manifest.py
+    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
 
   - file: references/entities.md
     source_globs:
@@ -58,7 +59,12 @@ references:
   - file: references/solutions.md
     source_globs:
       - api/bifrost/commands/solution.py
-    verified_at_sha: a254ac039dd8c4c2d53772bdf2123e59b604e094
+      - api/bifrost/commands/files.py
+      - api/bifrost/manifest.py
+      - api/src/models/contracts/solutions.py
+      - api/src/services/solution_files.py
+      - api/src/services/solutions/*.py
+    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
 
   - file: references/tables.md
     source_globs:
@@ -72,9 +78,11 @@ references:
     source_globs:
       - client/src/lib/app-sdk/index.v2.ts
       - client/src/lib/app-sdk/use-workflow*.ts
+      - client/src/lib/app-sdk/files.ts
+      - client/src/lib/app-sdk/use-files.ts
       - client/src/lib/app-sdk/provider.tsx
       - client/src/lib/app-sdk/bifrost-header.tsx
-    verified_at_sha: 42e04a10b751778c9f628dc040afa6eb9cdab863
+    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
 
   - file: references/workflows-python.md
     source_globs:

--- a/.claude/skills/bifrost-build/references/web-sdk-v2.md
+++ b/.claude/skills/bifrost-build/references/web-sdk-v2.md
@@ -149,16 +149,112 @@ Accumulates rows across all loaded pages. `hasMore` is true until a partial page
 
 ---
 
+## files and useFiles
+
+The Files SDK gives v2 apps direct, policy-gated access to Bifrost file storage. For Solution apps, declare durable runtime locations in `.bifrost/files.yaml`, then use that location name from the app:
+
+```yaml
+locations:
+  - documents
+```
+
+```tsx
+import { files, useFiles } from "bifrost";
+
+const docs = useFiles("", {
+  location: "documents",
+  includeMetadata: true,
+});
+
+async function saveNote() {
+  await files.write("notes/today.txt", "hello", { location: "documents" });
+  await docs.refetch();
+}
+```
+
+### useFiles — live list
+
+```tsx
+import { useFiles } from "bifrost";
+
+const {
+  files: names,
+  filesMetadata,
+  loading,
+  error,
+  denied,
+  empty,
+  refetch,
+} = useFiles("invoices/", {
+  location: "finance",
+  includeMetadata: true,
+});
+```
+
+- `prefix` is the first argument; use `""` for the location root.
+- `location` defaults to `"workspace"`. In Solution apps, prefer declared locations such as `"finance"` or `"documents"`.
+- `scope` is optional and normally omitted in an app; the platform injects the app/org context.
+- `denied` is true when file policy rejects the list request or revokes the subscription.
+- The hook subscribes to file changes and reloads the list when matching files change.
+
+### files — imperative API
+
+```tsx
+import {
+  files,
+  FileAccessDeniedError,
+  FileNotFoundError,
+  FilePolicyError,
+} from "bifrost";
+
+await files.write("reports/q1.txt", "ready", { location: "finance" });
+const text = await files.read("reports/q1.txt", { location: "finance" });
+const bytes = await files.readBytes("exports/q1.pdf", { location: "finance" });
+await files.writeBytes("exports/q1.pdf", pdfBytes, { location: "finance" });
+
+const listing = await files.list("reports/", {
+  location: "finance",
+  includeMetadata: true,
+});
+
+if (await files.exists("reports/q1.txt", { location: "finance" })) {
+  const blob = await files.download("reports/q1.txt", { location: "finance" });
+  // Or: const signed = await files.signedUrl("reports/q1.txt", { method: "GET", location: "finance" });
+}
+```
+
+Available methods: `read`, `readBytes`, `write`, `writeBytes`, `delete`, `list`, `exists`, `signedUrl`, `signedUrls`, `upload`, and `download`.
+
+Use `upload`/`download` for large or binary browser payloads; they go through signed URLs. Use `write`/`read` for small text payloads and `writeBytes`/`readBytes` for small binary payloads. File policies apply to every operation.
+
+---
+
 ## Error Classes
 
 ```tsx
-import { tables, TableAccessDeniedError, TableNotFoundError } from "bifrost";
+import {
+  tables,
+  files,
+  TableAccessDeniedError,
+  TableNotFoundError,
+  FileAccessDeniedError,
+  FileNotFoundError,
+  FilePolicyError,
+} from "bifrost";
 
 try {
   const snap = await tables.query("my_table");
 } catch (e) {
   if (e instanceof TableNotFoundError) { /* table missing */ }
   if (e instanceof TableAccessDeniedError) { /* policy denied */ }
+}
+
+try {
+  const content = await files.read("reports/q1.txt", { location: "finance" });
+} catch (e) {
+  if (e instanceof FileNotFoundError) { /* file missing */ }
+  if (e instanceof FileAccessDeniedError) { /* policy denied */ }
+  if (e instanceof FilePolicyError) { /* invalid location/path/policy request */ }
 }
 ```
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "version": "1.0.5",
-  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
+  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"
@@ -13,7 +13,7 @@
   "interface": {
     "displayName": "Bifrost",
     "shortDescription": "Build, set up, and package Bifrost automation artifacts",
-    "longDescription": "Use Bifrost skills to build workflows, forms, agents, and apps with the Bifrost SDK and CLI; set up local Bifrost development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
+    "longDescription": "Use Bifrost skills to build workflows, forms, agents, apps, tables, and files with the Bifrost SDK and CLI; set up local Bifrost development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
     "developerName": "Jack Musick",
     "category": "Engineering",
     "capabilities": [
@@ -22,7 +22,7 @@
       "Write"
     ],
     "defaultPrompt": [
-      "Help me build a Bifrost workflow, form, agent, or app.",
+      "Help me build a Bifrost workflow, form, agent, app, table, or file-backed Solution.",
       "Set up this project for local Bifrost development.",
       "Package a Bifrost agent as a Microsoft 365 Copilot Cowork plugin."
     ],

--- a/.github/workflows/ci-noop.yml
+++ b/.github/workflows/ci-noop.yml
@@ -1,6 +1,6 @@
-# Branch-protection bypass for docs-only PRs.
+# Branch-protection bypass for docs/plugin/config-only PRs.
 #
-# Background: ci.yml uses paths-ignore to skip Lint/Unit/E2E on docs-only
+# Background: ci.yml uses paths-ignore to skip Lint/Unit/E2E on docs/plugin/config-only
 # changes. But branch protection requires named status checks (e.g.
 # "Lint & Type Check") to report green before merge — and a job that
 # never runs reports nothing, blocking merge forever.
@@ -38,6 +38,7 @@ on:
       - ".claude-plugin/**"
       - ".codex/**"
       - ".codex-plugin/**"
+      - "plugins/bifrost/**"
       - "docs/**"
       - "LICENSE"
       - ".github/CODEOWNERS"
@@ -59,22 +60,22 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint & Type Check
     steps:
-      - run: echo "Skipped — docs/config-only PR."
+      - run: echo "Skipped — docs/plugin/config-only PR."
 
   test-unit:
     runs-on: ubuntu-latest
     name: Unit Tests
     steps:
-      - run: echo "Skipped — docs/config-only PR."
+      - run: echo "Skipped — docs/plugin/config-only PR."
 
   test-client-unit:
     runs-on: ubuntu-latest
     name: Client Unit Tests
     steps:
-      - run: echo "Skipped — docs/config-only PR."
+      - run: echo "Skipped — docs/plugin/config-only PR."
 
   test-e2e:
     runs-on: ubuntu-latest
     name: E2E Tests
     steps:
-      - run: echo "Skipped — docs/config-only PR."
+      - run: echo "Skipped — docs/plugin/config-only PR."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
-    # Skip CI for documentation/config-only changes. The companion workflow
+    # Skip CI for documentation/plugin/config-only changes. The companion workflow
     # ci-noop.yml fires on these same paths and reports the same status-check
     # names (Lint & Type Check, Unit Tests, E2E Tests) so branch protection
     # still sees the required checks reported as green.
@@ -35,6 +35,7 @@ on:
       - ".claude-plugin/**"
       - ".codex/**"
       - ".codex-plugin/**"
+      - "plugins/bifrost/**"
       - "docs/**"
       - "LICENSE"
       - ".github/CODEOWNERS"
@@ -86,7 +87,7 @@ jobs:
       # Codex skill mirrors (plugins/bifrost/skills/, .codex/skills/) are
       # generated from the canonical .claude/skills/ source. Regenerate and fail
       # if the committed mirrors drift. NOTE: ci.yml paths-ignore skips CI for
-      # skill-only/.md-only PRs (they route to ci-noop.yml), so this gate fires
+      # plugin/skill-only/.md-only PRs (they route to ci-noop.yml), so this gate fires
       # when non-ignored source changes — which is when a mirror regen is most
       # likely needed anyway.
       - name: Codex skill mirrors in sync

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "version": "1.0.5",
-  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, and apps with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
+  "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"
@@ -13,7 +13,7 @@
   "interface": {
     "displayName": "Bifrost",
     "shortDescription": "Build, set up, and package Bifrost automation artifacts",
-    "longDescription": "Use Bifrost skills to build workflows, forms, agents, and apps with the Bifrost SDK and CLI; set up local Bifrost development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
+    "longDescription": "Use Bifrost skills to build workflows, forms, agents, apps, tables, and files with the Bifrost SDK and CLI; set up local Bifrost development; and package Bifrost agents as Microsoft 365 Copilot Cowork plugins.",
     "developerName": "Jack Musick",
     "category": "Engineering",
     "capabilities": [
@@ -22,7 +22,7 @@
       "Write"
     ],
     "defaultPrompt": [
-      "Help me build a Bifrost workflow, form, agent, or app.",
+      "Help me build a Bifrost workflow, form, agent, app, table, or file-backed Solution.",
       "Set up this project for local Bifrost development.",
       "Package a Bifrost agent as a Microsoft 365 Copilot Cowork plugin."
     ],

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: bifrost:build
-description: Build Bifrost workflows, forms, and apps for both Solution workspaces (v2) and the global _repo workspace (v1). Supports SDK-first (local dev + git) and MCP-only modes.
+description: Build Bifrost workflows, forms, agents, apps, tables, and files for both Solution workspaces (v2) and the global _repo workspace (v1). Supports SDK-first (local dev + git) and MCP-only modes.
 ---
 
 # Bifrost Build
 
-Build Bifrost artifacts — apps, workflows, forms, agents, tables. This hub detects your workspace mode and routes you to the right entry doc.
+Build Bifrost artifacts — apps, workflows, forms, agents, tables, and files. This hub detects your workspace mode and routes you to the right entry doc.
 
 ## Prerequisites
 
@@ -33,7 +33,7 @@ echo "${found:-NOT_FOUND}"
 ```
 
 **Found → Solution workspace (v2).** Read `references/solutions.md` and follow it.
-- Entities (apps, workflows, forms, agents, tables, configs) are deploy-owned. They ship with the solution and are installed/updated by `bifrost solution deploy` — NOT by live CLI mutations. Calling `bifrost forms create` (or any entity create/update) in a solution workspace 409s because deploy owns those records.
+- Entities (apps, workflows, forms, agents, tables, configs) and declared file locations are deploy-owned. They ship with the solution and are installed/updated by `bifrost solution deploy` — NOT by live CLI mutations. Calling `bifrost forms create` (or any entity create/update) in a solution workspace 409s because deploy owns those records.
 - You author app code in `apps/` and Python workflows in `functions/`, then deploy with `bifrost solution deploy`.
 
 **Not found → Global `_repo` workspace (v1).** Read `references/repo.md` and follow it.
@@ -79,7 +79,7 @@ This is mode-agnostic — always do it before creating anything.
 
 ## Global Hard Rules (Both Modes)
 
-- **In a Solution workspace, entities are deploy-owned — never mutate them live.** Creating or updating a form, agent, table, config, app, or workflow via the entity CLI create/update verbs against a solution-managed record 409s (deploy owns them). Author the content in the workspace and ship it with `bifrost solution deploy`. (This rule does NOT apply in the global `_repo` workspace, where live mutation is the normal path — see the mode dispatcher above.)
+- **In a Solution workspace, entities are deploy-owned — never mutate them live.** Creating or updating a form, agent, table, config, app, or workflow via the entity CLI create/update verbs against a solution-managed record 409s (deploy owns them). Author the content in the workspace and ship it with `bifrost solution deploy`. Solution file locations are declared in `.bifrost/files.yaml`; runtime file bytes are user data, not source files to edit under `_solutions/`. (This rule does NOT apply in the global `_repo` workspace, where live mutation is the normal path — see the mode dispatcher above.)
 - **Never run the watch/push/pull/sync/git commands unsolicited.** These are user-driven, have broad blast radius, or launch interactive TUIs. Describe them to the user and ask them to run the command themselves. This applies in both solution and repo mode.
 - **Never call `bifrost api` for third-party integration APIs** (HaloPSA, Pax8, NinjaOne, etc.). `bifrost api` is the Bifrost platform API only. Call integration APIs from within a workflow using the SDK, not the `bifrost api` passthrough.
 - **Check before using `bifrost api GET <path>`.** If you don't know whether a platform endpoint exists, check `generated/openapi-digest.md` or the entity's `--help` flag first. Never guess URL patterns.
@@ -117,6 +117,7 @@ When workflows are exposed as MCP tools (via agents), their `name` becomes the M
 | Create a form | `references/entities.md` |
 | Create/update/delete any CLI entity | `references/entities.md` |
 | Work with tables (read/write structured data) | `references/tables.md` |
+| Work with app/user files | `references/solutions.md` · `references/web-sdk-v2.md` |
 | MCP-only mode (no local source) | `references/mcp-mode.md` |
 | Exact CLI flag for a command | `generated/cli-reference.md` |
 | Does a platform endpoint exist? | `generated/openapi-digest.md` |

--- a/plugins/bifrost/skills/bifrost-build/references/apps.md
+++ b/plugins/bifrost/skills/bifrost-build/references/apps.md
@@ -26,6 +26,7 @@ my-solution/
       pages/              # your route pages
   functions/
     hello.py              # @workflow decorated function (solution root, not under the app)
+  .bifrost/files.yaml     # optional Solution runtime file-location declarations
   bifrost.solution.yaml   # Solution descriptor
 ```
 
@@ -71,7 +72,7 @@ root.render(
 (The old `window.__BIFROST_API_URL__` / `window.__BIFROST_TOKEN__` globals AND `document.currentScript?.dataset?.m` are stale — the current boot protocol is the `new URL(import.meta.url)` nonce + registry above. Just keep the scaffolded `main.tsx`.)
 
 Imports in a **v2 standalone app** (this is NOT the v1 surface — see the warning below):
-- **SDK hooks/providers ONLY come from `"bifrost"`**: `import { BifrostProvider, BifrostHeader, useWorkflowQuery, useWorkflowMutation, useWorkflow, useTable, useInfiniteTable, tables } from "bifrost"`. That export list is the whole SDK — see `references/web-sdk-v2.md` / `generated/web-sdk-surface.md`. Nothing else lives in `"bifrost"`.
+- **SDK hooks/providers ONLY come from `"bifrost"`**: `import { BifrostProvider, BifrostHeader, useWorkflowQuery, useWorkflowMutation, useWorkflow, useTable, useInfiniteTable, tables, files, useFiles } from "bifrost"`. That export list is the whole SDK — see `references/web-sdk-v2.md` / `generated/web-sdk-surface.md`. Nothing else lives in `"bifrost"`.
 - **shadcn/ui components** (Button, Card, Dialog, …): `import { Button } from "@/components/ui/button"` — NOT from `"bifrost"`.
 - **React** (useState, lazy, Suspense, …): `import { useState, lazy, Suspense } from "react"` — NOT from `"bifrost"`.
 - **Router**: `import { Link, Outlet, useNavigate } from "react-router-dom"` — NOT from `"bifrost"`.
@@ -184,7 +185,7 @@ Files under `<app>/components/*.tsx` hold app-specific components.
 - One component per file; filename matches the component name (PascalCase).
 - Either default export OR named export matching the filename.
 - Import from siblings with relative paths: `import SearchInput from "./components/SearchInput"`.
-- Import shadcn/ui components from `@/components/ui/<component>`, icons from `"lucide-react"`, router from `"react-router-dom"`, SDK hooks/providers from `"bifrost"`.
+- Import shadcn/ui components from `@/components/ui/<component>`, icons from `"lucide-react"`, router from `"react-router-dom"`, SDK hooks/providers/files from `"bifrost"`.
 
 ```tsx
 // apps/my-app/components/ClientCard.tsx

--- a/plugins/bifrost/skills/bifrost-build/references/solutions.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solutions.md
@@ -1,6 +1,6 @@
 # Solution Workspace (v2) — Reference
 
-A Solution is an installable, deployable unit. Every entity it owns — apps, workflows, forms, agents, tables, configs — is **deploy-owned**: the platform writes them at install/deploy time and treats them as read-only afterwards. Live entity mutation (the entity create/update CLI verbs) returns a 409 because deploy owns those records. You author content in the workspace and ship it with `bifrost solution deploy` (full replace).
+A Solution is an installable, deployable unit. Every entity it owns — apps, workflows, forms, agents, tables, configs — is **deploy-owned**: the platform writes them at install/deploy time and treats them as read-only afterwards. Declared file locations are also part of the Solution definition; their runtime file bytes are user data. Live entity mutation (the entity create/update CLI verbs) returns a 409 because deploy owns those records. You author content in the workspace and ship it with `bifrost solution deploy` (full replace).
 
 > **For a full worked path (including v1→v2 migration and first-time setup), use the `bifrost:migrate` skill.**
 
@@ -81,6 +81,23 @@ bifrost solution deploy --org "Target Org"    # a specific org
 
 Full-replace deploy of the workspace — all entities are written (or overwritten) from the workspace content. Org targeting follows the **unified `--org` standard** (see below).
 
+### 5a. Declare Solution file locations
+
+If the Solution needs durable runtime files, declare named locations in `.bifrost/files.yaml`:
+
+```yaml
+locations:
+  - finance
+  - documents
+```
+
+These names become policy-addressable file locations for the install. They are the portable declaration, not the file content itself. Rules:
+
+- Use business/domain names (`finance`, `documents`, `attachments`), not platform internals.
+- Do not declare `workspace`; it is reserved.
+- Do not create or manage `_solutions/` or `_solution_artifacts/` folders yourself. Those are internal storage prefixes for deployed source and export artifacts.
+- Runtime files are read and written through the Files SDK (`files`, `useFiles`) or the Files CLI/API with `--solution <install-id-or-slug>`. They are not source files under `apps/` or `functions/`.
+
 ### 6. Install from a zip
 
 ```bash
@@ -89,7 +106,20 @@ bifrost solution install my-solution.zip --global            # global install
 bifrost solution install my-solution.zip --org "Target Org"  # a specific org
 ```
 
-Installs a packaged solution (drag-and-drop equivalent). Use `--set KEY=VALUE` to supply config values at install time. **`install` with no org flag installs into your own org** (not global) — pass `--global` for a global install.
+Installs a packaged solution (drag-and-drop equivalent). Use `--set KEY=VALUE` to supply config values at install time. Full-backup zips created with encrypted backup content require `--password`, and `--replace-secrets` / `--replace-data` control whether existing install data is overwritten. **`install` with no org flag installs into your own org** (not global) — pass `--global` for a global install.
+
+### 7. Export and backup
+
+```bash
+bifrost solution export <solution-ref> --mode shareable
+bifrost solution export <solution-ref> --mode full --password "$PASSWORD" --include-data
+```
+
+Export modes:
+
+- **Shareable** exports carry code, manifests, schema, declared file locations, and setup requirements. They do not carry secrets, table rows, or runtime file bytes.
+- **Full** exports are backups. With `--password`, they can carry secret/config values; with `--include-data`, they also carry table rows and solution runtime files in the encrypted tier.
+- File payloads in a full backup are encrypted payload members referenced from `.bifrost/secrets.enc`; do not expect plaintext runtime files as ordinary zip members.
 
 ### The unified `--org` standard
 
@@ -121,9 +151,9 @@ Install **kind** is chosen entirely at deploy/install time via the unified `--or
 
 ---
 
-## Getting forms, agents, tables, and configs into a Solution
+## Getting forms, agents, tables, configs, and files into a Solution
 
-A solution owns these entities the same way it owns apps and workflows: deploy writes them, and they are read-only afterwards. There are two ways content arrives in the workspace manifest deploy reads.
+A solution owns these entities the same way it owns apps and workflows: deploy writes them, and they are read-only afterwards. File location declarations are also deploy-owned. There are two ways entity content arrives in the workspace manifest deploy reads.
 
 **Path A — capture an existing entity (the migration road).** This adopts a loose `_repo`/global entity that already exists OUTSIDE the solution (authored earlier in the `_repo` workspace, where live entity create/update is the normal path — see `references/repo.md`). Capture stamps it into the install, then you pull and deploy:
 
@@ -159,6 +189,8 @@ Capture stamps ownership server-side but does **not** write source. `bifrost sol
 
 **Path B — author from scratch.** The `bifrost:migrate` skill scaffolds a complete solution (including its forms/agents/tables) end-to-end; invoke it as a Claude skill (not a CLI command) when starting fresh.
 
+**Files are different from captured entities.** Add file *locations* to `.bifrost/files.yaml`; do not capture individual files into the source manifest. Runtime files are written later by the installed app or workflows. A full backup can carry those file bytes, but normal deploy is intentionally non-destructive for files absent from the bundle.
+
 ### Updating an already-owned entity
 
 Once an entity is solution-managed, the live entity update verbs **409** (deploy owns it). The update path is to **edit its field in the corresponding `.bifrost/*.yaml` and redeploy**:
@@ -189,6 +221,8 @@ Apps built with `bifrost solution scaffold-app` consume the v2 `bifrost` SDK. Ke
 | `useWorkflow` / `useWorkflowQuery` / `useWorkflowMutation` | Execute workflows; query-style for data loads, mutation-style for actions |
 | `useTable` / `useInfiniteTable` | Direct table read with live updates |
 | `tables` | Low-level CRUD (`tables.get`, `tables.insert`, `tables.update`, `tables.delete`) + error classes |
+| `useFiles` | Live file listing for a location/prefix |
+| `files` | Low-level file API (`read`, `write`, `delete`, `list`, `exists`, signed URLs) + error classes |
 
 There is no React, shadcn, or router injection from the SDK — import those from the standard packages. See `references/web-sdk-v2.md` for full signatures and examples.
 
@@ -197,5 +231,7 @@ There is no React, shadcn, or router injection from the SDK — import those fro
 ## Key constraints
 
 - Workflows must use portable `path::function` refs (e.g. `functions/hello.py::main`), not UUIDs or bare names — UUIDs are environment-specific and break portability.
+- Solution file locations live in `.bifrost/files.yaml`; runtime file bytes are user data and only travel in encrypted full backups.
+- `_solutions/` and `_solution_artifacts/` are platform internals. Never create those folders in a Solution workspace.
 - The `bifrost:migrate` skill covers the v1→v2 migration path (slug swap, import rewrite, entity capture, etc.).
 - For table schema and query patterns, see `references/tables.md`. For workflow authoring, see `references/workflows-python.md`.

--- a/plugins/bifrost/skills/bifrost-build/references/sources.yaml
+++ b/plugins/bifrost/skills/bifrost-build/references/sources.yaml
@@ -15,7 +15,8 @@ references:
       - api/bifrost/commands/apps.py
       - client/src/lib/app-sdk/*.ts
       - client/src/lib/app-sdk/*.tsx
-    verified_at_sha: 42e04a10b751778c9f628dc040afa6eb9cdab863
+      - api/bifrost/manifest.py
+    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
 
   - file: references/entities.md
     source_globs:
@@ -58,7 +59,12 @@ references:
   - file: references/solutions.md
     source_globs:
       - api/bifrost/commands/solution.py
-    verified_at_sha: a254ac039dd8c4c2d53772bdf2123e59b604e094
+      - api/bifrost/commands/files.py
+      - api/bifrost/manifest.py
+      - api/src/models/contracts/solutions.py
+      - api/src/services/solution_files.py
+      - api/src/services/solutions/*.py
+    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
 
   - file: references/tables.md
     source_globs:
@@ -72,9 +78,11 @@ references:
     source_globs:
       - client/src/lib/app-sdk/index.v2.ts
       - client/src/lib/app-sdk/use-workflow*.ts
+      - client/src/lib/app-sdk/files.ts
+      - client/src/lib/app-sdk/use-files.ts
       - client/src/lib/app-sdk/provider.tsx
       - client/src/lib/app-sdk/bifrost-header.tsx
-    verified_at_sha: 42e04a10b751778c9f628dc040afa6eb9cdab863
+    verified_at_sha: 236d0f4753b4b14cfc05c42dccbe9db26b411a77
 
   - file: references/workflows-python.md
     source_globs:

--- a/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
+++ b/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
@@ -149,16 +149,112 @@ Accumulates rows across all loaded pages. `hasMore` is true until a partial page
 
 ---
 
+## files and useFiles
+
+The Files SDK gives v2 apps direct, policy-gated access to Bifrost file storage. For Solution apps, declare durable runtime locations in `.bifrost/files.yaml`, then use that location name from the app:
+
+```yaml
+locations:
+  - documents
+```
+
+```tsx
+import { files, useFiles } from "bifrost";
+
+const docs = useFiles("", {
+  location: "documents",
+  includeMetadata: true,
+});
+
+async function saveNote() {
+  await files.write("notes/today.txt", "hello", { location: "documents" });
+  await docs.refetch();
+}
+```
+
+### useFiles — live list
+
+```tsx
+import { useFiles } from "bifrost";
+
+const {
+  files: names,
+  filesMetadata,
+  loading,
+  error,
+  denied,
+  empty,
+  refetch,
+} = useFiles("invoices/", {
+  location: "finance",
+  includeMetadata: true,
+});
+```
+
+- `prefix` is the first argument; use `""` for the location root.
+- `location` defaults to `"workspace"`. In Solution apps, prefer declared locations such as `"finance"` or `"documents"`.
+- `scope` is optional and normally omitted in an app; the platform injects the app/org context.
+- `denied` is true when file policy rejects the list request or revokes the subscription.
+- The hook subscribes to file changes and reloads the list when matching files change.
+
+### files — imperative API
+
+```tsx
+import {
+  files,
+  FileAccessDeniedError,
+  FileNotFoundError,
+  FilePolicyError,
+} from "bifrost";
+
+await files.write("reports/q1.txt", "ready", { location: "finance" });
+const text = await files.read("reports/q1.txt", { location: "finance" });
+const bytes = await files.readBytes("exports/q1.pdf", { location: "finance" });
+await files.writeBytes("exports/q1.pdf", pdfBytes, { location: "finance" });
+
+const listing = await files.list("reports/", {
+  location: "finance",
+  includeMetadata: true,
+});
+
+if (await files.exists("reports/q1.txt", { location: "finance" })) {
+  const blob = await files.download("reports/q1.txt", { location: "finance" });
+  // Or: const signed = await files.signedUrl("reports/q1.txt", { method: "GET", location: "finance" });
+}
+```
+
+Available methods: `read`, `readBytes`, `write`, `writeBytes`, `delete`, `list`, `exists`, `signedUrl`, `signedUrls`, `upload`, and `download`.
+
+Use `upload`/`download` for large or binary browser payloads; they go through signed URLs. Use `write`/`read` for small text payloads and `writeBytes`/`readBytes` for small binary payloads. File policies apply to every operation.
+
+---
+
 ## Error Classes
 
 ```tsx
-import { tables, TableAccessDeniedError, TableNotFoundError } from "bifrost";
+import {
+  tables,
+  files,
+  TableAccessDeniedError,
+  TableNotFoundError,
+  FileAccessDeniedError,
+  FileNotFoundError,
+  FilePolicyError,
+} from "bifrost";
 
 try {
   const snap = await tables.query("my_table");
 } catch (e) {
   if (e instanceof TableNotFoundError) { /* table missing */ }
   if (e instanceof TableAccessDeniedError) { /* policy denied */ }
+}
+
+try {
+  const content = await files.read("reports/q1.txt", { location: "finance" });
+} catch (e) {
+  if (e instanceof FileNotFoundError) { /* file missing */ }
+  if (e instanceof FileAccessDeniedError) { /* policy denied */ }
+  if (e instanceof FilePolicyError) { /* invalid location/path/policy request */ }
 }
 ```
 


### PR DESCRIPTION
## Summary
- update the Bifrost Codex/Claude plugin descriptions to include files and tables while keeping plugin manifests at 1.0.5
- document Solution file-location declarations in `.bifrost/files.yaml`, internal storage prefixes to avoid, and full-backup file behavior
- add `files` / `useFiles` examples to the v2 web SDK skill reference and sync the public plugin mirror
- route future `plugins/bifrost/**` package-only changes through the noop CI workflow

## Verification
- `./test.sh tests/unit/test_skill_examples.py tests/unit/test_skill_reference_freshness.py tests/unit/test_skill_appendix_fresh.py -v` -> 11 passed, 1 skipped (host-only git freshness check)
- `./test.sh tests/unit/test_codex_mirror_sync.py -v` -> 1 skipped in container; mirror sync verified with `scripts/sync-codex-skills.sh` + direct mirror diff
- `git diff --check`
- `jq empty .codex-plugin/plugin.json .claude-plugin/plugin.json plugins/bifrost/.codex-plugin/plugin.json`
- touched reference freshness check for apps/solutions/web-sdk-v2 -> OK
- CI/noop path-list parity script -> OK
- `python3 api/scripts/check_github_action_pins.py`

No issue: small v1.0.5 plugin-doc follow-up requested directly.

Note: this PR itself changes workflow files, so it still gets full CI once. Future plugin-package-only PRs will hit the noop required checks.
