### PR TITLE
fix(files): workspace is superuser-only; CLI aborts on failed file list

### DIFF
--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -2875,10 +2875,18 @@ async def _watch_and_push(
         # Best-effort start notification — server tolerates clients that didn't announce
         logger.debug(f"watch start notification failed: {e}")
 
-    # Initial full sync
+    # Initial full sync. If it aborts (e.g. the server file listing failed —
+    # auth/permission error, server down), do NOT fall through to start the
+    # observer: a half-initialized watch with no server view would push every
+    # subsequent local edit blindly, which is the exact mass-push the abort is
+    # meant to prevent (just deferred to per-file events).
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         print(f"Initial sync of {path}...", flush=True)
-    await _sync_files(str(path), repo_prefix=repo_prefix, mirror=mirror, validate=validate, client=client)
+    initial_rc = await _sync_files(
+        str(path), repo_prefix=repo_prefix, mirror=mirror, validate=validate, client=client
+    )
+    if initial_rc != 0:
+        return initial_rc
 
     # Seed the known-server-hash cache from the server's file listing before
     # the observer starts. Without this, the very first observer event for

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -3081,6 +3081,14 @@ async def _sync_files(
     regular_files = {k: v for k, v in files.items() if not _is_bifrost_path(k)}
 
     # ── 2. Fetch server file metadata ────────────────────────────────────
+    # A failed listing is FATAL, not a "push everything" fallback. If we can't
+    # read server state (auth/permission failure, server error, network drop),
+    # every local file would look "new locally" and we'd mass-push the entire
+    # workspace over whatever is on the server — silently, with no way for the
+    # user to catch it. A genuinely empty workspace returns HTTP 200 with an
+    # empty list, so we can still distinguish "nothing on server" (safe to
+    # push) from "couldn't see the server" (abort). Bail loudly on anything
+    # else.
     server_metadata: dict[str, dict[str, str]] = {}
     try:
         resp = await client.post("/api/files/list", json={
@@ -3088,17 +3096,43 @@ async def _sync_files(
             "mode": "cloud",
             "location": "workspace",
         })
-        if resp.status_code == 200:
-            data = resp.json()
-            for item in data.get("files_metadata", []):
-                server_metadata[item["path"]] = {
-                    "etag": item["etag"],
-                    "last_modified": item["last_modified"],
-                    "updated_by": item.get("updated_by", ""),
-                }
     except Exception as e:
-        # Without metadata we'll push everything — slower but still correct
-        logger.debug(f"could not fetch server file metadata, will push without diff: {e}")
+        print(
+            f"Error: could not reach the server to list files ({e}).\n"
+            "Aborting to avoid pushing every local file as new.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if resp.status_code != 200:
+        detail = ""
+        try:
+            detail = resp.json().get("detail", "")
+        except Exception:  # noqa: BLE001 - body may not be JSON; detail stays ""
+            detail = (resp.text or "")[:200]
+        hint = ""
+        if resp.status_code in (401, 403):
+            hint = (
+                "\nThis looks like an authentication/permission problem — "
+                "re-run `bifrost login` and confirm your account can access "
+                "the workspace."
+            )
+        print(
+            f"Error: server returned HTTP {resp.status_code} listing files"
+            f"{f' ({detail})' if detail else ''}.\n"
+            "Aborting to avoid pushing every local file as new."
+            f"{hint}",
+            file=sys.stderr,
+        )
+        return 1
+
+    data = resp.json()
+    for item in data.get("files_metadata", []):
+        server_metadata[item["path"]] = {
+            "etag": item["etag"],
+            "last_modified": item["last_modified"],
+            "updated_by": item.get("updated_by", ""),
+        }
 
     # Filter .git/ objects from server listing
     server_metadata = {

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -354,8 +354,17 @@ async def _authorize_file_policy(
 
     For solution-context requests, `scope` is the install UUID string (not an
     org UUID), so we derive `organization_id` from the install and forward
-    `solution_id` separately rather than coercing the install UUID into org."""
+    `solution_id` separately rather than coercing the install UUID into org.
+
+    `workspace` is the shared platform codebase: it is superuser-only and never
+    carries file policies. Policy evaluation default-denies when no policy row
+    exists, which would 403 a superuser running `bifrost sync`/`watch` against
+    the normal (unconfigured) workspace, so we short-circuit to a plain
+    superuser check here rather than consulting the policy service."""
     from src.services.file_policy_service import FilePolicyService
+
+    if location == "workspace":
+        return bool(getattr(ctx.user, "is_superuser", False))
 
     policy_organization_id: UUID | None = None
     resolved_solution_id = solution_id

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -364,13 +364,14 @@ async def _authorize_file_policy(
     from src.services.file_policy_service import FilePolicyService
 
     if location == "workspace":
-        return bool(getattr(ctx.user, "is_superuser", False))
+        return ctx.user.is_superuser
 
+    # Past this point location is never "workspace" (handled above).
     policy_organization_id: UUID | None = None
     resolved_solution_id = solution_id
     if organization_id is not _USE_CONTEXT_SOLUTION_ID:
         policy_organization_id = cast(UUID | None, organization_id)
-    elif location != "workspace":
+    else:
         if scope is None:
             return False
         if resolved_solution_id is not None:
@@ -596,6 +597,22 @@ async def test_file_policy_access(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     principal = await _test_principal(ctx, db, request.user_id)
+
+    # workspace is superuser-only and never policy-governed — mirror the real
+    # enforcement in _authorize_file_policy so Test Access reports what actually
+    # happens, not a stale policy-service evaluation.
+    if request.location == "workspace":
+        allowed = principal.is_superuser
+        return FilePolicyAccessTestResponse(
+            allowed=allowed,
+            path=request.path,
+            location=request.location,
+            action=request.action,
+            matched_policy=None,
+            matched_rule="superuser (workspace is not policy-governed)" if allowed else None,
+            denial_reason=None if allowed else "workspace is superuser-only",
+        )
+
     service = FilePolicyService(db)
     matched = await service.load_policy(
         organization_id=org_id,

--- a/api/tests/e2e/platform/test_cli_push_pull.py
+++ b/api/tests/e2e/platform/test_cli_push_pull.py
@@ -1,17 +1,15 @@
-"""E2E tests for CLI push/pull endpoints and manifest round-tripping."""
+"""E2E tests for CLI push/pull endpoints and manifest round-tripping.
+
+NOTE: these tests deliberately do NOT grant a workspace file policy. `workspace`
+is superuser-only and never policy-governed, so a superuser reaches it without a
+grant — that is the exact path `bifrost sync`/`watch` uses. (A previous autouse
+`grant_file_policy(location="workspace")` fixture here was masking a regression
+where workspace reads/lists default-denied; see test_workspace_superuser_only.py.)
+"""
 import base64
 import hashlib
 import uuid
 from urllib.parse import quote
-
-import pytest
-
-from tests.e2e.file_policy_helpers import grant_file_policy
-
-
-@pytest.fixture(autouse=True)
-def _grant_workspace_file_policy(e2e_client, platform_admin):
-    grant_file_policy(e2e_client, platform_admin.headers, location="workspace")
 
 
 
@@ -227,14 +225,18 @@ def test_list_with_metadata(e2e_client, platform_admin):
     assert item["etag"] == expected_md5
 
 
-def test_list_with_metadata_filters_denied_platform_admin_paths(
+def test_workspace_ignores_file_policies_for_superuser(
     e2e_client,
     platform_admin,
 ):
-    """include_metadata should obey a revoked admin bypass for individual files."""
+    """workspace is superuser-only and NOT policy-governed: setting an empty
+    (deny-all) policy on a workspace path must NOT hide it from a superuser's
+    metadata listing. Guards against workspace policy enforcement regressing
+    back in (which 403'd `bifrost sync`)."""
     path = f"modules/metadata-denied-{uuid.uuid4().hex}.py"
     _write_file(e2e_client, platform_admin.headers, path, "# denied metadata")
 
+    # Even an explicit deny-all policy on this exact path is inert for workspace.
     for _ in range(2):
         response = e2e_client.put(
             f"/api/files/policies/{quote(path, safe='')}",
@@ -251,8 +253,8 @@ def test_list_with_metadata_filters_denied_platform_admin_paths(
     })
     assert resp.status_code == 200
     data = resp.json()
-    assert path not in data["files"]
-    assert path not in {item["path"] for item in data["files_metadata"]}
+    assert path in data["files"]
+    assert path in {item["path"] for item in data["files_metadata"]}
 
 
 def test_list_with_metadata_excludes_git(e2e_client, platform_admin):

--- a/api/tests/e2e/platform/test_file_policies_rest.py
+++ b/api/tests/e2e/platform/test_file_policies_rest.py
@@ -129,10 +129,12 @@ def _assign_role(e2e_client, platform_admin, role_id: str, *users) -> None:
 
 
 @pytest.mark.e2e
+# NOTE: `workspace` is intentionally NOT in this list. It is the shared
+# platform codebase: superuser-only and never policy-governed (default-deny
+# does not apply). Its contract lives in test_workspace_superuser_only.py.
 @pytest.mark.parametrize(
     ("location", "scope_kind"),
     [
-        ("workspace", "workspace"),
         ("temp", "org"),
         ("uploads", "org"),
         ("shared", "org"),

--- a/api/tests/e2e/platform/test_workspace_superuser_only.py
+++ b/api/tests/e2e/platform/test_workspace_superuser_only.py
@@ -1,0 +1,79 @@
+"""The `workspace` location is superuser-only and bypasses file policies.
+
+Regression guard for the CLI `sync`/`watch` 403: the file-policies feature
+made `/api/files/list` and `/api/files/read` evaluate file policies even for
+`location="workspace"`. With no policy row present (the normal case — nobody
+sets policies on the shared codebase), the policy service default-denies, so a
+superuser running `bifrost sync` got a 403. The CLI swallowed that and reported
+every local file as "new locally" → a mass push.
+
+`workspace` is the shared platform codebase: it must be reachable by any
+superuser WITHOUT a granted file policy, and denied to non-superusers. These
+tests assert that directly, with NO `grant_file_policy` scaffolding.
+"""
+import hashlib
+
+
+def _write(e2e_client, headers, path, content):
+    return e2e_client.post("/api/files/write", headers=headers, json={
+        "path": path,
+        "content": content,
+        "mode": "cloud",
+        "location": "workspace",
+        "binary": False,
+    })
+
+
+def test_superuser_lists_workspace_without_policy(e2e_client, platform_admin):
+    """A superuser can list the workspace with no file policy granted."""
+    resp = e2e_client.post("/api/files/list", headers=platform_admin.headers, json={
+        "include_metadata": True,
+        "mode": "cloud",
+        "location": "workspace",
+    })
+    assert resp.status_code == 200, f"workspace list denied: {resp.status_code} {resp.text}"
+
+
+def test_superuser_write_then_read_workspace_without_policy(e2e_client, platform_admin):
+    """A superuser can write and read back a workspace file with no policy."""
+    path = "modules/_ws_superuser_probe.py"
+    content = "# workspace superuser probe\n"
+    w = _write(e2e_client, platform_admin.headers, path, content)
+    assert w.status_code == 204, f"workspace write denied: {w.status_code} {w.text}"
+
+    r = e2e_client.post("/api/files/read", headers=platform_admin.headers, json={
+        "path": path,
+        "mode": "cloud",
+        "location": "workspace",
+        "binary": False,
+    })
+    assert r.status_code == 200, f"workspace read denied: {r.status_code} {r.text}"
+    assert r.json()["content"] == content
+
+
+def test_superuser_list_metadata_etag_matches_local_md5(e2e_client, platform_admin):
+    """The metadata listing returns plain-MD5 etags the CLI diff relies on."""
+    path = "modules/_ws_etag_probe.py"
+    content = "print('etag')\n"
+    assert _write(e2e_client, platform_admin.headers, path, content).status_code == 204
+
+    resp = e2e_client.post("/api/files/list", headers=platform_admin.headers, json={
+        "include_metadata": True,
+        "mode": "cloud",
+        "location": "workspace",
+    })
+    assert resp.status_code == 200, resp.text
+    meta = {m["path"]: m for m in resp.json()["files_metadata"]}
+    assert path in meta, f"{path} not in listing"
+    expected = hashlib.md5(content.encode()).hexdigest()
+    assert meta[path]["etag"] == expected
+
+
+def test_non_superuser_denied_workspace(e2e_client, non_admin_user):
+    """A non-superuser cannot touch the workspace location at all."""
+    resp = e2e_client.post("/api/files/list", headers=non_admin_user.headers, json={
+        "include_metadata": True,
+        "mode": "cloud",
+        "location": "workspace",
+    })
+    assert resp.status_code == 403, f"expected 403 for non-admin, got {resp.status_code}"

--- a/api/tests/e2e/platform/test_workspace_superuser_only.py
+++ b/api/tests/e2e/platform/test_workspace_superuser_only.py
@@ -77,3 +77,17 @@ def test_non_superuser_denied_workspace(e2e_client, non_admin_user):
         "location": "workspace",
     })
     assert resp.status_code == 403, f"expected 403 for non-admin, got {resp.status_code}"
+
+
+def test_access_test_endpoint_reports_workspace_superuser_only(e2e_client, platform_admin):
+    """The Test Access endpoint must mirror real enforcement: workspace is
+    superuser-only and ignores any policy row, so a superuser is allowed."""
+    resp = e2e_client.post(
+        "/api/files/policies/test",
+        headers=platform_admin.headers,
+        json={"path": "modules/anything.py", "location": "workspace", "action": "read"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["allowed"] is True
+    assert body["matched_policy"] is None

--- a/api/tests/unit/test_cli_sync_list_failure.py
+++ b/api/tests/unit/test_cli_sync_list_failure.py
@@ -1,0 +1,97 @@
+"""A failed server file-listing must ABORT the sync, never mass-push.
+
+Regression guard: `_sync_files` used to swallow any non-200 (or exception) from
+`/api/files/list` and proceed with an empty server view — so every local file
+looked "new locally" and got pushed. On an auth/permission failure (403/401)
+that silently overwrites the server with the entire local tree. The fetch is
+now fatal: bail with rc=1 and write NOTHING.
+"""
+import asyncio
+import base64
+
+import pytest
+
+from bifrost import cli
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> dict:
+        if self._payload is None:
+            raise ValueError("no json body")
+        return self._payload
+
+
+class _FailingListClient:
+    """Server rejects the listing; records any write attempts."""
+
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self._status = status_code
+        self._payload = payload
+        self.writes: list[dict] = []
+
+    async def post(self, url: str, json: dict | None = None):  # noqa: A002
+        if url == "/api/files/list":
+            return _Resp(self._status, self._payload)
+        if url == "/api/files/write":
+            self.writes.append(json or {})
+            return _Resp(204)
+        return _Resp(200, {})
+
+    async def get(self, url: str):
+        return _Resp(404)
+
+
+def _fake_collect(path, repo_prefix, single_file=None):
+    files = {
+        f"app/file{i}.txt": base64.b64encode(f"content {i}".encode()).decode()
+        for i in range(1, 4)
+    }
+    return files, 0
+
+
+@pytest.mark.parametrize("status_code", [403, 401, 500])
+def test_failed_list_aborts_without_pushing(monkeypatch, capsys, tmp_path, status_code):
+    monkeypatch.setattr(cli, "_is_tty", False)
+    monkeypatch.setattr(cli, "_collect_push_files", _fake_collect)
+    client = _FailingListClient(status_code, {"detail": "Forbidden"})
+
+    rc = asyncio.run(
+        cli._sync_files(str(tmp_path), repo_prefix="app", client=client, one_way=True)
+    )
+
+    assert rc == 1, "a failed listing must abort with a non-zero exit code"
+    assert client.writes == [], "no files may be pushed when the listing failed"
+    err = capsys.readouterr().err
+    assert "Aborting" in err
+    assert str(status_code) in err
+
+
+def test_list_network_error_aborts(monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(cli, "_is_tty", False)
+    monkeypatch.setattr(cli, "_collect_push_files", _fake_collect)
+
+    class _BoomClient:
+        def __init__(self):
+            self.writes: list[dict] = []
+
+        async def post(self, url: str, json: dict | None = None):  # noqa: A002
+            if url == "/api/files/list":
+                raise ConnectionError("connection refused")
+            if url == "/api/files/write":
+                self.writes.append(json or {})
+                return _Resp(204)
+            return _Resp(200, {})
+
+    client = _BoomClient()
+    rc = asyncio.run(
+        cli._sync_files(str(tmp_path), repo_prefix="app", client=client, one_way=True)
+    )
+
+    assert rc == 1
+    assert client.writes == []
+    assert "Aborting" in capsys.readouterr().err

--- a/api/tests/unit/test_cli_watch.py
+++ b/api/tests/unit/test_cli_watch.py
@@ -406,7 +406,9 @@ def test_watch_allowed_in_plain_repo_workspace(tmp_path):
 def test_watch_aborts_when_initial_sync_fails(tmp_path):
     """If the initial _sync_files aborts (e.g. server file listing 403s), watch
     must return that code and NEVER construct the Observer."""
-    import bifrost.cli as cli
+    import asyncio
+
+    from bifrost.cli import _watch_and_push
 
     class _ListFails:
         async def post(self, url: str, json: Any = None):
@@ -429,10 +431,11 @@ def test_watch_aborts_when_initial_sync_fails(tmp_path):
         observer_constructed["v"] = True
         raise AssertionError("Observer must not be constructed after an aborted initial sync")
 
+    # _watch_and_push does `from watchdog.observers import Observer` internally,
+    # so patch it at the source module.
     with patch("watchdog.observers.Observer", _boom_observer):
-        import asyncio
         rc = asyncio.run(
-            cli._watch_and_push(
+            _watch_and_push(
                 str(tmp_path), repo_prefix="", mirror=False, validate=False, client=_ListFails()
             )
         )

--- a/api/tests/unit/test_cli_watch.py
+++ b/api/tests/unit/test_cli_watch.py
@@ -395,3 +395,47 @@ def test_watch_allowed_in_plain_repo_workspace(tmp_path):
             handle_watch([str(tmp_path)])
         except RuntimeError as e:
             assert str(e) == "stop-after-guard"
+
+
+# =============================================================================
+# Initial-sync abort: a failed server listing must stop watch from starting
+# the observer (otherwise it half-initializes and mass-pushes per-file).
+# =============================================================================
+
+
+def test_watch_aborts_when_initial_sync_fails(tmp_path):
+    """If the initial _sync_files aborts (e.g. server file listing 403s), watch
+    must return that code and NEVER construct the Observer."""
+    import bifrost.cli as cli
+
+    class _ListFails:
+        async def post(self, url: str, json: Any = None):
+            # The initial sync's /api/files/list returns 403 → _sync_files aborts.
+            if url == "/api/files/list":
+                return SimpleNamespace(
+                    status_code=403,
+                    json=lambda: {"detail": "Forbidden"},
+                    text="Forbidden",
+                )
+            return SimpleNamespace(status_code=204, json=lambda: {})
+
+    # Give the workspace one local file so a non-aborting run would try to push.
+    (tmp_path / "modules").mkdir()
+    (tmp_path / "modules" / "x.py").write_text("print('x')\n")
+
+    observer_constructed = {"v": False}
+
+    def _boom_observer(*a, **k):
+        observer_constructed["v"] = True
+        raise AssertionError("Observer must not be constructed after an aborted initial sync")
+
+    with patch("watchdog.observers.Observer", _boom_observer):
+        import asyncio
+        rc = asyncio.run(
+            cli._watch_and_push(
+                str(tmp_path), repo_prefix="", mirror=False, validate=False, client=_ListFails()
+            )
+        )
+
+    assert rc == 1, "watch must propagate the initial-sync abort code"
+    assert observer_constructed["v"] is False


### PR DESCRIPTION
## Problem
`bifrost sync` / `watch` / `push` reported **every local file as "new locally"** and offered to push the whole workspace, instead of diffing against server state. A second user hit the same thing.

## Root cause
The files-SDK-policies feature switched `/api/files/list`, `/read`, `/write` from `CurrentSuperuser` to `CurrentActiveUser` + `_authorize_file_policy`. That policy check ran for `location == "workspace"` too, and `FilePolicyService.is_allowed` **default-denies when no policy row exists**. Nobody sets policies on the shared workspace, so a superuser got `403 {"detail":"Forbidden"}` listing it.

The CLI's `_sync_files` then **silently swallowed** the non-200 and proceeded with empty server metadata → every file looked new → mass push.

The Monaco editor was unaffected because it uses a different endpoint (`list_files_editor` / `/api/files/structure`). The e2e suite was green only because an autouse `grant_file_policy(location="workspace")` fixture masked it.

## Fix
- **Server** (`api/src/routers/files.py`): short-circuit `_authorize_file_policy` for `location == "workspace"` to a plain superuser check. The shared platform codebase is superuser-only and never policy-governed. Single chokepoint covering read/list/write + `_filter_listed_paths`.
- **CLI** (`api/bifrost/cli.py`): a non-200 (esp. 401/403) or network error from `/api/files/list` is now **fatal** — print an error + auth hint and exit 1, pushing nothing. An empty workspace still returns 200 + empty list, so "empty" stays distinguishable from "couldn't list".
- **Tests**: removed the masking autouse fixture; added `test_workspace_superuser_only.py` (superuser passes without a grant, non-admin denied, etags are plain MD5) and `test_cli_sync_list_failure.py` (403/401/500/network all abort without pushing); fixed two tests that encoded the old workspace-policy contract.

## Verification
- Reproduced the 403 live (prod + local debug stack) and red→green on the new tests.
- Drove the real CLI end-to-end: push → re-push = "Already up to date" (diff works); bad-token push aborts with exit 1, pushing nothing.
- 39 unit + affected files/policy/solution e2e suites pass; ruff + pyright clean on changed files.

Fixes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)