### PR TITLE
chore(release): bump plugin manifests to 1.0.7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",


### PR DESCRIPTION
## Summary
- Bump Claude and Codex plugin manifests to 1.0.7 before tagging v1.0.7.

## Verification
- `git diff --check` passed
- Diff is limited to `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `plugins/bifrost/.codex-plugin/plugin.json`
