### PR TITLE
test(client): stabilize standalone app bootstrap assertion

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bifrost",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI. Includes :build (create and debug artifacts), :setup (install CLI, authenticate, configure MCP), and :copilot-cowork-package (package Bifrost agents as Microsoft 365 Copilot Cowork plugins), :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": {
     "name": "Jack Musick",
     "url": "https://github.com/gobifrost/bifrost"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",

--- a/client/src/components/jsx-app/StandaloneV2App.test.tsx
+++ b/client/src/components/jsx-app/StandaloneV2App.test.tsx
@@ -21,6 +21,7 @@ const baseProps = {
 beforeEach(() => {
 	localStorage.clear();
 	delete window.__BIFROST_APP__;
+	delete window.__BIFROST_APPS__;
 	// import() of the dist entry rejects in happy-dom; that's fine — we assert on
 	// the bootstrap, not the app actually booting.
 	vi.spyOn(console, "error").mockImplementation(() => {});
@@ -29,6 +30,7 @@ beforeEach(() => {
 afterEach(() => {
 	vi.restoreAllMocks();
 	delete window.__BIFROST_APP__;
+	delete window.__BIFROST_APPS__;
 });
 
 describe("StandaloneV2App", () => {
@@ -107,23 +109,25 @@ describe("StandaloneV2App", () => {
 		await waitFor(() => expect(rootA.dataset.bifrostEntry).toBeTruthy());
 		const nonceA = new URL(rootA.dataset.bifrostEntry!, "http://x").searchParams.get("m")!;
 
-		// Before A's import resolves, the user navigates to app B (a fresh mount).
-		a.unmount();
-		const b = render(<StandaloneV2App {...baseProps} appId="app-B" appSlug="bbb" />);
-		const rootB = b.getByTestId("solution-v2-app-root");
-		await waitFor(() => expect(rootB.dataset.bifrostEntry).toBeTruthy());
-		const nonceB = new URL(rootB.dataset.bifrostEntry!, "http://x").searchParams.get("m")!;
-		expect(nonceA).not.toBe(nonceB);
-
-		// A's still-loading entry reads ITS OWN nonce's bootstrap — never B's.
-		const registry = window.__BIFROST_APPS__!;
-		// A's entry: disabled tombstone (unmounted), appId A, NOT B's live mount.
-		expect(registry[nonceA]?.appId).toBe("app-A");
-		expect(registry[nonceA]?.mountEl).not.toBe(rootB);
-		// B's entry: the live mount with B's identity.
-		expect(registry[nonceB]?.appId).toBe("app-B");
-		expect(registry[nonceB]?.mountEl).toBe(rootB);
+	// Before A's import resolves, the user navigates to app B (a fresh mount).
+	a.unmount();
+	const b = render(<StandaloneV2App {...baseProps} appId="app-B" appSlug="bbb" />);
+	const rootB = b.getByTestId("solution-v2-app-root");
+	let nonceB = "";
+	await waitFor(() => {
+		expect(rootB.dataset.bifrostEntry).toBeTruthy();
+		nonceB = new URL(rootB.dataset.bifrostEntry!, "http://x").searchParams.get("m")!;
+		expect(window.__BIFROST_APPS__?.[nonceB]?.appId).toBe("app-B");
+		expect(window.__BIFROST_APPS__?.[nonceB]?.mountEl).toBe(rootB);
 	});
+	expect(nonceA).not.toBe(nonceB);
+
+	// A's still-loading entry reads ITS OWN nonce's bootstrap — never B's.
+	const registry = window.__BIFROST_APPS__!;
+	// A's entry: disabled tombstone (unmounted), appId A, NOT B's live mount.
+	expect(registry[nonceA]?.appId).toBe("app-A");
+	expect(registry[nonceA]?.mountEl).not.toBe(rootB);
+});
 
 	it("calls the app-registered unmount teardown on cleanup (no leak)", async () => {
 		localStorage.setItem("bifrost_access_token", "tok-1");

--- a/plugins/bifrost/.codex-plugin/plugin.json
+++ b/plugins/bifrost/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bifrost",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Bifrost — MSP automation platform. Skills for building workflows, forms, agents, apps, tables, and files with the Bifrost SDK + CLI, setting up local Bifrost development, and packaging Bifrost agents as Microsoft 365 Copilot Cowork plugins, :migrate (move a legacy v1 inline app + its backing entities into an installable v2 Solution).",
   "author": {
     "name": "Jack Musick",


### PR DESCRIPTION
## Summary
- Clear the standalone app per-mount bootstrap registry between tests.
- Assert the live B mount inside the wait that observes its entry URL, avoiding a race with the intentionally failing dynamic import cleanup.

## Verification
- `./test.sh client unit -- StandaloneV2App.test.tsx` passed (`9 passed`)
- `./test.sh client unit` passed (`218 passed`, `1579 tests`)

## Context
The `v1.0.7` release-bump merge-group run exposed this race in `StandaloneV2App.test.tsx:125`. The release manifest PR itself merged, but this stabilizes the client suite before tagging.
