### PR TITLE
Enforce solution-bound CLI workflow

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -1692,16 +1692,30 @@ Options:
   --help  Show this message and exit.
 
 Commands:
+  bind          Bind this local Solution workspace to an existing install.
   capture       Adopt loose _repo/ entities into an install (migration).
+  create        Create and bind a new Solution workspace.
   deploy        Deploy the current Solution workspace (full replace,...
   export        Download a Solution's workspace zip (shareable or full...
-  init          Scaffold a bifrost.solution.yaml descriptor.
+  init          Alias for `solution create`: scaffold, create remote...
   install       Install a Solution from a workspace zip (drag-and-drop...
   migrate-app   Migrate a v1 inline app dir to a scaffolded standalone_v2...
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
   start         Run the app's dev server + local workflows (one origin).
   swap-slugs    Atomically exchange two apps' slugs (v1→v2 migration...
+```
+
+### `solution bind`
+
+```
+Usage: solution bind [OPTIONS] [PATH]
+
+  Bind this local Solution workspace to an existing install.
+
+Options:
+  --solution TEXT  Install id or unique slug.  [required]
+  --help           Show this message and exit.
 ```
 
 ### `solution capture`
@@ -1729,6 +1743,30 @@ Options:
   --help                          Show this message and exit.
 ```
 
+### `solution create`
+
+```
+Usage: solution create [OPTIONS] [PATH]
+
+  Create and bind a new Solution workspace.
+
+Options:
+  --slug TEXT                     Solution slug (definition identity).
+                                  [required]
+  --name TEXT                     Display name (defaults to slug).
+  --version TEXT                  Bundle version recorded on the install at
+                                  deploy time.  [default: 0.1.0]
+  --global-repo-access / --no-global-repo-access
+                                  [default: no-global-repo-access]
+  --global                        Target global scope (org=NULL). Alias for
+                                  --org global.
+  --org, --organization, --scope TEXT
+                                  Org UUID/name, or 'none'/'global' for global
+                                  scope. Omit = your org. (--organization /
+                                  --scope are synonyms.)
+  --help                          Show this message and exit.
+```
+
 ### `solution deploy`
 
 ```
@@ -1737,16 +1775,10 @@ Usage: solution deploy [OPTIONS] [PATH]
   Deploy the current Solution workspace (full replace, non-interactive).
 
 Options:
-  --solution TEXT                 Target install id (override when ambiguous).
-  --global                        Target global scope (org=NULL). Alias for
-                                  --org global.
-  --org, --organization, --scope TEXT
-                                  Org UUID/name, or 'none'/'global' for global
-                                  scope. Omit = your org. (--organization /
-                                  --scope are synonyms.)
-  --force                         Apply even if the bundle version is older
-                                  than the installed version (downgrade).
-  --help                          Show this message and exit.
+  --solution TEXT  Install id or unique slug.
+  --force          Apply even if the bundle version is older than the
+                   installed version (downgrade).
+  --help           Show this message and exit.
 ```
 
 ### `solution export`
@@ -1774,7 +1806,7 @@ Options:
 ```
 Usage: solution init [OPTIONS] [PATH]
 
-  Scaffold a bifrost.solution.yaml descriptor.
+  Alias for `solution create`: scaffold, create remote install, and bind .env.
 
 Options:
   --slug TEXT                     Solution slug (definition identity).
@@ -1784,6 +1816,12 @@ Options:
                                   deploy time.  [default: 0.1.0]
   --global-repo-access / --no-global-repo-access
                                   [default: no-global-repo-access]
+  --global                        Target global scope (org=NULL). Alias for
+                                  --org global.
+  --org, --organization, --scope TEXT
+                                  Org UUID/name, or 'none'/'global' for global
+                                  scope. Omit = your org. (--organization /
+                                  --scope are synonyms.)
   --help                          Show this message and exit.
 ```
 
@@ -1872,14 +1910,9 @@ Usage: solution start [OPTIONS] [APP_SLUG]
   Run the app's dev server + local workflows (one origin).
 
 Options:
-  --global                        Target global scope (org=NULL). Alias for
-                                  --org global.
-  --org, --organization, --scope TEXT
-                                  Org UUID/name, or 'none'/'global' for global
-                                  scope. Omit = your org. (--organization /
-                                  --scope are synonyms.)
-  --port INTEGER                  Local origin port.  [default: 3000]
-  --help                          Show this message and exit.
+  --solution TEXT  Install id or unique slug.
+  --port INTEGER   Local origin port.  [default: 3000]
+  --help           Show this message and exit.
 ```
 
 ### `solution swap-slugs`

--- a/.claude/skills/bifrost-build/references/entities.md
+++ b/.claude/skills/bifrost-build/references/entities.md
@@ -322,17 +322,18 @@ All install/remove operations recycle workers asynchronously (returns immediatel
 
 An installable surface — a workspace (apps + workflows + tables + configs + forms + agents) that deploys as one unit. See `references/apps.md` for the Solution app structure and `SKILL.md` for the Solutions skill.
 
-Commands: `solution init / scaffold-app / start / deploy / install`
+Commands: `solution create / init / bind / scaffold-app / start / deploy / install`
 
 ```bash
-bifrost solution init --slug my-solution --name "My Solution"
+bifrost solution create --slug my-solution --name "My Solution"
+bifrost solution bind --solution <id-or-slug>   # for cloned/existing workspaces
 bifrost solution scaffold-app my-app
-bifrost solution start [APP_SLUG]          # APP_SLUG positional (the apps/ dir name); optional org targeting + --port
-bifrost solution deploy                    # your org; --global or --org <ref> targets elsewhere
+bifrost solution start [APP_SLUG]          # APP_SLUG positional (the apps/ dir name); bound install + optional --port
+bifrost solution deploy                    # full-replace the bound install
 bifrost solution install solution.zip --org acme
 ```
 
-`solution init` carries **no install scope** — install kind (org vs global) is the deploy-time `--org`/`--global` choice (the unified standard, below), not a descriptor field.
+`solution init` is an alias for `solution create`: it writes the descriptor, creates an empty remote install, and writes the local `.env` binding. `solution start` and `solution deploy` use that bound install; pass `--solution <id-or-slug>` only when you need a one-command override.
 
 Non-obvious:
 - `deploy` (alias: `bifrost deploy`) full-replaces the install; refuses bundles older than the installed version unless `--force`.

--- a/.claude/skills/bifrost-build/references/solutions.md
+++ b/.claude/skills/bifrost-build/references/solutions.md
@@ -8,13 +8,14 @@ A Solution is an installable, deployable unit. Every entity it owns — apps, wo
 
 ## Lifecycle
 
-### 1. Scaffold the workspace
+### 1. Create and bind the workspace
 
 ```bash
-bifrost solution init . --slug my-solution --name "My Solution"
+bifrost solution create . --slug my-solution --name "My Solution"
+# `bifrost solution init` is an alias for create.
 ```
 
-Creates `bifrost.solution.yaml` in the current directory. The hub uses this file as the mode marker — its presence switches all subsequent commands to solution mode.
+Creates `bifrost.solution.yaml` in the current directory, creates an empty remote install, and writes the install binding to `.env`. The hub uses the descriptor as the mode marker — its presence switches all subsequent commands to solution mode. If you cloned an existing workspace instead, run `bifrost solution bind --solution <id-or-slug>` to write the `.env` binding without creating a new install.
 
 ### 2. Scaffold a v2 app
 
@@ -67,19 +68,18 @@ In a form, agent, or app, reference this as `functions/hello.py::main`. The plat
 bifrost solution start
 ```
 
-Runs the app's Vite dev server and local workflow functions behind one origin — no deploy required. Hot reload works for both app code and workflow code. The org-targeting flags (below) run under a specific org context (superuser only); omit them to run under your own org.
+Runs the app's Vite dev server and local workflow functions behind one origin — no deploy required. Hot reload works for both app code and workflow code. `start` requires the workspace's `.env` Solution binding, or an explicit `--solution <id-or-slug>` override; install scope comes from that binding, not `--org`.
 
 Open the origin the command prints (the **proxy** port; `--port` sets it, default 3000). Vite itself binds to **`--port + 1`** behind the proxy — drive the app at the proxy port the command prints, not the Vite port.
 
 ### 5. Deploy
 
 ```bash
-bifrost solution deploy                       # your own org (home)
-bifrost solution deploy --global              # the global install
-bifrost solution deploy --org "Target Org"    # a specific org
+bifrost solution deploy                       # bound install from .env
+bifrost solution deploy --solution <id>       # explicit install override
 ```
 
-Full-replace deploy of the workspace — all entities are written (or overwritten) from the workspace content. Org targeting follows the **unified `--org` standard** (see below).
+Full-replace deploy of the workspace — all entities are written (or overwritten) from the workspace content. `deploy` requires a bound install and never creates a missing install. To target another install of the same definition, bind the workspace to it or pass `--solution <install-id-or-slug>`.
 
 ### 5a. Declare Solution file locations
 
@@ -123,31 +123,31 @@ Export modes:
 
 ### The unified `--org` standard
 
-Every org-targeting **write** command (`create`/`update`/`set`/`register`, and the `solution` subcommands) takes the same flag:
+Every org-targeting **write** command (`create`/`update`/`set`/`register`, plus install-creating Solution commands such as `solution create`, `solution install`, and `solution pull`) takes the same flag:
 
 - **Omit it** → your own org ("home"). A bare command never writes a global entity by accident.
 - **`--org <uuid|name>`** → that org.
 - **`--global`** (or `--org none` / `--org global`) → global scope (organization_id NULL).
 - **`--organization` and `--scope`** are permanent synonyms for `--org`.
 
-This applies to the `solution` subcommands (`deploy`, `pull`, `start`, `install`) and to the write verbs of the `_repo`-workspace entity commands (`tables`, `forms`, `agents`, `configs`, `claims`, `workflows`, `events`). **Read commands (`list`/`get`) do NOT take `--org`/`--global`** — they return the caller's full combined visibility. Install **kind** (org vs global) is purely this deploy-time choice — it is **not** stored in the descriptor; the server derives it from `organization_id` (NULL == global).
+This applies to install-creating or install-selecting Solution commands (`create`, `install`, `pull`) and to the write verbs of the `_repo`-workspace entity commands (`tables`, `forms`, `agents`, `configs`, `claims`, `workflows`, `events`). `solution start` and `solution deploy` do **not** take `--org`/`--global`; they use the bound install's scope. **Read commands (`list`/`get`) do NOT take `--org`/`--global`** — they return the caller's full combined visibility. Install **kind** (org vs global) is stored on the remote install, not in the descriptor.
 
 ---
 
 ## One definition, many installs
 
-`bifrost.solution.yaml` is the **definition** descriptor — `slug`, `name`, `version`, `global_repo_access`, and git-source fields (`git_connected`, `git_repo_url`, `repo_subpath`, `git_ref`, `logo`). It is **stateless** and intentionally carries **no install id** and **no install scope** — install kind (org vs global) is the installer's deploy-time `--org`/`--global` choice, not a descriptor field. It also doubles as the workspace mode marker (its presence is what switches tooling into solution mode).
+`bifrost.solution.yaml` is the **definition** descriptor — `slug`, `name`, `version`, `global_repo_access`, and git-source fields (`git_connected`, `git_repo_url`, `repo_subpath`, `git_ref`, `logo`). It intentionally carries **no install id** and **no install scope**. The concrete install binding lives in `.env` (`BIFROST_SOLUTION_ID`, slug, org id, scope), which is local environment state and should not be committed. The descriptor also doubles as the workspace mode marker (its presence is what switches tooling into solution mode).
 
-The install id lives **server-side** (`Solution.id` — the `solution_id` stamped on every managed entity *at deploy time*). **Nothing in the repo carries install identity** — not the descriptor, not `.bifrost/*.yaml` (its entries deliberately omit org/access/identity for portability). The repo is the **definition**; deploy is what mints an install and stamps identity onto the entity rows it writes. Deploy/pull resolve *which install* at runtime by matching **`(slug, org)`** against the server's installs, creating one if none matches.
+The install id lives **server-side** (`Solution.id` — the `solution_id` stamped on every managed entity *at deploy time*) and in the local uncommitted `.env` binding. The repo is the **definition**; `solution create` or `solution bind` chooses which concrete install this checkout is working against. Deploy/pull then operate on that install (or an explicit `--solution` override).
 
 **Instance vs fork — the `slug` is the dividing line:**
 
-- **One definition, many installs (instances).** Keep **one repo / one slug** and deploy it per customer-org: `bifrost solution deploy --org "Customer Org"` (or `bifrost solution install pkg.zip --org "Customer Org"`). Each org gets an **independent install** — its own id, config values, and entity rows — from the *same* source. Deploy refuses to let one org clobber another org's install of the same slug. This is how you run "the same HR portal" for 3 customers: one codebase, three installs.
+- **One definition, many installs (instances).** Keep **one repo / one slug** and create/install it per customer-org: `bifrost solution create --org "Customer Org"` for an authoring checkout, or `bifrost solution install pkg.zip --org "Customer Org"` for packaged delivery. Each org gets an **independent install** — its own id, config values, and entity rows — from the *same* source. Bind the checkout to the install you are editing before `start` or `deploy`. This is how you run "the same HR portal" for 3 customers: one codebase, three installs.
 - **A genuinely different solution → fork (new slug).** If a customer needs the solution to *diverge* (different features/code, not just different data), **fork the repo and give it a new `slug`**. Different slug = different definition = a separate solution, not an instance of the first. There is no per-customer stamping in the repo to do this for you — forking is the mechanism.
 - **Multiple repos / subfolders** for git-connected installs are distinguished by `repo_subpath` (omni-repo: one repo, a folder per solution) and `git_ref` (pin a branch/tag).
 - **Natural key collision** (two installs of the same slug in the same org) → resolution raises an ambiguity error; pass **`--solution <install-id>`** to target one install by id.
 
-Install **kind** is chosen entirely at deploy/install time via the unified `--org`/`--global` standard — there is no `scope` in the descriptor. `--global` makes a global install (organization_id NULL); `--org "Customer Org"` makes an org install; omitting both installs into your own org. The server derives the install's scope from `organization_id` (NULL == global), so the same descriptor deploys global OR per-org from the same source.
+Install **kind** is chosen when the remote install is created or installed via the unified `--org`/`--global` standard — there is no `scope` in the descriptor. `--global` makes a global install (organization_id NULL); `--org "Customer Org"` makes an org install; omitting both installs into your own org. The same descriptor can back global or per-org installs from the same source, but each checkout should be bound to exactly one install while developing.
 
 ---
 
@@ -159,23 +159,24 @@ A solution owns these entities the same way it owns apps and workflows: deploy w
 
 ```bash
 bifrost solution capture <solution-id> --table <id> --form <id> --agent <id> --config <KEY>
-bifrost solution pull --org "Target Org"     # bring captured entities into source .bifrost/
-bifrost solution deploy --org "Target Org"   # ship them
+bifrost solution pull --solution <solution-id>  # bring captured entities into source .bifrost/
+bifrost solution bind --solution <solution-id>  # if this checkout is not already bound
+bifrost solution deploy                         # ship them to the bound install
 ```
 
-(Use the same org target — `--org "Target Org"`, `--global`, or omit for your own org — on `pull` and `deploy` that you used to create the install.)
+(Use the same concrete install id you captured into. Binding keeps `start` and `deploy` stamped to that install.)
 
 The capture flags are singular and repeatable: `--table`, `--form`, `--agent`, `--config`, `--claim`, `--workflow`, `--app` (each takes a name or id; `--config` takes a key).
 
 > **Ordering for a form/agent that references a workflow:** a form's `workflow_id` (and an agent's tool refs) must resolve to a **registered** workflow UUID — i.e. a workflow that has a row. The scaffold's sample (`functions/hello.py::main`) ships with a `.bifrost/workflows.yaml` entry, so it's registered on the **first `bifrost solution deploy`**. A workflow you write yourself is registered the same way: add its `.bifrost/workflows.yaml` entry (see "Write workflows in `functions/`" above), then `bifrost solution deploy` creates the row. So for a fresh solution the order is: write the workflow → add its manifest entry → **`solution deploy`** (creates the workflow row) → create the form/agent referencing that workflow → capture the form/agent (`--form`/`--agent`) → pull → deploy. (Reference the workflow by portable `path::function` ref; a bare name like `hello` can collide, so prefer the full `functions/hello.py::main` ref or the UUID.)
 
-**Which org target to use on `pull`/`deploy`.** `pull` and `deploy` resolve *which install* by `(slug, org)`, where the org comes from the unified `--org` standard (omit = your own org; `--org <uuid|name>` = that org; `--global` = the global install). So:
+**Which install to use on `pull`/`deploy`.** Capture, pull, start, and deploy should all target the same concrete install id. So:
 
-- **Global install** (created with `--global`) → pass `--global` on `pull`/`deploy`.
-- **Install in your own org** → omit the flag; resolution is unambiguous.
-- **Install in a *different* org** (created with `--org "Target Org"`) → pass the **same `--org "Target Org"`** to `pull` and `deploy`. Resolution only looks in the targeted org, so without it `pull`/`deploy` won't find that install (and may resolve a stale same-slug install in your own org instead) — a deploy can keep 409-blocking even after you "pulled".
+- **Bound checkout** → `bifrost solution deploy` uses `.env`.
+- **Different install of the same slug** → run `bifrost solution bind --solution <install-id>` first, or pass `--solution <install-id>` for one command.
+- **Ambiguous slug** → pass the install id instead of the slug.
 
-The rule: pick the org target once (commonly when first deploying a fresh install into a customer's org) and use the **same** target for that install's `pull`/`deploy`. To skip org resolution entirely, pass **`--solution <install-id>`** to target an install by id.
+The rule: pick the install once, bind the workspace, and let the binding stamp every local data-plane call and deploy.
 
 **Scope and capture — the loose entity must already be in the install's scope.** `bifrost solution capture` only adopts loose entities **already in the install's own scope**: an org install captures that org's entities; a global install captures global (`organization_id: null`) entities. The CLI resolves your `--table/--form/...` selectors against the install's **candidate list** (`/capture/candidates`) and refuses anything outside its scope — including by id — with "not in /capture/candidates for its scope". A concrete org-A entity is likewise never capturable into an org-B install (cross-tenant).
 

--- a/.claude/skills/bifrost-migrate/SKILL.md
+++ b/.claude/skills/bifrost-migrate/SKILL.md
@@ -41,8 +41,8 @@ Before touching code, collect the conventions — they shape every later step:
    `orders_sync_records`). Renames MUST rewrite every ref (this skill does that — see step 6).
 2. **Folder layout.** Default: flat `workflows/` + flat `modules/` (NOT nested "feature" dirs).
    Standardize whatever mess `_repo` is in.
-3. **Which app(s)** to migrate, and the **target Solution** (existing install id, or scaffold a new
-   one with `bifrost solution init`).
+3. **Which app(s)** to migrate, and the **target Solution** (existing install id, or create and bind
+   a new one with `bifrost solution create` / `init`).
 4. **Confirm-in-browser or skip.** Offer to skip the browser-confirm loop once the user trusts the
    output.
 
@@ -74,14 +74,14 @@ Do ONE app at a time, fully, before the next. Each step gates the following.
 
 ### Fast path — `bifrost solution migrate-app` does steps 2–5 deterministically
 
-`migrate-app` (and `scaffold-app`) MUST run from inside a Solution workspace — so create one
-FIRST with `solution init`, then run `migrate-app` from that dir. The SOURCE argument is a real
+`migrate-app` (and `scaffold-app`) MUST run from inside a Solution workspace — so create and bind one
+FIRST with `solution create` (or its `init` alias), then run `migrate-app` from that dir. The SOURCE argument is a real
 filesystem path to the v1 app's source (pull it locally first with `bifrost pull`, or point at a
 local checkout) — NOT a `_repo/...` URL.
 
 ```bash
 mkdir <new-slug>-workspace && cd <new-slug>-workspace
-bifrost solution init . --slug <solution-slug> --name "<Title>" --scope org
+bifrost solution create . --slug <solution-slug> --name "<Title>"
 bifrost solution migrate-app /path/to/v1/apps/<old-slug> <new-slug> --title "<Title>" --api-url <debug-url>
 ```
 This scaffolds the v2 app, ports the v1 `pages/`+`components/` (all source files, incl. `.ts`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,13 +299,12 @@ export async function getDataProviders() {
 ./test.sh ci
 
 # Type Generation (requires dev stack running via ./debug.sh)
-cd client && npm run generate:types       # Regenerate TypeScript types from API
+(cd client && npm run generate:types)     # Regenerate TypeScript types from API
 
 # Quality Checks
-cd api && pyright                         # Type check Python
-cd api && ruff check .                    # Lint Python
-cd client && npm run tsc                  # Type check TypeScript
-cd client && npm run lint                 # Lint TypeScript
+./test.sh quality api                     # Type check + lint Python in Docker
+(cd client && npm run tsc)                # Type check TypeScript
+(cd client && npm run lint)               # Lint TypeScript
 ```
 
 **Parallel worktrees:** Each git worktree gets its own isolated test stack (Compose project name is derived from the worktree path). Run `./test.sh stack up` in multiple worktrees simultaneously without conflict.
@@ -355,13 +354,11 @@ Before marking any significant work complete, run this verification sequence:
 # 1. Ensure debug stack is running for THIS worktree
 ./debug.sh status | grep -q "Status:   UP" || ./debug.sh up
 
-# 2. Backend checks (from api/ directory)
-cd api
-pyright                    # Type checking - must pass with 0 errors
-ruff check .               # Linting - must pass
+# 2. Backend checks
+./test.sh quality api       # Dockerized pyright + ruff; must pass with 0 errors
 
 # 3. Regenerate frontend types (from client/ directory)
-cd ../client
+cd client
 npm run generate:types     # Requires debug stack up. If client is bound to a non-default port,
                            # set OPENAPI_URL=http://localhost:<port>/openapi.json (see ./debug.sh status).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,13 +301,12 @@ export async function getDataProviders() {
 ./test.sh ci
 
 # Type Generation (requires dev stack running via ./debug.sh)
-cd client && npm run generate:types       # Regenerate TypeScript types from API
+(cd client && npm run generate:types)     # Regenerate TypeScript types from API
 
 # Quality Checks
-cd api && pyright                         # Type check Python
-cd api && ruff check .                    # Lint Python
-cd client && npm run tsc                  # Type check TypeScript
-cd client && npm run lint                 # Lint TypeScript
+./test.sh quality api                     # Type check + lint Python in Docker
+(cd client && npm run tsc)                # Type check TypeScript
+(cd client && npm run lint)               # Lint TypeScript
 ```
 
 **Parallel worktrees:** Each git worktree gets its own isolated test stack (Compose project name is derived from the worktree path). Run `./test.sh stack up` in multiple worktrees simultaneously without conflict.
@@ -357,13 +356,11 @@ Before marking any significant work complete, run this verification sequence:
 # 1. Ensure debug stack is running for THIS worktree
 ./debug.sh status | grep -q "Status:   UP" || ./debug.sh up
 
-# 2. Backend checks (from api/ directory)
-cd api
-pyright                    # Type checking - must pass with 0 errors
-ruff check .               # Linting - must pass
+# 2. Backend checks
+./test.sh quality api       # Dockerized pyright + ruff; must pass with 0 errors
 
 # 3. Regenerate frontend types (from client/ directory)
-cd ../client
+cd client
 npm run generate:types     # Requires debug stack up. If client is bound to a non-default port,
                            # set OPENAPI_URL=http://localhost:<port>/openapi.json (see ./debug.sh status).
 

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -25,8 +25,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # We deliberately do NOT run `pip install --upgrade pip` first — Scorecard
 # flags unpinned `pip install <pkg>` invocations, and the pip shipped in
 # python:3.14-slim already supports --require-hashes (>= 8.0).
-COPY pyproject.toml requirements.lock ./
-RUN pip install --no-cache-dir --require-hashes -r requirements.lock
+COPY pyproject.toml requirements.lock requirements-pyright.lock ./
+RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
+    && pip install --no-cache-dir --require-hashes -r requirements-pyright.lock
 
 # =============================================================================
 # Stage 2: Runtime

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -718,7 +718,7 @@ Commands:
   git         Git source control operations (fetch, status, commit, push, resolve, diff, discard)
   push        Push local files to Bifrost platform (alias for sync)
   pull        Pull files from Bifrost platform to local directory (alias for sync)
-  solution    Manage Solution installs (init, scaffold-app, start, deploy, install)
+  solution    Manage Solution installs (create, bind, scaffold-app, start, deploy, install)
   deploy      Deploy the current Solution workspace (alias for 'solution deploy')
   watch       Watch for file changes and auto-push
   api         Generic authenticated API request
@@ -763,7 +763,8 @@ Examples:
   bifrost pull apps/my-app
   bifrost watch
   bifrost watch apps/my-app
-  bifrost solution init --slug my-solution
+  bifrost solution create --slug my-solution
+  bifrost solution bind --solution <id-or-slug>
   bifrost solution scaffold-app dashboard
   bifrost solution start                 # local dev: app + local workflows, one origin
   bifrost api GET /api/workflows

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -5,10 +5,11 @@ the disconnected-install writer and are **non-interactive by contract**:
 ``deploy`` always applies the full bundle, so the whole create → deploy → run
 loop runs headless (criterion 17).
 
-* ``bifrost solution init`` — scaffold a ``bifrost.solution.yaml`` descriptor.
+* ``bifrost solution create`` — scaffold a descriptor, create an install, bind ``.env``.
+* ``bifrost solution init`` — alias for ``create``.
 * ``bifrost solution deploy`` (alias: top-level ``bifrost deploy``) — read the
-  descriptor, ensure the install exists, zip the workspace, and POST it to
-  ``/api/solutions/{id}/deploy``.
+  descriptor, require a bound install, zip the workspace, and POST it to
+  ``/api/solutions/{bound_id}/deploy``.
 
 Apps/forms/agents/tables bundling joins in their sub-plans; Sub-plan 1 wires the
 load-bearing workflow path.
@@ -25,14 +26,23 @@ import pathlib
 import subprocess
 import time
 import zipfile
+from typing import Any
 
 import click
 import yaml
 
 from bifrost.client import BifrostClient
 from bifrost.org_target import org_option, resolve_org_target
+from bifrost.solution_binding import (
+    SolutionBindingError,
+    binding_from_install,
+    read_solution_binding,
+    resolve_install_ref,
+    write_solution_binding,
+)
 from bifrost.solution_descriptor import (
     DESCRIPTOR_FILENAME,
+    SolutionDescriptor,
     find_solution_root,
     is_solution_workspace,
     load_descriptor,
@@ -63,23 +73,13 @@ def solution_group() -> None:
     pass
 
 
-@solution_group.command(name="init", help="Scaffold a bifrost.solution.yaml descriptor.")
-@click.argument("path", type=click.Path(file_okay=False), default=".")
-@click.option("--slug", required=True, help="Solution slug (definition identity).")
-@click.option("--name", default=None, help="Display name (defaults to slug).")
-@click.option("--version", "version", default="0.1.0", show_default=True,
-              help="Bundle version recorded on the install at deploy time.")
-@click.option("--global-repo-access/--no-global-repo-access", default=False, show_default=True)
-def init_cmd(
-    path: str, slug: str, name: str | None, version: str, global_repo_access: bool
-) -> None:
-    """Scaffold a ``bifrost.solution.yaml`` descriptor.
-
-    The descriptor carries no install *scope* — install kind (org vs global) is
-    the installer's deploy-time choice via ``--org``/``--global`` on
-    ``deploy``/``install``.
-    """
-    workspace = pathlib.Path(path)
+def _write_solution_descriptor(
+    workspace: pathlib.Path,
+    slug: str,
+    name: str | None,
+    version: str,
+    global_repo_access: bool,
+) -> pathlib.Path:
     workspace.mkdir(parents=True, exist_ok=True)
     descriptor = workspace / DESCRIPTOR_FILENAME
     if descriptor.exists():
@@ -95,7 +95,166 @@ def init_cmd(
             sort_keys=False,
         )
     )
-    click.echo(f"Wrote {descriptor}")
+    return descriptor
+
+
+async def _post_create_install_for_descriptor(
+    client,
+    descriptor: SolutionDescriptor,
+    target_org_id: str | None,
+) -> Any:
+    create = await client.post("/api/solutions", json={
+        "slug": descriptor.slug,
+        "name": descriptor.name,
+        "organization_id": target_org_id,
+        "global_repo_access": descriptor.global_repo_access,
+        "git_connected": descriptor.git_connected,
+        "git_repo_url": descriptor.git_repo_url,
+        "repo_subpath": descriptor.repo_subpath,
+        "git_ref": descriptor.git_ref,
+    })
+    if create.status_code not in (200, 201):
+        raise click.ClickException(
+            f"Failed to create install: {create.status_code} {create.text}"
+        )
+    return create
+
+
+def _create_and_bind_solution_workspace(
+    path: str,
+    slug: str,
+    name: str | None,
+    version: str,
+    global_repo_access: bool,
+    org: str | None,
+    is_global: bool,
+) -> None:
+    workspace = pathlib.Path(path)
+    descriptor_path = _write_solution_descriptor(
+        workspace, slug, name, version, global_repo_access
+    )
+    descriptor = load_descriptor(workspace)
+    remote_created = False
+
+    async def _run() -> None:
+        nonlocal remote_created
+        client = BifrostClient.get_instance(require_auth=True)
+        target_org_id = await _resolve_install_org(client, org, is_global)
+        create = await _post_create_install_for_descriptor(client, descriptor, target_org_id)
+        remote_created = True
+        try:
+            install = create.json()
+            binding = binding_from_install(install, descriptor_slug=descriptor.slug)
+        except (ValueError, SolutionBindingError) as exc:
+            raise click.ClickException(
+                "Created Solution install, but failed to read its binding from the "
+                f"response: {exc}. Use `bifrost solution bind --solution <id>` "
+                "once you have the install id."
+            ) from exc
+        try:
+            write_solution_binding(workspace, binding)
+        except Exception as exc:
+            raise click.ClickException(
+                f"Created Solution install {binding.solution_id}, but failed to bind "
+                f"workspace in .env: {exc}"
+            ) from exc
+        click.echo(f"Wrote {descriptor_path}")
+        click.echo(f"Created Solution install {binding.solution_id}.")
+        click.echo("Bound workspace in .env.")
+
+    try:
+        asyncio.run(_run())
+    except Exception:
+        if not remote_created and descriptor_path.exists():
+            descriptor_path.unlink()
+        raise
+
+
+@solution_group.command(name="create", help="Create and bind a new Solution workspace.")
+@click.argument("path", type=click.Path(file_okay=False), default=".")
+@click.option("--slug", required=True, help="Solution slug (definition identity).")
+@click.option("--name", default=None, help="Display name (defaults to slug).")
+@click.option("--version", "version", default="0.1.0", show_default=True,
+              help="Bundle version recorded on the install at deploy time.")
+@click.option("--global-repo-access/--no-global-repo-access", default=False, show_default=True)
+@org_option
+def create_cmd(
+    path: str,
+    slug: str,
+    name: str | None,
+    version: str,
+    global_repo_access: bool,
+    org: str | None,
+    is_global: bool,
+) -> None:
+    """Create a local descriptor and an empty remote install, then bind them."""
+    _create_and_bind_solution_workspace(
+        path, slug, name, version, global_repo_access, org, is_global
+    )
+
+
+@solution_group.command(
+    name="init",
+    help="Alias for `solution create`: scaffold, create remote install, and bind .env.",
+)
+@click.argument("path", type=click.Path(file_okay=False), default=".")
+@click.option("--slug", required=True, help="Solution slug (definition identity).")
+@click.option("--name", default=None, help="Display name (defaults to slug).")
+@click.option("--version", "version", default="0.1.0", show_default=True,
+              help="Bundle version recorded on the install at deploy time.")
+@click.option("--global-repo-access/--no-global-repo-access", default=False, show_default=True)
+@org_option
+def init_cmd(
+    path: str,
+    slug: str,
+    name: str | None,
+    version: str,
+    global_repo_access: bool,
+    org: str | None,
+    is_global: bool,
+) -> None:
+    """Backward-compatible alias for ``bifrost solution create``."""
+    _create_and_bind_solution_workspace(
+        path, slug, name, version, global_repo_access, org, is_global
+    )
+
+
+@solution_group.command(
+    name="bind",
+    help="Bind this local Solution workspace to an existing install.",
+)
+@click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
+@click.option("--solution", "solution_ref", required=True, help="Install id or unique slug.")
+def bind_cmd(path: str, solution_ref: str) -> None:
+    """Bind a local descriptor to an existing remote install without creating one."""
+    workspace = pathlib.Path(path).resolve()
+    if not is_solution_workspace(workspace):
+        raise click.ClickException(
+            f"No {DESCRIPTOR_FILENAME} in {workspace} - not a Solution workspace. "
+            f"Run `bifrost solution init` first."
+        )
+    descriptor = load_descriptor(workspace)
+
+    async def _run() -> None:
+        client = BifrostClient.get_instance(require_auth=True)
+        resp = await client.get("/api/solutions")
+        if resp.status_code != 200:
+            raise click.ClickException(
+                f"Failed to list installs ({resp.status_code}): {resp.text[:200]}"
+            )
+        installs = resp.json().get("solutions", [])
+        try:
+            binding = resolve_install_ref(
+                installs,
+                solution_ref,
+                descriptor_slug=descriptor.slug,
+            )
+        except SolutionBindingError as exc:
+            raise click.ClickException(str(exc)) from exc
+        write_solution_binding(workspace, binding)
+        click.echo(f"Bound Solution install {binding.solution_id} in .env.")
+
+    asyncio.run(_run())
 
 
 @solution_group.command(
@@ -1120,7 +1279,7 @@ def _resolve_target_install(
     that org's id. The kind is no longer read from the descriptor.
 
     Returns the install id if exactly one matches, ``None`` if none match (the
-    caller creates a fresh install). Raises :class:`_AmbiguousInstall` if MORE
+    caller may handle as missing). Raises :class:`_AmbiguousInstall` if MORE
     THAN ONE install matches within the resolved scope — silently full-replacing
     the first would clobber the wrong install. The user must disambiguate with
     ``--solution <id>``.
@@ -1188,6 +1347,44 @@ def resolve_install_id_for_workspace(client, solution_root) -> str | None:
             return None
     except Exception:  # noqa: BLE001 — best-effort; never break the local run loop over install resolution
         return None
+
+
+async def _resolve_bound_solution(
+    client,
+    workspace: pathlib.Path,
+    descriptor: SolutionDescriptor,
+    solution_ref: str | None,
+):
+    if solution_ref is not None:
+        resp = await client.get("/api/solutions")
+        if resp.status_code != 200:
+            raise click.ClickException(
+                f"Failed to list installs ({resp.status_code}): {resp.text[:200]}"
+            )
+        installs = resp.json().get("solutions", [])
+        try:
+            return resolve_install_ref(
+                installs,
+                solution_ref,
+                descriptor_slug=descriptor.slug,
+            )
+        except SolutionBindingError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    binding = read_solution_binding(workspace)
+    if binding is None:
+        raise click.ClickException(
+            "This Solution workspace is not bound to an install. "
+            "Run `bifrost solution create` to create and bind one, or "
+            "`bifrost solution bind --solution <id-or-slug>` to bind an existing install."
+        )
+    if binding.slug != descriptor.slug:
+        raise click.ClickException(
+            f"Workspace is bound to Solution slug {binding.slug!r}, but "
+            f"{DESCRIPTOR_FILENAME} declares {descriptor.slug!r}. "
+            "Re-run `bifrost solution bind --solution <id-or-slug>`."
+        )
+    return binding
 
 
 # Map a pending-capture entity_type to its `.bifrost/*.yaml` manifest file and the
@@ -1441,12 +1638,11 @@ def _build_deploy_zip(
 
 @solution_group.command(name="deploy", help="Deploy the current Solution workspace (full replace, non-interactive).")
 @click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
-@click.option("--solution", "solution_id", default=None, help="Target install id (override when ambiguous).")
-@org_option
+@click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
 @click.option("--force", is_flag=True, default=False,
               help="Apply even if the bundle version is older than the installed version (downgrade).")
 def deploy_cmd(
-    path: str, solution_id: str | None, org: str | None, is_global: bool, force: bool
+    path: str, solution_ref: str | None, force: bool
 ) -> None:
     workspace = pathlib.Path(path).resolve()
     if not is_solution_workspace(workspace):
@@ -1469,41 +1665,10 @@ def deploy_cmd(
 
     async def _run() -> int:
         client = BifrostClient.get_instance(require_auth=True)
-
-        target_id = solution_id
-        if target_id is None:
-            # Resolve or create the install by (slug, scope).
-            resp = await client.get("/api/solutions")
-            if resp.status_code != 200:
-                raise click.ClickException(
-                    f"Failed to list installs ({resp.status_code}): {resp.text[:200]}"
-                )
-            installs = resp.json().get("solutions", [])
-            target_org_id = await _resolve_install_org(client, org, is_global)
-            try:
-                target_id = _resolve_target_install(
-                    installs, descriptor.slug, target_org_id
-                )
-            except _AmbiguousInstall as e:
-                click.echo(str(e), err=True)
-                return 1
-            if target_id is None:
-                # Install kind is the deploy-time choice: organization_id None ==
-                # global, a UUID == that org. The server derives scope from it.
-                create = await client.post("/api/solutions", json={
-                    "slug": descriptor.slug,
-                    "name": descriptor.name,
-                    "organization_id": target_org_id,
-                    "global_repo_access": descriptor.global_repo_access,
-                    "git_connected": descriptor.git_connected,
-                    "git_repo_url": descriptor.git_repo_url,
-                    "repo_subpath": descriptor.repo_subpath,
-                    "git_ref": descriptor.git_ref,
-                })
-                if create.status_code not in (200, 201):
-                    click.echo(f"Failed to create install: {create.status_code} {create.text}", err=True)
-                    return 1
-                target_id = create.json()["id"]
+        binding = await _resolve_bound_solution(
+            client, workspace, descriptor, solution_ref
+        )
+        target_id = binding.solution_id
 
         # Vendor referenced _repo/ shared modules into the bundle so the deployed
         # Solution is self-contained (criterion 5). When global_repo_access is on
@@ -1835,9 +2000,9 @@ def export_cmd(
 
 @solution_group.command(name="start", help="Run the app's dev server + local workflows (one origin).")
 @click.argument("app_slug", required=False)
-@org_option
+@click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
 @click.option("--port", default=3000, show_default=True, type=int, help="Local origin port.")
-def start_cmd(app_slug: str | None, org: str | None, is_global: bool, port: int) -> None:
+def start_cmd(app_slug: str | None, solution_ref: str | None, port: int) -> None:
     import shutil
 
     from bifrost.client import BifrostClient
@@ -1850,24 +2015,17 @@ def start_cmd(app_slug: str | None, org: str | None, is_global: bool, port: int)
         raise click.ClickException(
             f"Not a Solution workspace (no {DESCRIPTOR_FILENAME}). Run `bifrost solution init` first."
         )
+    descriptor = load_descriptor(workspace)
 
     client = BifrostClient.get_instance(require_auth=True)
-
-    # Unified --org standard: HOME (omit both) runs under the caller's own org
-    # context (no override); --org <id|name> / --global override the execution
-    # org context (superuser-gated). Only fetch the override when a flag was
-    # actually given — HOME leaves the caller's own context untouched.
-    org_info = client.organization
-    if org is not None or is_global:
-        target = asyncio.run(_resolve_install_org(client, org, is_global))
-        resp = client._sync_http.get("/api/sdk/context", params={"org_id": target})
-        if resp.status_code == 403:
-            raise click.ClickException("--org/--global requires superuser privileges.")
-        if resp.status_code >= 400:
-            raise click.ClickException(
-                f"Could not resolve org context: HTTP {resp.status_code}"
-            )
-        org_info = resp.json().get("organization", org_info)
+    binding = asyncio.run(
+        _resolve_bound_solution(client, workspace, descriptor, solution_ref)
+    )
+    org_info = (
+        {"id": binding.organization_id}
+        if binding.organization_id is not None
+        else None
+    )
 
     try:
         chosen = select_app(workspace, slug=app_slug)
@@ -1878,14 +2036,10 @@ def start_cmd(app_slug: str | None, org: str | None, is_global: bool, port: int)
     if main_tsx_needs_dev_fallback(main_tsx):
         click.echo(PATCH_HINT, err=True)
 
-    # Resolve this install's id so the host's functions resolve their own
-    # solution-scoped data plane own-first, matching the server engine (F2).
-    dev_solution_id = resolve_install_id_for_workspace(client, workspace)
-    if dev_solution_id:
-        click.echo(f"Resolved Solution install id: {dev_solution_id}")
+    click.echo(f"Using Solution install id: {binding.solution_id}")
 
     set_dev_execution_context(
-        user=client.user, org=org_info, solution_id=dev_solution_id
+        user=client.user, org=org_info, solution_id=binding.solution_id
     )
 
     host = FunctionHost(workspace)
@@ -1921,7 +2075,18 @@ def start_cmd(app_slug: str | None, org: str | None, is_global: bool, port: int)
     )
 
     try:
-        asyncio.run(_serve(client, chosen, org_info, host, port, vite_port, workspace))
+        asyncio.run(
+            _serve(
+                client,
+                chosen,
+                org_info,
+                host,
+                port,
+                vite_port,
+                workspace,
+                binding.solution_id,
+            )
+        )
     finally:
         _terminate_process_group(vite_proc)
 
@@ -2370,7 +2535,7 @@ def _terminate_process_group(proc: "subprocess.Popen") -> None:
         _signal_group(signal.SIGKILL)
 
 
-async def _serve(client, chosen, org_info, host, port, vite_port, workspace):
+async def _serve(client, chosen, org_info, host, port, vite_port, workspace, solution_id):
     from aiohttp import web
 
     from bifrost.solution_dev.proxy import DevProxyConfig, build_dev_app
@@ -2381,6 +2546,7 @@ async def _serve(client, chosen, org_info, host, port, vite_port, workspace):
         token=client._access_token,
         app_id=chosen.app_id,
         org_id=(org_info or {}).get("id"),
+        solution_id=solution_id,
     )
     app = build_dev_app(cfg, host, vite_url=f"http://127.0.0.1:{vite_port}")
     runner = web.AppRunner(app)

--- a/api/bifrost/solution_binding.py
+++ b/api/bifrost/solution_binding.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping, Sequence, cast
+
+
+SOLUTION_ENV_KEYS = {
+    "BIFROST_SOLUTION_ID",
+    "BIFROST_SOLUTION_SLUG",
+    "BIFROST_SOLUTION_ORG_ID",
+    "BIFROST_SOLUTION_SCOPE",
+}
+
+
+@dataclass(frozen=True)
+class SolutionBinding:
+    solution_id: str
+    slug: str
+    organization_id: str | None
+    scope: Literal["org", "global"]
+
+
+class SolutionBindingError(ValueError):
+    pass
+
+
+def _env_path(workspace: Path) -> Path:
+    return workspace / ".env"
+
+
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped[len("export ") :]
+    if "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    value = value.strip().strip('"').strip("'")
+    return key, value
+
+
+def read_solution_binding(workspace: Path) -> SolutionBinding | None:
+    env = _env_path(workspace)
+    if not env.is_file():
+        return None
+    values: dict[str, str] = {}
+    for line in env.read_text().splitlines():
+        parsed = _parse_env_line(line)
+        if parsed is not None:
+            key, value = parsed
+            values[key] = value
+    solution_id = values.get("BIFROST_SOLUTION_ID")
+    slug = values.get("BIFROST_SOLUTION_SLUG")
+    if not solution_id or not slug:
+        return None
+    scope = values.get("BIFROST_SOLUTION_SCOPE") or "org"
+    if scope not in {"org", "global"}:
+        return None
+    org_id = values.get("BIFROST_SOLUTION_ORG_ID") or None
+    if scope == "global":
+        org_id = None
+    elif org_id is None:
+        return None
+    scope_value = cast(Literal["org", "global"], scope)
+    return SolutionBinding(
+        solution_id=solution_id,
+        slug=slug,
+        organization_id=org_id,
+        scope=scope_value,
+    )
+
+
+def write_solution_binding(workspace: Path, binding: SolutionBinding) -> None:
+    env = _env_path(workspace)
+    existing = env.read_text().splitlines() if env.is_file() else []
+    kept = []
+    for line in existing:
+        parsed = _parse_env_line(line)
+        if parsed is None or parsed[0] not in SOLUTION_ENV_KEYS:
+            kept.append(line)
+    additions = [
+        f"BIFROST_SOLUTION_ID={binding.solution_id}",
+        f"BIFROST_SOLUTION_SLUG={binding.slug}",
+        f"BIFROST_SOLUTION_ORG_ID={binding.organization_id or ''}",
+        f"BIFROST_SOLUTION_SCOPE={binding.scope}",
+    ]
+    env.write_text("\n".join([*kept, *additions]).rstrip() + "\n")
+
+
+def binding_from_install(
+    install: Mapping[str, Any],
+    *,
+    descriptor_slug: str,
+) -> SolutionBinding:
+    """Build a binding from an install, requiring its slug to match the descriptor."""
+    solution_id = str(install.get("id") or "")
+    if not solution_id:
+        raise SolutionBindingError("Install is missing id")
+    slug = str(install.get("slug") or "")
+    if not slug:
+        raise SolutionBindingError("Install is missing slug")
+    if slug != descriptor_slug:
+        raise SolutionBindingError(
+            f"Install slug {slug!r} does not match descriptor slug {descriptor_slug!r}"
+        )
+    org_id = install.get("organization_id")
+    return SolutionBinding(
+        solution_id=solution_id,
+        slug=slug,
+        organization_id=str(org_id) if org_id else None,
+        scope="org" if org_id else "global",
+    )
+
+
+def resolve_install_ref(
+    installs: Sequence[Mapping[str, Any]],
+    ref: str,
+    *,
+    descriptor_slug: str,
+) -> SolutionBinding:
+    """Resolve an install by id first, then unique slug, validating descriptor slug."""
+    matches = [s for s in installs if s.get("id") == ref]
+    if not matches:
+        matches = [s for s in installs if s.get("slug") == ref]
+    if not matches:
+        raise SolutionBindingError(f"No solution install found for {ref!r}")
+    if len(matches) > 1:
+        ids = ", ".join(str(m.get("id")) for m in matches)
+        raise SolutionBindingError(
+            f"Slug {ref!r} matches multiple installs ({ids}); pass an install id"
+        )
+    return binding_from_install(matches[0], descriptor_slug=descriptor_slug)

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -8,8 +8,9 @@ Routes:
   everything else              → reverse-proxy to the Vite dev server (the app),
                                  including Vite's own HMR websocket.
 
-The upstream proxy injects the CLI token (Authorization) and the resolved org
-(X-Bifrost-Org) so data-plane calls run under the chosen --org, matching deployed.
+The upstream proxy injects the CLI token (Authorization), the bound install org
+(X-Bifrost-Org), and the bound install id (``?solution=`` / ``solution_id``) so
+data-plane calls run under the same install scope as deployed.
 
 WebSockets are NOT given the injected Authorization header: the browser
 authenticates the realtime socket via cookies or a `token` query param (see
@@ -76,7 +77,8 @@ class DevProxyConfig:
     upstream_url: str   # the dev API, e.g. http://localhost:37791
     token: str          # CLI access token
     app_id: str         # chosen app's manifest UUID
-    org_id: str | None  # resolved --org (or None → caller's default org)
+    org_id: str | None  # bound install org id (or None for a global install)
+    solution_id: str | None = None  # bound Solution install id
 
 
 # Typed app keys (avoid aiohttp's NotAppKeyWarning for plain-string keys).
@@ -112,6 +114,12 @@ def _auth_headers(cfg: DevProxyConfig, incoming) -> dict[str, str]:
         headers["X-Bifrost-Org"] = cfg.org_id
     headers["X-Bifrost-App"] = cfg.app_id
     return headers
+
+
+def _with_solution_query(rel_url: yarl.URL, solution_id: str | None) -> yarl.URL:
+    if not solution_id:
+        return rel_url
+    return rel_url.update_query(solution=solution_id)
 
 
 def _passthrough_headers(resp, default_content_type: str) -> dict[str, str]:
@@ -221,6 +229,8 @@ async def _execute_handler(request: web.Request) -> web.Response:
         return web.json_response({"status": "completed", "result": result})
 
     # Otherwise proxy to the dev API (UUIDs, _repo/ refs, sibling installs).
+    if cfg.solution_id:
+        body["solution_id"] = cfg.solution_id
     try:
         resp = await request.app[_HTTP].post(
             f"{cfg.upstream_url}/api/workflows/execute",
@@ -246,7 +256,10 @@ async def _api_proxy_handler(request: web.Request) -> web.StreamResponse:
     try:
         resp = await request.app[_HTTP].request(
             request.method,
-            _join_upstream(cfg.upstream_url, request.rel_url),
+            _join_upstream(
+                cfg.upstream_url,
+                _with_solution_query(request.rel_url, cfg.solution_id),
+            ),
             content=data or None,
             headers=_auth_headers(cfg, request.headers),
         )

--- a/api/scripts/quality_api.sh
+++ b/api/scripts/quality_api.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+cd /app
+
+python - <<'PY'
+import json
+from pathlib import Path
+
+config = json.loads(Path("pyrightconfig.json").read_text())
+config.pop("venvPath", None)
+config.pop("venv", None)
+Path("pyrightconfig.docker.json").write_text(json.dumps(config, indent=2) + "\n")
+PY
+
+pyright --project pyrightconfig.docker.json --pythonpath /usr/local/bin/python
+ruff check .

--- a/api/tests/unit/test_cli_solution_deploy_phases.py
+++ b/api/tests/unit/test_cli_solution_deploy_phases.py
@@ -9,9 +9,10 @@ that gap stays instrumented:
   Bundle: ...
   Uploading workspace zip...  ->  Deploying install ...
 
-BifrostClient is mocked so no network/DB is touched. Deploying with --global and
-the default (vendoring-on) descriptor drives the no-shared-deps branch: the
-mocked /api/files/read returns nothing, so vendoring resolves to zero files.
+BifrostClient is mocked so no network/DB is touched. Deploying with a local
+binding and the default (vendoring-on) descriptor drives the no-shared-deps
+branch: the mocked /api/files/read returns nothing, so vendoring resolves to
+zero files.
 """
 from __future__ import annotations
 
@@ -37,8 +38,6 @@ def _resp(payload, status=200):
 
 def _client(captured: dict | None = None):
     async def get(path, **_kwargs):  # type: ignore[no-untyped-def]
-        if path == "/api/solutions":
-            return _resp({"solutions": []})
         if "/deploy-jobs/" in path:
             return _resp({"status": "succeeded", "error": None, "install_id": INSTALL_ID})
         return _resp({}, status=404)
@@ -46,8 +45,6 @@ def _client(captured: dict | None = None):
     async def post(path, json=None, **kwargs):  # type: ignore[no-untyped-def]  # noqa: ARG001
         if captured is not None:
             captured.setdefault("posts", []).append((path, {"json": json, **kwargs}))
-        if path == "/api/solutions":
-            return _resp({"id": INSTALL_ID}, status=201)
         if path == "/api/files/read":
             # Nothing resolvable in _repo/ -> nothing to vendor.
             return _resp({"content": None}, status=404)
@@ -76,6 +73,12 @@ def _scaffold(tmp_path: pathlib.Path) -> pathlib.Path:
             sort_keys=False,
         )
     )
+    (ws / ".env").write_text(
+        f"BIFROST_SOLUTION_ID={INSTALL_ID}\n"
+        "BIFROST_SOLUTION_SLUG=demo\n"
+        "BIFROST_SOLUTION_ORG_ID=00000000-0000-0000-0000-000000000000\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
     (ws / "workflows").mkdir()
     (ws / "workflows" / "hello.py").write_text("def run():\n    return 1\n")
     return ws
@@ -86,7 +89,7 @@ def _invoke(ws: pathlib.Path, captured: dict | None = None):
         "bifrost.client.BifrostClient.get_instance", return_value=_client(captured)
     ):
         return CliRunner().invoke(
-            solution_group, ["deploy", str(ws), "--global"], catch_exceptions=False
+            solution_group, ["deploy", str(ws)], catch_exceptions=False
         )
 
 

--- a/api/tests/unit/test_compose_test_harness.py
+++ b/api/tests/unit/test_compose_test_harness.py
@@ -47,6 +47,20 @@ def _find_compose() -> pathlib.Path:
 _COMPOSE = _find_compose()
 
 
+def _find_repo_file(path: str) -> pathlib.Path:
+    """Locate a repo-root file in-container or on host."""
+    candidates = [
+        pathlib.Path("/app") / path,
+        pathlib.Path(__file__).resolve().parents[3] / path,
+    ]
+    if path.startswith("api/"):
+        candidates.insert(1, pathlib.Path("/app") / path.removeprefix("api/"))
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"{path} not found in test harness mounts")
+
+
 def _api_bind_targets() -> list[str]:
     compose = yaml.safe_load(_COMPOSE.read_text())
     volumes = compose["services"]["api"].get("volumes", [])
@@ -90,3 +104,35 @@ def test_api_shares_fixture_subdir_for_install_from_repo():
         "api no longer shares /tmp/bifrost/solution-repo-fixtures; "
         "install/preview-repo e2e tests can't clone host-staged fixtures."
     )
+
+
+def test_test_runner_mounts_pyright_inputs():
+    """The Dockerized quality lane needs the same API config CI uses."""
+    compose = yaml.safe_load(_COMPOSE.read_text())
+    volumes = compose["services"]["test-runner"].get("volumes", [])
+    assert "./api/pyrightconfig.json:/app/pyrightconfig.json:ro" in volumes
+    assert "./test.sh:/app/test.sh:ro" in volumes
+    assert "./api/Dockerfile.dev:/app/api/Dockerfile.dev:ro" in volumes
+
+
+def test_dev_image_installs_pyright_from_hash_pinned_lock():
+    """Local Docker type-checks should not depend on host pyright installs."""
+    dockerfile = _find_repo_file("api/Dockerfile.dev").read_text()
+    assert "requirements-pyright.lock" in dockerfile
+    assert "pip install --no-cache-dir --require-hashes -r requirements-pyright.lock" in dockerfile
+
+
+def test_test_sh_advertises_dockerized_api_quality_lane():
+    script = _find_repo_file("test.sh").read_text()
+    assert "./test.sh quality api" in script
+    assert "cmd_quality" in script
+    assert "sh /app/scripts/quality_api.sh" in script
+
+
+def test_api_quality_script_runs_pyright_without_ci_venv_config():
+    script = _find_repo_file("api/scripts/quality_api.sh").read_text()
+    assert 'config.pop("venvPath", None)' in script
+    assert 'config.pop("venv", None)' in script
+    assert 'Path("pyrightconfig.docker.json")' in script
+    assert "pyright --project pyrightconfig.docker.json --pythonpath /usr/local/bin/python" in script
+    assert "ruff check ." in script

--- a/api/tests/unit/test_solution_binding.py
+++ b/api/tests/unit/test_solution_binding.py
@@ -1,0 +1,173 @@
+from pathlib import Path
+
+import pytest
+
+from bifrost.solution_binding import (
+    SolutionBinding,
+    SolutionBindingError,
+    binding_from_install,
+    read_solution_binding,
+    resolve_install_ref,
+    write_solution_binding,
+)
+
+
+def test_write_solution_binding_merges_env(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("BIFROST_API_URL=http://api\nOTHER=value\n")
+
+    write_solution_binding(
+        tmp_path,
+        SolutionBinding(
+            solution_id="11111111-1111-1111-1111-111111111111",
+            slug="dispatch",
+            organization_id="22222222-2222-2222-2222-222222222222",
+            scope="org",
+        ),
+    )
+
+    text = env.read_text()
+    assert "BIFROST_API_URL=http://api\n" in text
+    assert "OTHER=value\n" in text
+    assert "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n" in text
+    assert "BIFROST_SOLUTION_SLUG=dispatch\n" in text
+    assert "BIFROST_SOLUTION_ORG_ID=22222222-2222-2222-2222-222222222222\n" in text
+    assert "BIFROST_SOLUTION_SCOPE=org\n" in text
+
+
+def test_write_solution_binding_replaces_existing_solution_keys(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text(
+        "BIFROST_SOLUTION_ID=old-id\n"
+        "BIFROST_SOLUTION_SLUG=old-slug\n"
+        "OTHER=value\n"
+    )
+
+    write_solution_binding(
+        tmp_path,
+        SolutionBinding(
+            solution_id="11111111-1111-1111-1111-111111111111",
+            slug="dispatch",
+            organization_id="22222222-2222-2222-2222-222222222222",
+            scope="org",
+        ),
+    )
+
+    text = env.read_text()
+    assert "OTHER=value\n" in text
+    assert "old-id" not in text
+    assert "old-slug" not in text
+    assert text.count("BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n") == 1
+    assert text.count("BIFROST_SOLUTION_SLUG=dispatch\n") == 1
+    assert text.count("BIFROST_SOLUTION_ORG_ID=22222222-2222-2222-2222-222222222222\n") == 1
+    assert text.count("BIFROST_SOLUTION_SCOPE=org\n") == 1
+
+
+def test_read_solution_binding_returns_none_when_missing(tmp_path: Path) -> None:
+    assert read_solution_binding(tmp_path) is None
+
+
+def test_read_solution_binding_returns_none_when_org_scope_missing_org_id(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=dispatch\n"
+        "BIFROST_SOLUTION_ORG_ID=\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
+
+    assert read_solution_binding(tmp_path) is None
+
+
+def test_read_solution_binding_parses_global_scope(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=dispatch\n"
+        "BIFROST_SOLUTION_ORG_ID=\n"
+        "BIFROST_SOLUTION_SCOPE=global\n"
+    )
+
+    binding = read_solution_binding(tmp_path)
+
+    assert binding is not None
+    assert binding.solution_id == "11111111-1111-1111-1111-111111111111"
+    assert binding.slug == "dispatch"
+    assert binding.organization_id is None
+    assert binding.scope == "global"
+
+
+def test_binding_from_install_rejects_slug_mismatch() -> None:
+    with pytest.raises(SolutionBindingError, match="does not match descriptor slug"):
+        binding_from_install(
+            {"id": "i", "slug": "other", "organization_id": None},
+            descriptor_slug="expected",
+        )
+
+
+def test_binding_from_install_rejects_missing_id() -> None:
+    with pytest.raises(SolutionBindingError, match="missing id"):
+        binding_from_install(
+            {"slug": "expected", "organization_id": None},
+            descriptor_slug="expected",
+        )
+
+
+def test_binding_from_install_global() -> None:
+    binding = binding_from_install(
+        {"id": "i", "slug": "expected", "organization_id": None},
+        descriptor_slug="expected",
+    )
+    assert binding.scope == "global"
+    assert binding.organization_id is None
+
+
+def test_resolve_install_ref_resolves_by_id() -> None:
+    installs = [
+        {"id": "a", "slug": "other", "organization_id": "org-a"},
+        {"id": "b", "slug": "expected", "organization_id": "org-b"},
+    ]
+
+    binding = resolve_install_ref(installs, "b", descriptor_slug="expected")
+
+    assert binding.solution_id == "b"
+    assert binding.slug == "expected"
+    assert binding.organization_id == "org-b"
+    assert binding.scope == "org"
+
+
+def test_resolve_install_ref_resolves_by_unique_slug() -> None:
+    installs = [
+        {"id": "a", "slug": "other", "organization_id": "org-a"},
+        {"id": "b", "slug": "expected", "organization_id": None},
+    ]
+
+    binding = resolve_install_ref(installs, "expected", descriptor_slug="expected")
+
+    assert binding.solution_id == "b"
+    assert binding.slug == "expected"
+    assert binding.organization_id is None
+    assert binding.scope == "global"
+
+
+def test_resolve_install_ref_prefers_id_over_slug() -> None:
+    installs = [
+        {"id": "expected", "slug": "descriptor", "organization_id": "org-a"},
+        {"id": "b", "slug": "expected", "organization_id": "org-b"},
+    ]
+
+    binding = resolve_install_ref(installs, "expected", descriptor_slug="descriptor")
+
+    assert binding.solution_id == "expected"
+    assert binding.slug == "descriptor"
+    assert binding.organization_id == "org-a"
+    assert binding.scope == "org"
+
+
+def test_resolve_install_ref_rejects_ambiguous_slug() -> None:
+    installs = [
+        {"id": "a", "slug": "expected", "organization_id": "org-a"},
+        {"id": "b", "slug": "expected", "organization_id": "org-b"},
+    ]
+    with pytest.raises(SolutionBindingError, match="multiple installs"):
+        resolve_install_ref(installs, "expected", descriptor_slug="expected")

--- a/api/tests/unit/test_solution_descriptor.py
+++ b/api/tests/unit/test_solution_descriptor.py
@@ -129,14 +129,36 @@ def test_version_defaults_to_none(tmp_path: pathlib.Path) -> None:
     assert load_descriptor(tmp_path).version is None
 
 
-def test_init_writes_version(tmp_path: pathlib.Path) -> None:
+def test_init_writes_version(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """`bifrost solution init` writes the version (default 0.1.0) into the
     descriptor, ordered after name, and load_descriptor round-trips it. The
-    descriptor carries no scope: key (install kind is a deploy-time choice)."""
+    descriptor carries no scope: key (install kind lives on the remote install)."""
     from click.testing import CliRunner
 
+    import bifrost.client as client_mod
     from bifrost.commands.solution import solution_group
 
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {"id": "inst-1", "slug": "mna", "organization_id": "org-1"}
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+
+        async def post(self, path, json=None, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
     ws = tmp_path / "ws"
     result = CliRunner().invoke(solution_group, ["init", str(ws), "--slug", "mna"])
     assert result.exit_code == 0, result.output
@@ -146,23 +168,76 @@ def test_init_writes_version(tmp_path: pathlib.Path) -> None:
     assert "scope:" not in text
 
 
-def test_init_rejects_scope_flag(tmp_path: pathlib.Path) -> None:
-    """`--scope` was removed from init — passing it is a usage error."""
+def test_init_scope_flag_targets_global_install_without_descriptor_scope(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--scope global` remains an org-option synonym but is not serialized."""
     from click.testing import CliRunner
 
+    import bifrost.client as client_mod
     from bifrost.commands.solution import solution_group
+
+    payloads = []
+
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {"id": "inst-1", "slug": "mna", "organization_id": None}
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+
+        async def post(self, path, json=None, **kwargs):
+            payloads.append(json)
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
 
     ws = tmp_path / "ws"
     result = CliRunner().invoke(
         solution_group, ["init", str(ws), "--slug", "mna", "--scope", "global"]
     )
-    assert result.exit_code != 0
+    assert result.exit_code == 0, result.output
+    assert payloads[0]["organization_id"] is None
+    text = (ws / DESCRIPTOR_FILENAME).read_text()
+    assert "scope:" not in text
+    assert "BIFROST_SOLUTION_SCOPE=global" in (ws / ".env").read_text()
 
 
-def test_init_writes_explicit_version(tmp_path: pathlib.Path) -> None:
+def test_init_writes_explicit_version(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from click.testing import CliRunner
 
+    import bifrost.client as client_mod
     from bifrost.commands.solution import solution_group
+
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {"id": "inst-1", "slug": "mna", "organization_id": "org-1"}
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+
+        async def post(self, path, json=None, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
 
     ws = tmp_path / "ws"
     result = CliRunner().invoke(

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -6,11 +6,444 @@ from click.testing import CliRunner
 from bifrost.commands.solution import handle_solution, solution_group
 
 
+def test_solution_init_creates_remote_install_and_env(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    created_payloads = []
+
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "slug": "dispatch",
+                "organization_id": "22222222-2222-2222-2222-222222222222",
+            }
+
+    class _FakeClient:
+        organization = {"id": "22222222-2222-2222-2222-222222222222"}
+
+        async def post(self, path, json=None, **kwargs):
+            assert path == "/api/solutions"
+            created_payloads.append(json)
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["init", ".", "--slug", "dispatch", "--name", "Dispatch"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "bifrost.solution.yaml").is_file()
+    env = (tmp_path / ".env").read_text()
+    assert "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111" in env
+    assert created_payloads[0]["slug"] == "dispatch"
+    assert (
+        created_payloads[0]["organization_id"]
+        == "22222222-2222-2222-2222-222222222222"
+    )
+
+
+def test_solution_create_creates_remote_install_and_env(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    created_payloads = []
+
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "slug": "dispatch",
+                "organization_id": "22222222-2222-2222-2222-222222222222",
+            }
+
+    class _FakeClient:
+        organization = {"id": "22222222-2222-2222-2222-222222222222"}
+
+        async def post(self, path, json=None, **kwargs):
+            assert path == "/api/solutions"
+            created_payloads.append(json)
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["create", ".", "--slug", "dispatch", "--name", "Dispatch"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "bifrost.solution.yaml").is_file()
+    env = (tmp_path / ".env").read_text()
+    assert "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111" in env
+    assert created_payloads[0]["slug"] == "dispatch"
+
+
+def test_solution_create_global_scope(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    created_payloads = []
+
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "slug": "dispatch",
+                "organization_id": None,
+            }
+
+    class _FakeClient:
+        organization = {"id": "22222222-2222-2222-2222-222222222222"}
+
+        async def post(self, path, json=None, **kwargs):
+            created_payloads.append(json)
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["create", ".", "--slug", "dispatch", "--name", "Dispatch", "--global"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert created_payloads[0]["organization_id"] is None
+    env = (tmp_path / ".env").read_text()
+    assert "BIFROST_SOLUTION_SCOPE=global" in env
+
+
+def test_solution_create_remote_failure_removes_new_descriptor(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    class _Resp:
+        status_code = 500
+        text = "boom"
+
+    class _FakeClient:
+        organization = {"id": "22222222-2222-2222-2222-222222222222"}
+
+        async def post(self, path, json=None, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["create", ".", "--slug", "dispatch", "--name", "Dispatch"],
+    )
+
+    assert result.exit_code != 0
+    assert "Failed to create install: 500 boom" in result.output
+    assert not (tmp_path / "bifrost.solution.yaml").exists()
+
+
+def test_solution_create_binding_failure_keeps_descriptor(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "slug": "dispatch",
+                "organization_id": "22222222-2222-2222-2222-222222222222",
+            }
+
+    class _FakeClient:
+        organization = {"id": "22222222-2222-2222-2222-222222222222"}
+
+        async def post(self, path, json=None, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+    monkeypatch.setattr(
+        "bifrost.commands.solution.write_solution_binding",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("readonly")),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["create", ".", "--slug", "dispatch", "--name", "Dispatch"],
+    )
+
+    assert result.exit_code != 0
+    assert "Created Solution install 11111111-1111-1111-1111-111111111111" in result.output
+    assert "failed to bind workspace in .env" in result.output
+    assert (tmp_path / "bifrost.solution.yaml").is_file()
+
+
+def test_solution_create_malformed_success_keeps_descriptor(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    class _Resp:
+        status_code = 201
+        text = "not json"
+
+        def json(self):
+            raise ValueError("bad json")
+
+    class _FakeClient:
+        organization = {"id": "22222222-2222-2222-2222-222222222222"}
+
+        async def post(self, path, json=None, **kwargs):
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["create", ".", "--slug", "dispatch", "--name", "Dispatch"],
+    )
+
+    assert result.exit_code != 0
+    assert "Created Solution install, but failed to read its binding" in result.output
+    assert (tmp_path / "bifrost.solution.yaml").is_file()
+
+
+def test_solution_bind_by_id_writes_env(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: dispatch\nname: Dispatch\n")
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "solutions": [
+                    {
+                        "id": "11111111-1111-1111-1111-111111111111",
+                        "slug": "dispatch",
+                        "organization_id": "22222222-2222-2222-2222-222222222222",
+                    }
+                ]
+            }
+
+    class _FakeClient:
+        async def get(self, path, **kwargs):
+            assert path == "/api/solutions"
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["bind", ".", "--solution", "11111111-1111-1111-1111-111111111111"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Bound Solution install 11111111-1111-1111-1111-111111111111" in result.output
+    env = (tmp_path / ".env").read_text()
+    assert "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n" in env
+    assert "BIFROST_SOLUTION_SLUG=dispatch\n" in env
+    assert "BIFROST_SOLUTION_ORG_ID=22222222-2222-2222-2222-222222222222\n" in env
+    assert "BIFROST_SOLUTION_SCOPE=org\n" in env
+
+
+def test_solution_bind_by_slug_writes_env(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: dispatch\nname: Dispatch\n")
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "solutions": [
+                    {
+                        "id": "11111111-1111-1111-1111-111111111111",
+                        "slug": "other",
+                        "organization_id": None,
+                    },
+                    {
+                        "id": "33333333-3333-3333-3333-333333333333",
+                        "slug": "dispatch",
+                        "organization_id": None,
+                    },
+                ]
+            }
+
+    class _FakeClient:
+        async def get(self, path, **kwargs):
+            assert path == "/api/solutions"
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["bind", ".", "--solution", "dispatch"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Bound Solution install 33333333-3333-3333-3333-333333333333" in result.output
+    env = (tmp_path / ".env").read_text()
+    assert "BIFROST_SOLUTION_ID=33333333-3333-3333-3333-333333333333\n" in env
+    assert "BIFROST_SOLUTION_SLUG=dispatch\n" in env
+    assert "BIFROST_SOLUTION_ORG_ID=\n" in env
+    assert "BIFROST_SOLUTION_SCOPE=global\n" in env
+
+
+def test_solution_bind_refuses_slug_mismatch(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: dispatch\nname: Dispatch\n")
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "solutions": [
+                    {
+                        "id": "11111111-1111-1111-1111-111111111111",
+                        "slug": "other",
+                        "organization_id": None,
+                    }
+                ]
+            }
+
+    class _FakeClient:
+        async def get(self, path, **kwargs):
+            assert path == "/api/solutions"
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["bind", ".", "--solution", "11111111-1111-1111-1111-111111111111"],
+    )
+
+    assert result.exit_code != 0
+    assert "does not match descriptor slug" in result.output
+    assert not (tmp_path / ".env").exists()
+
+
+def test_solution_bind_list_failure_is_surfaced(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: dispatch\nname: Dispatch\n")
+
+    class _Resp:
+        status_code = 503
+        text = "unavailable"
+
+    class _FakeClient:
+        async def get(self, path, **kwargs):
+            assert path == "/api/solutions"
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["bind", ".", "--solution", "dispatch"],
+    )
+
+    assert result.exit_code != 0
+    assert "Failed to list installs (503): unavailable" in result.output
+    assert not (tmp_path / ".env").exists()
+
+
 def test_start_refuses_outside_solution_workspace(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)  # no bifrost.solution.yaml here
     result = CliRunner().invoke(solution_group, ["start"])
     assert result.exit_code != 0
     assert "Solution workspace" in result.output or "solution init" in result.output
+
+
+def test_start_refuses_unbound_solution_workspace(tmp_path: Path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: dispatch\nname: Dispatch\n")
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+        user = {"id": "u", "is_superuser": True}
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(solution_group, ["start"])
+
+    assert result.exit_code != 0
+    assert "not bound to an install" in result.output
+    assert "bifrost solution bind --solution" in result.output
 
 
 def test_set_dev_execution_context_sets_org(monkeypatch):
@@ -41,6 +474,12 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
     (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=s\n"
+        "BIFROST_SOLUTION_ORG_ID=org-1\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
     (tmp_path / ".bifrost").mkdir()
     (tmp_path / ".bifrost" / "apps.yaml").write_text(
         yaml.safe_dump({"apps": {
@@ -111,6 +550,12 @@ def test_handle_solution_renders_clickexception_not_traceback(tmp_path, monkeypa
     # traceback. (This also covers deploy_cmd/install_cmd, which raise the same.)
     monkeypatch.chdir(tmp_path)
     (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=s\n"
+        "BIFROST_SOLUTION_ORG_ID=org-1\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
     (tmp_path / ".bifrost").mkdir()
     (tmp_path / ".bifrost" / "apps.yaml").write_text(
         yaml.safe_dump({"apps": {

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -73,6 +73,7 @@ def _make_upstream(record):
 
     async def other(request):
         record["other_path"] = request.path
+        record["other_query"] = request.rel_url.query_string
         record["other_org"] = request.headers.get("X-Bifrost-Org")
         return web.json_response({"upstream_other": True})
 
@@ -175,7 +176,13 @@ async def test_unknown_ref_proxies_to_upstream():
     up_port, dev_port = _free_port(), _free_port()
     up_runner = await _serve(_make_upstream(record), up_port)
     host = _StubHost(set())
-    cfg = DevProxyConfig(upstream_url=f"http://127.0.0.1:{up_port}", token="t", app_id="A", org_id="O")
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="t",
+        app_id="A",
+        org_id="O",
+        solution_id="S",
+    )
     dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
     try:
         async with httpx.AsyncClient() as c:
@@ -184,6 +191,7 @@ async def test_unknown_ref_proxies_to_upstream():
         assert r.status_code == 200
         assert r.json()["ran_upstream"] is True
         assert record["execute_body"]["app_id"] == "A"
+        assert record["execute_body"]["solution_id"] == "S"
     finally:
         await dev_runner.cleanup()
         await up_runner.cleanup()
@@ -194,14 +202,21 @@ async def test_other_api_path_proxies_with_org_header():
     up_port, dev_port = _free_port(), _free_port()
     up_runner = await _serve(_make_upstream(record), up_port)
     host = _StubHost(set())
-    cfg = DevProxyConfig(upstream_url=f"http://127.0.0.1:{up_port}", token="t", app_id="A", org_id="O")
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="t",
+        app_id="A",
+        org_id="O",
+        solution_id="S",
+    )
     dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
     try:
         async with httpx.AsyncClient() as c:
-            r = await c.get(f"http://127.0.0.1:{dev_port}/api/tables/foo")
+            r = await c.get(f"http://127.0.0.1:{dev_port}/api/tables/foo?limit=10")
         assert r.status_code == 200
         assert r.json()["upstream_other"] is True
         assert record["other_path"] == "/api/tables/foo"
+        assert record["other_query"] == "limit=10&solution=S"
         assert record["other_org"] == "O"
     finally:
         await dev_runner.cleanup()

--- a/api/tests/unit/test_solution_marketplace.py
+++ b/api/tests/unit/test_solution_marketplace.py
@@ -54,13 +54,15 @@ def test_resolve_targets_explicit_org():
     assert _resolve_target_install(installs, "s", "org-A") == "a"
 
 
-def test_deploy_cmd_has_org_option():
+def test_deploy_cmd_has_solution_option_not_org_option():
     from bifrost.commands.solution import deploy_cmd
 
-    # deploy now uses the unified --org standard (org + is_global params).
+    # deploy targets the bound install; --solution can override, but org comes
+    # from the install itself.
     names = {p.name for p in deploy_cmd.params}
-    assert "org" in names
-    assert "is_global" in names
+    assert "solution_ref" in names
+    assert "org" not in names
+    assert "is_global" not in names
 
 
 def test_compute_update_available():

--- a/api/tests/unit/test_solution_resolve_install.py
+++ b/api/tests/unit/test_solution_resolve_install.py
@@ -84,9 +84,7 @@ def test_scope_filters_out_wrong_scope():
 
 
 def test_deploy_fails_loudly_when_install_list_fetch_fails(tmp_path, monkeypatch):
-    """A non-200 from GET /api/solutions must abort the deploy with a loud
-    error — not silently treat the list as empty, attempt a fresh create, and
-    surface a confusing downstream 409 ('Failed to create install')."""
+    """An explicit --solution must surface list failures and never create."""
     from click.testing import CliRunner
 
     import bifrost.client as client_mod
@@ -120,11 +118,37 @@ def test_deploy_fails_loudly_when_install_list_fetch_fails(tmp_path, monkeypatch
         client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: _FakeClient())
     )
 
-    result = CliRunner().invoke(solution_group, ["deploy"])
+    result = CliRunner().invoke(solution_group, ["deploy", "--solution", "s"])
     assert result.exit_code != 0
     assert "Failed to list installs (500)" in result.output
     assert "internal server error" in result.output
     assert "Failed to create install" not in result.output
+
+
+def test_deploy_requires_bound_workspace(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    import bifrost.client as client_mod
+    from bifrost.commands.solution import solution_group
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\n")
+
+    class _FakeClient:
+        async def get(self, path, **kwargs):
+            raise AssertionError(f"unexpected GET {path}")
+
+        async def post(self, path, **kwargs):
+            raise AssertionError(f"unexpected POST {path}")
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: _FakeClient())
+    )
+
+    result = CliRunner().invoke(solution_group, ["deploy"])
+
+    assert result.exit_code != 0
+    assert "not bound to an install" in result.output
 
 
 # ── deploy version + --force (Task 21) ──────────────────────────────────────
@@ -202,6 +226,12 @@ def _deploy_workspace(tmp_path, monkeypatch, fake, descriptor_text: str):
 
     monkeypatch.chdir(tmp_path)
     (tmp_path / "bifrost.solution.yaml").write_text(descriptor_text)
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=inst-1\n"
+        "BIFROST_SOLUTION_SLUG=s\n"
+        "BIFROST_SOLUTION_ORG_ID=org-1\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
     monkeypatch.setattr(
         client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: fake)
     )

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -358,6 +358,9 @@ services:
       - ./api/alembic.ini:/app/alembic.ini:ro
       - ./api/pytest.ini:/app/pytest.ini:ro
       - ./api/pyproject.toml:/app/pyproject.toml:ro
+      - ./api/pyrightconfig.json:/app/pyrightconfig.json:ro
+      - ./api/Dockerfile.dev:/app/api/Dockerfile.dev:ro
+      - ./test.sh:/app/test.sh:ro
       - ./docker-compose.test.yml:/app/docker-compose.test.yml:ro  # Read-only —
                                       # the harness guard in
                                       # tests/unit/test_compose_test_harness.py

--- a/docs/superpowers/plans/2026-06-26-solution-bound-dev.md
+++ b/docs/superpowers/plans/2026-06-26-solution-bound-dev.md
@@ -1,0 +1,994 @@
+# Solution-Bound Development Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Solution workspaces usable only after they are bound to a concrete remote Solution install, so local development cannot silently write tables, files, configs, or app calls into loose `_repo` / org / global scope.
+
+**Architecture:** Introduce a small CLI binding layer that stores `BIFROST_SOLUTION_*` values in the workspace `.env`. `solution init` becomes a transparent alias of the new online `solution create` flow, `solution bind` attaches cloned workspaces to existing installs, and `solution start` / `solution deploy` require a bound install or an explicit `--solution`. The local dev proxy carries the bound `solution_id` explicitly because a local manifest app id may not exist in the database before the first deploy.
+
+**Tech Stack:** Python Click CLI, existing `BifrostClient`, FastAPI auth context via `?solution=`, pytest through `./test.sh`.
+
+---
+
+## Model Change
+
+The command model after this change:
+
+- `bifrost solution init <path> --slug ...` is a transparent alias of `bifrost solution create`.
+- `bifrost solution create <path> --slug ... [--org ...|--global]` creates the local descriptor and an empty remote install, then writes `.env`.
+- `bifrost solution bind --solution <id-or-slug>` binds an existing local workspace to an existing remote install, then writes `.env`.
+- `bifrost solution start [--solution <id-or-slug>]` requires a bound install. It has no `--org`; install scope is authoritative.
+- `bifrost solution deploy [--solution <id-or-slug>]` deploys to the bound install. It no longer silently creates or guesses an install.
+- `bifrost solution install` keeps its current install-from-zip behavior because it is intentionally a remote install operation.
+
+The `.env` binding keys:
+
+```dotenv
+BIFROST_SOLUTION_ID=<install uuid>
+BIFROST_SOLUTION_SLUG=<descriptor/install slug>
+BIFROST_SOLUTION_ORG_ID=<org uuid or empty for global>
+BIFROST_SOLUTION_SCOPE=org|global
+```
+
+`BIFROST_API_URL` already belongs in `.env` through login. Binding should not overwrite unrelated `.env` keys.
+
+## Files
+
+- Create `api/bifrost/solution_binding.py`: parse/write `.env` binding keys, resolve explicit install refs, validate descriptor/install matches.
+- Modify `api/bifrost/commands/solution.py`: add `create`, convert `init`, add `bind`, require bindings in `start` and `deploy`, thread `solution_id` into proxy config.
+- Modify `api/bifrost/solution_dev/proxy.py`: add `solution_id` to `DevProxyConfig`, append `?solution=<id>` to proxied data-plane requests, and pass `solution_id` on proxied workflow executions.
+- Test `api/tests/unit/test_solution_binding.py`: `.env` merge/read/write and install validation.
+- Test `api/tests/unit/test_solution_dev_command.py`: `start` binding requirements and `--solution` override.
+- Test `api/tests/unit/test_cli_solution_deploy_phases.py` or new `api/tests/unit/test_cli_solution_bound_deploy.py`: deploy requires binding and uses bound install.
+- Test `api/tests/unit/test_solution_dev_proxy.py`: proxied local app calls carry the bound `solution` query.
+
+---
+
+### Task 1: Add Solution Binding Helpers
+
+**Files:**
+- Create: `api/bifrost/solution_binding.py`
+- Test: `api/tests/unit/test_solution_binding.py`
+
+- [ ] **Step 1: Write failing tests for `.env` binding read/write**
+
+Create `api/tests/unit/test_solution_binding.py` with these tests:
+
+```python
+from pathlib import Path
+
+from bifrost.solution_binding import (
+    SolutionBinding,
+    read_solution_binding,
+    write_solution_binding,
+)
+
+
+def test_write_solution_binding_merges_env(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("BIFROST_API_URL=http://api\nOTHER=value\n")
+
+    write_solution_binding(
+        tmp_path,
+        SolutionBinding(
+            solution_id="11111111-1111-1111-1111-111111111111",
+            slug="dispatch",
+            organization_id="22222222-2222-2222-2222-222222222222",
+            scope="org",
+        ),
+    )
+
+    text = env.read_text()
+    assert "BIFROST_API_URL=http://api\n" in text
+    assert "OTHER=value\n" in text
+    assert "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n" in text
+    assert "BIFROST_SOLUTION_SLUG=dispatch\n" in text
+    assert "BIFROST_SOLUTION_ORG_ID=22222222-2222-2222-2222-222222222222\n" in text
+    assert "BIFROST_SOLUTION_SCOPE=org\n" in text
+
+
+def test_read_solution_binding_returns_none_when_missing(tmp_path: Path) -> None:
+    assert read_solution_binding(tmp_path) is None
+
+
+def test_read_solution_binding_parses_global_scope(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=dispatch\n"
+        "BIFROST_SOLUTION_ORG_ID=\n"
+        "BIFROST_SOLUTION_SCOPE=global\n"
+    )
+
+    binding = read_solution_binding(tmp_path)
+
+    assert binding is not None
+    assert binding.solution_id == "11111111-1111-1111-1111-111111111111"
+    assert binding.slug == "dispatch"
+    assert binding.organization_id is None
+    assert binding.scope == "global"
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_binding.py -v
+```
+
+Expected: import failure for `bifrost.solution_binding`.
+
+- [ ] **Step 3: Implement binding helpers**
+
+Create `api/bifrost/solution_binding.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+SOLUTION_ENV_KEYS = {
+    "BIFROST_SOLUTION_ID",
+    "BIFROST_SOLUTION_SLUG",
+    "BIFROST_SOLUTION_ORG_ID",
+    "BIFROST_SOLUTION_SCOPE",
+}
+
+
+@dataclass(frozen=True)
+class SolutionBinding:
+    solution_id: str
+    slug: str
+    organization_id: str | None
+    scope: Literal["org", "global"]
+
+
+def _env_path(workspace: Path) -> Path:
+    return workspace / ".env"
+
+
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped[len("export ") :]
+    if "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    value = value.strip().strip('"').strip("'")
+    return key, value
+
+
+def read_solution_binding(workspace: Path) -> SolutionBinding | None:
+    env = _env_path(workspace)
+    if not env.is_file():
+        return None
+    values: dict[str, str] = {}
+    for line in env.read_text().splitlines():
+        parsed = _parse_env_line(line)
+        if parsed is not None:
+            key, value = parsed
+            values[key] = value
+    solution_id = values.get("BIFROST_SOLUTION_ID")
+    slug = values.get("BIFROST_SOLUTION_SLUG")
+    if not solution_id or not slug:
+        return None
+    scope = values.get("BIFROST_SOLUTION_SCOPE") or "org"
+    if scope not in {"org", "global"}:
+        return None
+    org_id = values.get("BIFROST_SOLUTION_ORG_ID") or None
+    if scope == "global":
+        org_id = None
+    return SolutionBinding(
+        solution_id=solution_id,
+        slug=slug,
+        organization_id=org_id,
+        scope=scope,  # type: ignore[arg-type]
+    )
+
+
+def write_solution_binding(workspace: Path, binding: SolutionBinding) -> None:
+    env = _env_path(workspace)
+    existing = env.read_text().splitlines() if env.is_file() else []
+    kept = []
+    for line in existing:
+        parsed = _parse_env_line(line)
+        if parsed is None or parsed[0] not in SOLUTION_ENV_KEYS:
+            kept.append(line)
+    additions = [
+        f"BIFROST_SOLUTION_ID={binding.solution_id}",
+        f"BIFROST_SOLUTION_SLUG={binding.slug}",
+        f"BIFROST_SOLUTION_ORG_ID={binding.organization_id or ''}",
+        f"BIFROST_SOLUTION_SCOPE={binding.scope}",
+    ]
+    env.write_text("\n".join([*kept, *additions]).rstrip() + "\n")
+```
+
+- [ ] **Step 4: Run binding tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_binding.py -v
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 2: Add Install Resolution and Validation Helpers
+
+**Files:**
+- Modify: `api/bifrost/solution_binding.py`
+- Test: `api/tests/unit/test_solution_binding.py`
+
+- [ ] **Step 1: Add failing tests for install ref resolution**
+
+Append:
+
+```python
+import pytest
+
+from bifrost.solution_binding import (
+    SolutionBindingError,
+    binding_from_install,
+    resolve_install_ref,
+)
+
+
+def test_binding_from_install_rejects_slug_mismatch() -> None:
+    with pytest.raises(SolutionBindingError, match="does not match descriptor slug"):
+        binding_from_install(
+            {"id": "i", "slug": "other", "organization_id": None},
+            descriptor_slug="expected",
+        )
+
+
+def test_binding_from_install_global() -> None:
+    binding = binding_from_install(
+        {"id": "i", "slug": "expected", "organization_id": None},
+        descriptor_slug="expected",
+    )
+    assert binding.scope == "global"
+    assert binding.organization_id is None
+
+
+def test_resolve_install_ref_rejects_ambiguous_slug() -> None:
+    installs = [
+        {"id": "a", "slug": "expected", "organization_id": "org-a"},
+        {"id": "b", "slug": "expected", "organization_id": "org-b"},
+    ]
+    with pytest.raises(SolutionBindingError, match="multiple installs"):
+        resolve_install_ref(installs, "expected", descriptor_slug="expected")
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_binding.py -v
+```
+
+Expected: import failure for the new helper names.
+
+- [ ] **Step 3: Implement resolver helpers**
+
+Add to `api/bifrost/solution_binding.py`:
+
+```python
+class SolutionBindingError(ValueError):
+    pass
+
+
+def binding_from_install(install: dict, *, descriptor_slug: str) -> SolutionBinding:
+    slug = str(install.get("slug") or "")
+    if slug != descriptor_slug:
+        raise SolutionBindingError(
+            f"Install slug {slug!r} does not match descriptor slug {descriptor_slug!r}"
+        )
+    org_id = install.get("organization_id")
+    return SolutionBinding(
+        solution_id=str(install["id"]),
+        slug=slug,
+        organization_id=str(org_id) if org_id else None,
+        scope="org" if org_id else "global",
+    )
+
+
+def resolve_install_ref(
+    installs: list[dict],
+    ref: str,
+    *,
+    descriptor_slug: str,
+) -> SolutionBinding:
+    matches = [s for s in installs if s.get("id") == ref]
+    if not matches:
+        matches = [s for s in installs if s.get("slug") == ref]
+    if not matches:
+        raise SolutionBindingError(f"No solution install found for {ref!r}")
+    if len(matches) > 1:
+        ids = ", ".join(str(m.get("id")) for m in matches)
+        raise SolutionBindingError(
+            f"Slug {ref!r} matches multiple installs ({ids}); pass an install id"
+        )
+    return binding_from_install(matches[0], descriptor_slug=descriptor_slug)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_binding.py -v
+```
+
+Expected: all tests pass.
+
+---
+
+### Task 3: Add Online `solution create` and Make `init` an Alias
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py`
+- Test: `api/tests/unit/test_solution_dev_command.py`
+
+- [ ] **Step 1: Add failing CLI tests**
+
+Append to `api/tests/unit/test_solution_dev_command.py`:
+
+```python
+def test_solution_init_creates_remote_install_and_env(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+
+    created_payloads = []
+
+    class _Resp:
+        status_code = 201
+        text = ""
+
+        def json(self):
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "slug": "dispatch",
+                "organization_id": "22222222-2222-2222-2222-222222222222",
+            }
+
+    class _FakeClient:
+        organization = {"id": "22222222-2222-2222-2222-222222222222"}
+
+        async def post(self, path, json=None, **kwargs):
+            assert path == "/api/solutions"
+            created_payloads.append(json)
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["init", ".", "--slug", "dispatch", "--name", "Dispatch"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "bifrost.solution.yaml").is_file()
+    env = (tmp_path / ".env").read_text()
+    assert "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111" in env
+    assert created_payloads[0]["slug"] == "dispatch"
+    assert created_payloads[0]["organization_id"] == "22222222-2222-2222-2222-222222222222"
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_command.py::test_solution_init_creates_remote_install_and_env -v
+```
+
+Expected: `.env` is missing because current `init` only writes the descriptor.
+
+- [ ] **Step 3: Implement shared create flow**
+
+In `api/bifrost/commands/solution.py`:
+
+- Import `SolutionBinding`, `binding_from_install`, and `write_solution_binding`.
+- Move the existing descriptor-writing body into `_write_solution_descriptor`.
+- Add `_create_solution_workspace_and_install(...)`.
+- Add `@solution_group.command(name="create", ...)`.
+- Change `init_cmd` to call the same helper.
+
+The create helper must:
+
+```python
+async def _create_install_for_descriptor(client, descriptor, target_org_id):
+    create = await client.post("/api/solutions", json={
+        "slug": descriptor.slug,
+        "name": descriptor.name,
+        "organization_id": target_org_id,
+        "global_repo_access": descriptor.global_repo_access,
+        "git_connected": descriptor.git_connected,
+        "git_repo_url": descriptor.git_repo_url,
+        "repo_subpath": descriptor.repo_subpath,
+        "git_ref": descriptor.git_ref,
+    })
+    if create.status_code not in (200, 201):
+        raise click.ClickException(
+            f"Failed to create install: {create.status_code} {create.text}"
+        )
+    return create.json()
+```
+
+`init` and `create` should both print:
+
+```text
+Created Solution install <id>.
+Bound workspace in .env.
+```
+
+- [ ] **Step 4: Run create/init tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_command.py::test_solution_init_creates_remote_install_and_env -v
+```
+
+Expected: pass.
+
+---
+
+### Task 4: Add `solution bind`
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py`
+- Test: `api/tests/unit/test_solution_dev_command.py`
+
+- [ ] **Step 1: Add failing bind test**
+
+Append:
+
+```python
+def test_solution_bind_writes_existing_install_to_env(tmp_path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: dispatch\nname: Dispatch\n")
+
+    class _Resp:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "solutions": [{
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "slug": "dispatch",
+                    "organization_id": None,
+                }]
+            }
+
+    class _FakeClient:
+        async def get(self, path, **kwargs):
+            assert path == "/api/solutions"
+            return _Resp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["bind", "--solution", "dispatch"],
+    )
+
+    assert result.exit_code == 0, result.output
+    env = (tmp_path / ".env").read_text()
+    assert "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111" in env
+    assert "BIFROST_SOLUTION_SCOPE=global" in env
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_command.py::test_solution_bind_writes_existing_install_to_env -v
+```
+
+Expected: Click reports no `bind` command.
+
+- [ ] **Step 3: Implement `bind` command**
+
+Add:
+
+```python
+@solution_group.command(name="bind", help="Bind this workspace to an existing Solution install.")
+@click.option("--solution", "solution_ref", required=True, help="Solution install id or unique slug.")
+def bind_cmd(solution_ref: str) -> None:
+    workspace = pathlib.Path(".").resolve()
+    if not is_solution_workspace(workspace):
+        raise click.ClickException(
+            f"No {DESCRIPTOR_FILENAME} in {workspace} — not a Solution workspace. "
+            "Run `bifrost solution create` first."
+        )
+    descriptor = load_descriptor(workspace)
+
+    async def _run() -> int:
+        from bifrost.solution_binding import (
+            SolutionBindingError,
+            resolve_install_ref,
+            write_solution_binding,
+        )
+
+        client = BifrostClient.get_instance(require_auth=True)
+        resp = await client.get("/api/solutions")
+        if resp.status_code != 200:
+            raise click.ClickException(
+                f"Failed to list installs ({resp.status_code}): {resp.text[:200]}"
+            )
+        try:
+            binding = resolve_install_ref(
+                resp.json().get("solutions", []),
+                solution_ref,
+                descriptor_slug=descriptor.slug,
+            )
+        except SolutionBindingError as exc:
+            raise click.ClickException(str(exc))
+        write_solution_binding(workspace, binding)
+        click.echo(f"Bound workspace to Solution install {binding.solution_id}.")
+        return 0
+
+    rc = asyncio.run(_run())
+    if rc:
+        raise SystemExit(rc)
+```
+
+- [ ] **Step 4: Run bind test**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_command.py::test_solution_bind_writes_existing_install_to_env -v
+```
+
+Expected: pass.
+
+---
+
+### Task 5: Require Binding in `solution start`
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py`
+- Test: `api/tests/unit/test_solution_dev_command.py`
+
+- [ ] **Step 1: Add failing start tests**
+
+Modify the existing `test_start_spawns_npm_via_resolved_path` setup to write `.env` with `BIFROST_SOLUTION_ID`, or add this focused test:
+
+```python
+def test_start_refuses_solution_workspace_without_binding(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\n")
+    (tmp_path / ".bifrost").mkdir()
+    (tmp_path / ".bifrost" / "apps.yaml").write_text(
+        yaml.safe_dump({"apps": {
+            "a": {"id": "a", "slug": "dash", "path": "apps/dash", "app_model": "standalone_v2"},
+        }})
+    )
+    (tmp_path / "apps" / "dash").mkdir(parents=True)
+
+    result = CliRunner().invoke(solution_group, ["start"])
+
+    assert result.exit_code != 0
+    assert "not bound to a Solution install" in result.output
+    assert "bifrost solution create" in result.output
+    assert "bifrost solution bind" in result.output
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_command.py::test_start_refuses_solution_workspace_without_binding -v
+```
+
+Expected: current code tries to authenticate/select app instead of refusing for missing binding.
+
+- [ ] **Step 3: Implement start binding resolution**
+
+Change `start_cmd` signature to:
+
+```python
+@solution_group.command(name="start", help="Run the app's dev server + local workflows (one origin).")
+@click.argument("app_slug", required=False)
+@click.option("--solution", "solution_ref", default=None, help="Solution install id or unique slug; also updates .env binding.")
+@click.option("--port", default=3000, show_default=True, type=int, help="Local origin port.")
+def start_cmd(app_slug: str | None, solution_ref: str | None, port: int) -> None:
+```
+
+Remove `@org_option` from `start`.
+
+Resolution order:
+
+1. If `--solution` is passed, list installs, validate against descriptor slug, write `.env`, and use it.
+2. Else read `.env` with `read_solution_binding`.
+3. If missing, raise:
+
+```text
+This Solution workspace is not bound to a Solution install.
+Run `bifrost solution create` for a new install, or `bifrost solution bind --solution <id-or-slug>` for an existing one.
+```
+
+Use the binding’s `organization_id` for `/api/sdk/context`, not a user-supplied `--org`.
+
+- [ ] **Step 4: Update existing start tests**
+
+In tests that expect `solution start` to proceed, write:
+
+```python
+(tmp_path / ".env").write_text(
+    "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+    "BIFROST_SOLUTION_SLUG=s\n"
+    "BIFROST_SOLUTION_ORG_ID=org-1\n"
+    "BIFROST_SOLUTION_SCOPE=org\n"
+)
+```
+
+Expected: existing tests continue past the binding gate.
+
+- [ ] **Step 5: Run start tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_command.py -v
+```
+
+Expected: all solution dev command tests pass.
+
+---
+
+### Task 6: Thread Bound `solution_id` Through the Local Dev Proxy
+
+**Files:**
+- Modify: `api/bifrost/solution_dev/proxy.py`
+- Modify: `api/bifrost/commands/solution.py`
+- Test: `api/tests/unit/test_solution_dev_proxy.py`
+
+- [ ] **Step 1: Add failing proxy test**
+
+Add to `api/tests/unit/test_solution_dev_proxy.py`:
+
+```python
+def test_dev_proxy_appends_solution_query_to_api_requests():
+    import yarl
+    from bifrost.solution_dev.proxy import _join_upstream_with_solution
+
+    target = _join_upstream_with_solution(
+        "http://api.local",
+        yarl.URL("/api/files/list?location=reports"),
+        solution_id="11111111-1111-1111-1111-111111111111",
+    )
+
+    assert target == (
+        "http://api.local/api/files/list?"
+        "location=reports&solution=11111111-1111-1111-1111-111111111111"
+    )
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_proxy.py::test_dev_proxy_appends_solution_query_to_api_requests -v
+```
+
+Expected: helper missing.
+
+- [ ] **Step 3: Implement proxy solution plumbing**
+
+In `api/bifrost/solution_dev/proxy.py`:
+
+- Add `solution_id: str` to `DevProxyConfig`.
+- Add `_join_upstream_with_solution(base_url, rel_url, solution_id)`.
+- Use it in `_api_proxy_handler` for `/api/*` requests.
+- In `_execute_handler`, when proxying to the remote API, send:
+
+```python
+proxied_body = dict(body)
+proxied_body.setdefault("solution_id", cfg.solution_id)
+```
+
+The helper should preserve existing query params and not duplicate `solution`:
+
+```python
+def _join_upstream_with_solution(base_url: str, rel_url: yarl.URL, *, solution_id: str) -> str:
+    target = yarl.URL(_join_upstream(base_url, rel_url))
+    if "solution" in target.query:
+        return str(target)
+    return str(target.update_query({**target.query, "solution": solution_id}))
+```
+
+In `api/bifrost/commands/solution.py`, pass `binding.solution_id` into `DevProxyConfig`.
+
+- [ ] **Step 4: Run proxy tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_dev_proxy.py -v
+```
+
+Expected: pass.
+
+---
+
+### Task 7: Require Binding in `solution deploy`
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py`
+- Test: `api/tests/unit/test_cli_solution_bound_deploy.py`
+
+- [ ] **Step 1: Add deploy binding tests**
+
+Create `api/tests/unit/test_cli_solution_bound_deploy.py`:
+
+```python
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bifrost.commands.solution import solution_group
+
+
+def test_deploy_refuses_without_binding(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\n")
+
+    result = CliRunner().invoke(solution_group, ["deploy"])
+
+    assert result.exit_code != 0
+    assert "not bound to a Solution install" in result.output
+
+
+def test_deploy_accepts_solution_override_without_env(tmp_path: Path, monkeypatch):
+    import bifrost.client as client_mod
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\n")
+    (tmp_path / ".bifrost").mkdir()
+
+    calls = []
+
+    class _ListResp:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {
+                "solutions": [{
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "slug": "s",
+                    "organization_id": None,
+                }]
+            }
+
+    class _DeployResp:
+        status_code = 202
+        text = ""
+
+        def json(self):
+            return {"deploy_job_id": "job-1"}
+
+    class _JobResp:
+        status_code = 200
+
+        def json(self):
+            return {"status": "succeeded"}
+
+    class _FakeClient:
+        async def get(self, path, **kwargs):
+            if path == "/api/solutions":
+                return _ListResp()
+            return _JobResp()
+
+        async def post(self, path, **kwargs):
+            calls.append(path)
+            return _DeployResp()
+
+    monkeypatch.setattr(
+        client_mod.BifrostClient,
+        "get_instance",
+        staticmethod(lambda **kwargs: _FakeClient()),
+    )
+
+    result = CliRunner().invoke(
+        solution_group,
+        ["deploy", "--solution", "11111111-1111-1111-1111-111111111111"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "/api/solutions/11111111-1111-1111-1111-111111111111/deploy" in calls
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_cli_solution_bound_deploy.py -v
+```
+
+Expected: current deploy creates/resolves instead of refusing without binding.
+
+- [ ] **Step 3: Implement deploy binding resolution**
+
+Change `deploy_cmd`:
+
+- Add `--solution`.
+- Remove `@org_option`.
+- Before scanning/deploying, resolve binding by `--solution` or `.env`.
+- Delete the create-if-missing branch from deploy.
+- Use `target_id = binding.solution_id`.
+- On successful deploy, rewrite `.env` with the binding.
+
+Do not change `solution install` in this task.
+
+- [ ] **Step 4: Run deploy binding tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_cli_solution_bound_deploy.py -v
+```
+
+Expected: pass.
+
+---
+
+### Task 8: Update User-Facing Messages and Docs
+
+**Files:**
+- Modify: `api/bifrost/commands/solution.py`
+- Modify: `docs/llm.txt` if it documents Solution first-run flow
+- Modify: `api/tests/unit/test_solution_workspace_guard.py`
+
+- [ ] **Step 1: Update guard/error text tests**
+
+Search for current messages:
+
+```bash
+rg -n "solution init|solution deploy|Solution workspace|not bound" api/tests docs api/bifrost
+```
+
+Update tests to expect:
+
+```text
+Run `bifrost solution create` for a new install, or `bifrost solution bind --solution <id-or-slug>` for an existing one.
+```
+
+- [ ] **Step 2: Update command help text**
+
+Ensure `bifrost solution --help` describes:
+
+```text
+create   Create a local Solution workspace and empty remote install.
+init     Alias for create.
+bind     Bind this workspace to an existing install.
+start    Run the bound install locally.
+deploy   Deploy to the bound install.
+```
+
+- [ ] **Step 3: Update docs**
+
+If `docs/llm.txt` exists and includes Solution first-run recipes, update the recipe to:
+
+```bash
+bifrost solution create . --slug example --name "Example"
+bifrost solution scaffold-app dashboard
+bifrost solution start dashboard
+bifrost solution deploy
+```
+
+Existing-clone recipe:
+
+```bash
+bifrost solution bind --solution <id-or-slug>
+bifrost solution start
+```
+
+- [ ] **Step 4: Run targeted docs/help-adjacent tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_workspace_guard.py tests/unit/test_solution_dev_command.py -v
+```
+
+Expected: pass.
+
+---
+
+### Task 9: Verification
+
+**Files:**
+- No new code changes.
+
+- [ ] **Step 1: Run targeted unit tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_solution_binding.py \
+  tests/unit/test_solution_dev_command.py \
+  tests/unit/test_solution_dev_proxy.py \
+  tests/unit/test_cli_solution_bound_deploy.py \
+  -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run broader Solution CLI tests**
+
+Run:
+
+```bash
+./test.sh tests/unit/test_cli_solution_deploy_phases.py \
+  tests/unit/test_cli_solution_run.py \
+  tests/unit/test_solution_workspace_guard.py \
+  tests/unit/test_solution_descriptor.py \
+  -v
+```
+
+Expected: all pass or failures are unrelated pre-existing expectations that need updating for the model change.
+
+- [ ] **Step 3: Run lint/type checks for touched Python**
+
+Run:
+
+```bash
+cd api && ruff check bifrost/commands/solution.py bifrost/solution_binding.py bifrost/solution_dev/proxy.py tests/unit/test_solution_binding.py tests/unit/test_solution_dev_command.py tests/unit/test_solution_dev_proxy.py
+```
+
+Expected: no ruff violations.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add api/bifrost/solution_binding.py \
+  api/bifrost/commands/solution.py \
+  api/bifrost/solution_dev/proxy.py \
+  api/tests/unit/test_solution_binding.py \
+  api/tests/unit/test_solution_dev_command.py \
+  api/tests/unit/test_solution_dev_proxy.py \
+  api/tests/unit/test_cli_solution_bound_deploy.py \
+  docs/llm.txt
+git commit -m "feat: require solution-bound local development"
+```
+
+If `docs/llm.txt` was not touched, omit it from `git add`.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers stamped `.env` binding, online `init/create`, existing-install `bind`, no `--org` on `start`, binding-required `start` and `deploy`, and explicit proxy `solution_id` propagation for pre-deploy app calls.
+- Placeholder scan: No `TBD`, deferred implementation, or unnamed tests remain.
+- Type consistency: `SolutionBinding.solution_id`, `slug`, `organization_id`, and `scope` are used consistently across helper, command, and proxy tasks.

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -1692,16 +1692,30 @@ Options:
   --help  Show this message and exit.
 
 Commands:
+  bind          Bind this local Solution workspace to an existing install.
   capture       Adopt loose _repo/ entities into an install (migration).
+  create        Create and bind a new Solution workspace.
   deploy        Deploy the current Solution workspace (full replace,...
   export        Download a Solution's workspace zip (shareable or full...
-  init          Scaffold a bifrost.solution.yaml descriptor.
+  init          Alias for `solution create`: scaffold, create remote...
   install       Install a Solution from a workspace zip (drag-and-drop...
   migrate-app   Migrate a v1 inline app dir to a scaffolded standalone_v2...
   pull          Pull captured entities into the local .bifrost/ manifest...
   scaffold-app  Scaffold a standalone_v2 React app (package.json, vite,...
   start         Run the app's dev server + local workflows (one origin).
   swap-slugs    Atomically exchange two apps' slugs (v1→v2 migration...
+```
+
+### `solution bind`
+
+```
+Usage: solution bind [OPTIONS] [PATH]
+
+  Bind this local Solution workspace to an existing install.
+
+Options:
+  --solution TEXT  Install id or unique slug.  [required]
+  --help           Show this message and exit.
 ```
 
 ### `solution capture`
@@ -1729,6 +1743,30 @@ Options:
   --help                          Show this message and exit.
 ```
 
+### `solution create`
+
+```
+Usage: solution create [OPTIONS] [PATH]
+
+  Create and bind a new Solution workspace.
+
+Options:
+  --slug TEXT                     Solution slug (definition identity).
+                                  [required]
+  --name TEXT                     Display name (defaults to slug).
+  --version TEXT                  Bundle version recorded on the install at
+                                  deploy time.  [default: 0.1.0]
+  --global-repo-access / --no-global-repo-access
+                                  [default: no-global-repo-access]
+  --global                        Target global scope (org=NULL). Alias for
+                                  --org global.
+  --org, --organization, --scope TEXT
+                                  Org UUID/name, or 'none'/'global' for global
+                                  scope. Omit = your org. (--organization /
+                                  --scope are synonyms.)
+  --help                          Show this message and exit.
+```
+
 ### `solution deploy`
 
 ```
@@ -1737,16 +1775,10 @@ Usage: solution deploy [OPTIONS] [PATH]
   Deploy the current Solution workspace (full replace, non-interactive).
 
 Options:
-  --solution TEXT                 Target install id (override when ambiguous).
-  --global                        Target global scope (org=NULL). Alias for
-                                  --org global.
-  --org, --organization, --scope TEXT
-                                  Org UUID/name, or 'none'/'global' for global
-                                  scope. Omit = your org. (--organization /
-                                  --scope are synonyms.)
-  --force                         Apply even if the bundle version is older
-                                  than the installed version (downgrade).
-  --help                          Show this message and exit.
+  --solution TEXT  Install id or unique slug.
+  --force          Apply even if the bundle version is older than the
+                   installed version (downgrade).
+  --help           Show this message and exit.
 ```
 
 ### `solution export`
@@ -1774,7 +1806,7 @@ Options:
 ```
 Usage: solution init [OPTIONS] [PATH]
 
-  Scaffold a bifrost.solution.yaml descriptor.
+  Alias for `solution create`: scaffold, create remote install, and bind .env.
 
 Options:
   --slug TEXT                     Solution slug (definition identity).
@@ -1784,6 +1816,12 @@ Options:
                                   deploy time.  [default: 0.1.0]
   --global-repo-access / --no-global-repo-access
                                   [default: no-global-repo-access]
+  --global                        Target global scope (org=NULL). Alias for
+                                  --org global.
+  --org, --organization, --scope TEXT
+                                  Org UUID/name, or 'none'/'global' for global
+                                  scope. Omit = your org. (--organization /
+                                  --scope are synonyms.)
   --help                          Show this message and exit.
 ```
 
@@ -1872,14 +1910,9 @@ Usage: solution start [OPTIONS] [APP_SLUG]
   Run the app's dev server + local workflows (one origin).
 
 Options:
-  --global                        Target global scope (org=NULL). Alias for
-                                  --org global.
-  --org, --organization, --scope TEXT
-                                  Org UUID/name, or 'none'/'global' for global
-                                  scope. Omit = your org. (--organization /
-                                  --scope are synonyms.)
-  --port INTEGER                  Local origin port.  [default: 3000]
-  --help                          Show this message and exit.
+  --solution TEXT  Install id or unique slug.
+  --port INTEGER   Local origin port.  [default: 3000]
+  --help           Show this message and exit.
 ```
 
 ### `solution swap-slugs`

--- a/plugins/bifrost/skills/bifrost-build/references/entities.md
+++ b/plugins/bifrost/skills/bifrost-build/references/entities.md
@@ -322,17 +322,18 @@ All install/remove operations recycle workers asynchronously (returns immediatel
 
 An installable surface — a workspace (apps + workflows + tables + configs + forms + agents) that deploys as one unit. See `references/apps.md` for the Solution app structure and `SKILL.md` for the Solutions skill.
 
-Commands: `solution init / scaffold-app / start / deploy / install`
+Commands: `solution create / init / bind / scaffold-app / start / deploy / install`
 
 ```bash
-bifrost solution init --slug my-solution --name "My Solution"
+bifrost solution create --slug my-solution --name "My Solution"
+bifrost solution bind --solution <id-or-slug>   # for cloned/existing workspaces
 bifrost solution scaffold-app my-app
-bifrost solution start [APP_SLUG]          # APP_SLUG positional (the apps/ dir name); optional org targeting + --port
-bifrost solution deploy                    # your org; --global or --org <ref> targets elsewhere
+bifrost solution start [APP_SLUG]          # APP_SLUG positional (the apps/ dir name); bound install + optional --port
+bifrost solution deploy                    # full-replace the bound install
 bifrost solution install solution.zip --org acme
 ```
 
-`solution init` carries **no install scope** — install kind (org vs global) is the deploy-time `--org`/`--global` choice (the unified standard, below), not a descriptor field.
+`solution init` is an alias for `solution create`: it writes the descriptor, creates an empty remote install, and writes the local `.env` binding. `solution start` and `solution deploy` use that bound install; pass `--solution <id-or-slug>` only when you need a one-command override.
 
 Non-obvious:
 - `deploy` (alias: `bifrost deploy`) full-replaces the install; refuses bundles older than the installed version unless `--force`.

--- a/plugins/bifrost/skills/bifrost-build/references/solutions.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solutions.md
@@ -8,13 +8,14 @@ A Solution is an installable, deployable unit. Every entity it owns — apps, wo
 
 ## Lifecycle
 
-### 1. Scaffold the workspace
+### 1. Create and bind the workspace
 
 ```bash
-bifrost solution init . --slug my-solution --name "My Solution"
+bifrost solution create . --slug my-solution --name "My Solution"
+# `bifrost solution init` is an alias for create.
 ```
 
-Creates `bifrost.solution.yaml` in the current directory. The hub uses this file as the mode marker — its presence switches all subsequent commands to solution mode.
+Creates `bifrost.solution.yaml` in the current directory, creates an empty remote install, and writes the install binding to `.env`. The hub uses the descriptor as the mode marker — its presence switches all subsequent commands to solution mode. If you cloned an existing workspace instead, run `bifrost solution bind --solution <id-or-slug>` to write the `.env` binding without creating a new install.
 
 ### 2. Scaffold a v2 app
 
@@ -67,19 +68,18 @@ In a form, agent, or app, reference this as `functions/hello.py::main`. The plat
 bifrost solution start
 ```
 
-Runs the app's Vite dev server and local workflow functions behind one origin — no deploy required. Hot reload works for both app code and workflow code. The org-targeting flags (below) run under a specific org context (superuser only); omit them to run under your own org.
+Runs the app's Vite dev server and local workflow functions behind one origin — no deploy required. Hot reload works for both app code and workflow code. `start` requires the workspace's `.env` Solution binding, or an explicit `--solution <id-or-slug>` override; install scope comes from that binding, not `--org`.
 
 Open the origin the command prints (the **proxy** port; `--port` sets it, default 3000). Vite itself binds to **`--port + 1`** behind the proxy — drive the app at the proxy port the command prints, not the Vite port.
 
 ### 5. Deploy
 
 ```bash
-bifrost solution deploy                       # your own org (home)
-bifrost solution deploy --global              # the global install
-bifrost solution deploy --org "Target Org"    # a specific org
+bifrost solution deploy                       # bound install from .env
+bifrost solution deploy --solution <id>       # explicit install override
 ```
 
-Full-replace deploy of the workspace — all entities are written (or overwritten) from the workspace content. Org targeting follows the **unified `--org` standard** (see below).
+Full-replace deploy of the workspace — all entities are written (or overwritten) from the workspace content. `deploy` requires a bound install and never creates a missing install. To target another install of the same definition, bind the workspace to it or pass `--solution <install-id-or-slug>`.
 
 ### 5a. Declare Solution file locations
 
@@ -123,31 +123,31 @@ Export modes:
 
 ### The unified `--org` standard
 
-Every org-targeting **write** command (`create`/`update`/`set`/`register`, and the `solution` subcommands) takes the same flag:
+Every org-targeting **write** command (`create`/`update`/`set`/`register`, plus install-creating Solution commands such as `solution create`, `solution install`, and `solution pull`) takes the same flag:
 
 - **Omit it** → your own org ("home"). A bare command never writes a global entity by accident.
 - **`--org <uuid|name>`** → that org.
 - **`--global`** (or `--org none` / `--org global`) → global scope (organization_id NULL).
 - **`--organization` and `--scope`** are permanent synonyms for `--org`.
 
-This applies to the `solution` subcommands (`deploy`, `pull`, `start`, `install`) and to the write verbs of the `_repo`-workspace entity commands (`tables`, `forms`, `agents`, `configs`, `claims`, `workflows`, `events`). **Read commands (`list`/`get`) do NOT take `--org`/`--global`** — they return the caller's full combined visibility. Install **kind** (org vs global) is purely this deploy-time choice — it is **not** stored in the descriptor; the server derives it from `organization_id` (NULL == global).
+This applies to install-creating or install-selecting Solution commands (`create`, `install`, `pull`) and to the write verbs of the `_repo`-workspace entity commands (`tables`, `forms`, `agents`, `configs`, `claims`, `workflows`, `events`). `solution start` and `solution deploy` do **not** take `--org`/`--global`; they use the bound install's scope. **Read commands (`list`/`get`) do NOT take `--org`/`--global`** — they return the caller's full combined visibility. Install **kind** (org vs global) is stored on the remote install, not in the descriptor.
 
 ---
 
 ## One definition, many installs
 
-`bifrost.solution.yaml` is the **definition** descriptor — `slug`, `name`, `version`, `global_repo_access`, and git-source fields (`git_connected`, `git_repo_url`, `repo_subpath`, `git_ref`, `logo`). It is **stateless** and intentionally carries **no install id** and **no install scope** — install kind (org vs global) is the installer's deploy-time `--org`/`--global` choice, not a descriptor field. It also doubles as the workspace mode marker (its presence is what switches tooling into solution mode).
+`bifrost.solution.yaml` is the **definition** descriptor — `slug`, `name`, `version`, `global_repo_access`, and git-source fields (`git_connected`, `git_repo_url`, `repo_subpath`, `git_ref`, `logo`). It intentionally carries **no install id** and **no install scope**. The concrete install binding lives in `.env` (`BIFROST_SOLUTION_ID`, slug, org id, scope), which is local environment state and should not be committed. The descriptor also doubles as the workspace mode marker (its presence is what switches tooling into solution mode).
 
-The install id lives **server-side** (`Solution.id` — the `solution_id` stamped on every managed entity *at deploy time*). **Nothing in the repo carries install identity** — not the descriptor, not `.bifrost/*.yaml` (its entries deliberately omit org/access/identity for portability). The repo is the **definition**; deploy is what mints an install and stamps identity onto the entity rows it writes. Deploy/pull resolve *which install* at runtime by matching **`(slug, org)`** against the server's installs, creating one if none matches.
+The install id lives **server-side** (`Solution.id` — the `solution_id` stamped on every managed entity *at deploy time*) and in the local uncommitted `.env` binding. The repo is the **definition**; `solution create` or `solution bind` chooses which concrete install this checkout is working against. Deploy/pull then operate on that install (or an explicit `--solution` override).
 
 **Instance vs fork — the `slug` is the dividing line:**
 
-- **One definition, many installs (instances).** Keep **one repo / one slug** and deploy it per customer-org: `bifrost solution deploy --org "Customer Org"` (or `bifrost solution install pkg.zip --org "Customer Org"`). Each org gets an **independent install** — its own id, config values, and entity rows — from the *same* source. Deploy refuses to let one org clobber another org's install of the same slug. This is how you run "the same HR portal" for 3 customers: one codebase, three installs.
+- **One definition, many installs (instances).** Keep **one repo / one slug** and create/install it per customer-org: `bifrost solution create --org "Customer Org"` for an authoring checkout, or `bifrost solution install pkg.zip --org "Customer Org"` for packaged delivery. Each org gets an **independent install** — its own id, config values, and entity rows — from the *same* source. Bind the checkout to the install you are editing before `start` or `deploy`. This is how you run "the same HR portal" for 3 customers: one codebase, three installs.
 - **A genuinely different solution → fork (new slug).** If a customer needs the solution to *diverge* (different features/code, not just different data), **fork the repo and give it a new `slug`**. Different slug = different definition = a separate solution, not an instance of the first. There is no per-customer stamping in the repo to do this for you — forking is the mechanism.
 - **Multiple repos / subfolders** for git-connected installs are distinguished by `repo_subpath` (omni-repo: one repo, a folder per solution) and `git_ref` (pin a branch/tag).
 - **Natural key collision** (two installs of the same slug in the same org) → resolution raises an ambiguity error; pass **`--solution <install-id>`** to target one install by id.
 
-Install **kind** is chosen entirely at deploy/install time via the unified `--org`/`--global` standard — there is no `scope` in the descriptor. `--global` makes a global install (organization_id NULL); `--org "Customer Org"` makes an org install; omitting both installs into your own org. The server derives the install's scope from `organization_id` (NULL == global), so the same descriptor deploys global OR per-org from the same source.
+Install **kind** is chosen when the remote install is created or installed via the unified `--org`/`--global` standard — there is no `scope` in the descriptor. `--global` makes a global install (organization_id NULL); `--org "Customer Org"` makes an org install; omitting both installs into your own org. The same descriptor can back global or per-org installs from the same source, but each checkout should be bound to exactly one install while developing.
 
 ---
 
@@ -159,23 +159,24 @@ A solution owns these entities the same way it owns apps and workflows: deploy w
 
 ```bash
 bifrost solution capture <solution-id> --table <id> --form <id> --agent <id> --config <KEY>
-bifrost solution pull --org "Target Org"     # bring captured entities into source .bifrost/
-bifrost solution deploy --org "Target Org"   # ship them
+bifrost solution pull --solution <solution-id>  # bring captured entities into source .bifrost/
+bifrost solution bind --solution <solution-id>  # if this checkout is not already bound
+bifrost solution deploy                         # ship them to the bound install
 ```
 
-(Use the same org target — `--org "Target Org"`, `--global`, or omit for your own org — on `pull` and `deploy` that you used to create the install.)
+(Use the same concrete install id you captured into. Binding keeps `start` and `deploy` stamped to that install.)
 
 The capture flags are singular and repeatable: `--table`, `--form`, `--agent`, `--config`, `--claim`, `--workflow`, `--app` (each takes a name or id; `--config` takes a key).
 
 > **Ordering for a form/agent that references a workflow:** a form's `workflow_id` (and an agent's tool refs) must resolve to a **registered** workflow UUID — i.e. a workflow that has a row. The scaffold's sample (`functions/hello.py::main`) ships with a `.bifrost/workflows.yaml` entry, so it's registered on the **first `bifrost solution deploy`**. A workflow you write yourself is registered the same way: add its `.bifrost/workflows.yaml` entry (see "Write workflows in `functions/`" above), then `bifrost solution deploy` creates the row. So for a fresh solution the order is: write the workflow → add its manifest entry → **`solution deploy`** (creates the workflow row) → create the form/agent referencing that workflow → capture the form/agent (`--form`/`--agent`) → pull → deploy. (Reference the workflow by portable `path::function` ref; a bare name like `hello` can collide, so prefer the full `functions/hello.py::main` ref or the UUID.)
 
-**Which org target to use on `pull`/`deploy`.** `pull` and `deploy` resolve *which install* by `(slug, org)`, where the org comes from the unified `--org` standard (omit = your own org; `--org <uuid|name>` = that org; `--global` = the global install). So:
+**Which install to use on `pull`/`deploy`.** Capture, pull, start, and deploy should all target the same concrete install id. So:
 
-- **Global install** (created with `--global`) → pass `--global` on `pull`/`deploy`.
-- **Install in your own org** → omit the flag; resolution is unambiguous.
-- **Install in a *different* org** (created with `--org "Target Org"`) → pass the **same `--org "Target Org"`** to `pull` and `deploy`. Resolution only looks in the targeted org, so without it `pull`/`deploy` won't find that install (and may resolve a stale same-slug install in your own org instead) — a deploy can keep 409-blocking even after you "pulled".
+- **Bound checkout** → `bifrost solution deploy` uses `.env`.
+- **Different install of the same slug** → run `bifrost solution bind --solution <install-id>` first, or pass `--solution <install-id>` for one command.
+- **Ambiguous slug** → pass the install id instead of the slug.
 
-The rule: pick the org target once (commonly when first deploying a fresh install into a customer's org) and use the **same** target for that install's `pull`/`deploy`. To skip org resolution entirely, pass **`--solution <install-id>`** to target an install by id.
+The rule: pick the install once, bind the workspace, and let the binding stamp every local data-plane call and deploy.
 
 **Scope and capture — the loose entity must already be in the install's scope.** `bifrost solution capture` only adopts loose entities **already in the install's own scope**: an org install captures that org's entities; a global install captures global (`organization_id: null`) entities. The CLI resolves your `--table/--form/...` selectors against the install's **candidate list** (`/capture/candidates`) and refuses anything outside its scope — including by id — with "not in /capture/candidates for its scope". A concrete org-A entity is likewise never capturable into an org-B install (cross-tenant).
 

--- a/plugins/bifrost/skills/bifrost-migrate/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-migrate/SKILL.md
@@ -41,8 +41,8 @@ Before touching code, collect the conventions — they shape every later step:
    `orders_sync_records`). Renames MUST rewrite every ref (this skill does that — see step 6).
 2. **Folder layout.** Default: flat `workflows/` + flat `modules/` (NOT nested "feature" dirs).
    Standardize whatever mess `_repo` is in.
-3. **Which app(s)** to migrate, and the **target Solution** (existing install id, or scaffold a new
-   one with `bifrost solution init`).
+3. **Which app(s)** to migrate, and the **target Solution** (existing install id, or create and bind
+   a new one with `bifrost solution create` / `init`).
 4. **Confirm-in-browser or skip.** Offer to skip the browser-confirm loop once the user trusts the
    output.
 
@@ -74,14 +74,14 @@ Do ONE app at a time, fully, before the next. Each step gates the following.
 
 ### Fast path — `bifrost solution migrate-app` does steps 2–5 deterministically
 
-`migrate-app` (and `scaffold-app`) MUST run from inside a Solution workspace — so create one
-FIRST with `solution init`, then run `migrate-app` from that dir. The SOURCE argument is a real
+`migrate-app` (and `scaffold-app`) MUST run from inside a Solution workspace — so create and bind one
+FIRST with `solution create` (or its `init` alias), then run `migrate-app` from that dir. The SOURCE argument is a real
 filesystem path to the v1 app's source (pull it locally first with `bifrost pull`, or point at a
 local checkout) — NOT a `_repo/...` URL.
 
 ```bash
 mkdir <new-slug>-workspace && cd <new-slug>-workspace
-bifrost solution init . --slug <solution-slug> --name "<Title>" --scope org
+bifrost solution create . --slug <solution-slug> --name "<Title>"
 bifrost solution migrate-app /path/to/v1/apps/<old-slug> <new-slug> --title "<Title>" --api-url <debug-url>
 ```
 This scaffolds the v2 app, ports the v1 `pages/`+`components/` (all source files, incl. `.ts`

--- a/test.sh
+++ b/test.sh
@@ -14,6 +14,9 @@
 #   ./test.sh all                       Unit + e2e (mirrors CI).
 #   ./test.sh tests/path/... [args]     Pass through to pytest.
 #
+# Quality checks:
+#   ./test.sh quality api               Run API pyright + ruff inside Docker.
+#
 # Client tests:
 #   ./test.sh client unit               Vitest on the host (no stack).
 #   ./test.sh client e2e                Playwright in the stack's client container.
@@ -265,6 +268,34 @@ cmd_unit() { run_pytest tests/ --ignore=tests/e2e/ -m "not slow" -v "$@"; }
 cmd_e2e()  { run_pytest tests/e2e/ -v "$@"; }
 cmd_all()  { run_pytest tests/ -v "$@"; }
 
+cmd_quality() {
+    local sub="${1:-}"
+    shift || true
+    case "$sub" in
+        api) quality_api "$@" ;;
+        *)
+            echo "Usage: ./test.sh quality api [args]" >&2
+            exit 2
+            ;;
+    esac
+}
+
+quality_api() {
+    print_project
+
+    if [ "${BIFROST_SKIP_BUILD:-0}" != "1" ]; then
+        docker compose -f "$COMPOSE_FILE" build test-runner
+    else
+        echo "BIFROST_SKIP_BUILD=1 — using pre-built test-runner image from local docker."
+    fi
+
+    chmod 777 "$LOG_DIR" 2>/dev/null || true
+    docker compose -f "$COMPOSE_FILE" --profile test run --rm --no-deps test-runner \
+        sh /app/scripts/quality_api.sh \
+        2>&1 | tee "$LOG_DIR/quality-api.log"
+    return "${PIPESTATUS[0]}"
+}
+
 cmd_client() {
     local sub="${1:-}"
     shift || true
@@ -364,6 +395,7 @@ case "$1" in
     unit) shift; cmd_unit "$@" ;;
     e2e) shift; cmd_e2e "$@" ;;
     all) shift; cmd_all "$@" ;;
+    quality) shift; cmd_quality "$@" ;;
     client) shift; cmd_client "$@" ;;
     ci) cmd_ci ;;
     -h|--help|help)


### PR DESCRIPTION
## Summary
- Make `bifrost solution create` create the local descriptor, create the remote install, and bind the checkout in `.env`; keep `solution init` as a transparent alias.
- Add `bifrost solution bind --solution <id-or-slug>` for cloned/existing Solution workspaces, and make `solution start` / `solution deploy` require a bound install or explicit `--solution` override.
- Stamp local dev proxy/execution with the resolved install id so generated tables/files/config use the Solution scope instead of falling back to global.
- Refresh Codex/Claude Bifrost skill references and plugin mirrors for the new CLI model.
- Add `./test.sh quality api` so pyright/ruff run inside Docker where the repo actually runs.

## Verification
- `./test.sh quality api` passed
- `./test.sh tests/unit/test_compose_test_harness.py -v` passed
- `./test.sh tests/unit/test_codex_mirror_sync.py tests/unit/test_skill_reference_freshness.py tests/unit/test_skill_cli_claims.py -v` passed (`7 passed, 2 skipped`; mirror skip is expected in the test container, direct mirror diffs were checked on host)
- `./test.sh unit` passed (`5081 passed, 2 skipped, 19 deselected`)
- `bash -n test.sh && sh -n api/scripts/quality_api.sh` passed
- `git diff --check` passed
- `python api/scripts/skill-truth/generate.py --check` passed in Docker (`secret_key` warnings only from route mount checks)
- `./test.sh e2e` had one unrelated full-suite failure in `TestMCPConfigToolFiltering::test_delete_resets_to_defaults`; targeted reruns passed:
  - `./test.sh tests/e2e/api-integration/test_mcp_endpoints.py::TestMCPConfigToolFiltering::test_delete_resets_to_defaults -v` passed
  - `./test.sh tests/e2e/api-integration/test_mcp_endpoints.py -v` passed (`22 passed`)
