### PR TITLE
Clarify Bifrost plugin skills and file CLI help

### DIFF
--- a/.claude/skills/bifrost-build/SKILL.md
+++ b/.claude/skills/bifrost-build/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:build
+name: build
 description: Build Bifrost workflows, forms, agents, apps, tables, and files for both Solution workspaces (v2) and the global _repo workspace (v1). Supports SDK-first (local dev + git) and MCP-only modes.
 ---
 

--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -816,7 +816,28 @@ Options:
 ```
 Usage: files [OPTIONS] COMMAND [ARGS]...
 
-  Read, write, list, search workspace files.
+  Read, write, list, search files and manage file policies.
+
+  Without --solution, commands target the global _repo workspace file scope
+  (location "workspace" by default). With --solution <slug|id>,
+  read/write/list target that Solution install's runtime file scope and
+  default the location to "solutions". Solution source files are deployed from
+  the local workspace with `bifrost solution deploy`; `bifrost files
+  --solution ...` is for runtime/user file bytes after install, not for
+  editing deploy-owned source.
+
+  `bifrost files write` writes one explicit file through the Files API. It
+  does not walk a local tree, apply the sync ignore rules, compare server
+  state, or trigger the push/sync TUI. Use `bifrost push`/`sync`/`watch` when
+  local disk is the source of truth for _repo source files; use `files write`
+  for one-off API writes, scripts, or Solution runtime file data.
+
+  Examples:
+    bifrost files list workflows/              # global _repo files
+    bifrost files write notes.txt --content hi # one direct API write
+    bifrost files read apps/desk/pages/App.tsx # global _repo file
+    bifrost files list --solution desk         # Solution runtime files
+    bifrost files read notes/today.txt --solution desk
 
 Options:
   --json  Emit JSON instead of human-readable output.

--- a/.claude/skills/bifrost-copilot-cowork-package/SKILL.md
+++ b/.claude/skills/bifrost-copilot-cowork-package/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:copilot-cowork-package
+name: copilot-cowork-package
 description: |
   Use when the user wants to turn a Bifrost agent into a Microsoft 365 Copilot Cowork
   plugin (.zip with manifest.json + skills/SKILL.md + agentConnectors pointing at the

--- a/.claude/skills/bifrost-migrate/SKILL.md
+++ b/.claude/skills/bifrost-migrate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:migrate
+name: migrate
 description: Migrate a legacy Bifrost v1 (inline) app and its backing entities into a clean, installable v2 Solution. Use when the user wants to move an existing _repo app into Solutions, modernize a v1 inline app to standalone_v2, capture loose workflows/tables/configs into a Solution, or standardize/rename a messy workspace. Trigger phrases — "migrate this app to a solution", "move X into a solution", "v1 to v2", "/migrate", "convert my app to standalone v2", "capture these workflows into a solution".
 ---
 

--- a/.claude/skills/bifrost-setup/SKILL.md
+++ b/.claude/skills/bifrost-setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:setup
+name: setup
 description: Set up Bifrost SDK - install CLI, authenticate, configure MCP server. Use when user needs to get started with Bifrost or has incomplete setup.
 ---
 

--- a/api/bifrost/cli.py
+++ b/api/bifrost/cli.py
@@ -635,14 +635,16 @@ def main(args: list[str] | None = None) -> int:
         print(f"bifrost {__version__}")
         return 0
 
-    _check_cli_version()
+    help_requested = any(a in ("-h", "--help") for a in args)
+    if args[0].lower() == "help" or args[0] in ("-h", "--help"):
+        print_help()
+        return 0
+
+    if not help_requested:
+        _check_cli_version()
 
     try:
         command = args[0].lower()
-
-        if command in ("help", "-h", "--help"):
-            print_help()
-            return 0
 
         if command == "login":
             return handle_login(args[1:])
@@ -739,11 +741,40 @@ Entity mutation commands (see 'bifrost <entity> --help'):
   forms        Manage forms
   agents       Manage AI agents
   apps         Manage applications and dependencies
+  claims       Manage custom claims
   integrations Manage integrations, config schemas, and mappings
   configs      Manage config values
   tables       Manage tables
+  files        Read/write _repo files, Solution runtime files, and file policies
   events       Manage event sources and subscriptions
+  policy-rule  Manage reusable table/file policy rules
   requirements Manage workspace Python requirements.txt (install/list/remove)
+
+Workspace/file targets:
+  _repo source files:
+    bifrost push|pull|sync|watch [path]          # local directory <-> global _repo
+    bifrost files list [path]                    # direct API access to global _repo files
+    bifrost files write <path> --content ...     # one direct API write, no local tree sync
+
+  Solution source files:
+    bifrost solution create --slug <slug>
+    bifrost solution bind --solution <id-or-slug>
+    bifrost solution pull                        # pull captured entity manifests
+    bifrost solution deploy                      # deploy local Solution source
+
+  Solution runtime files:
+    bifrost files list --solution <id-or-slug>   # installed app/workflow file data
+    bifrost files read <path> --solution <id-or-slug>
+
+Push vs files write:
+  bifrost push [path] walks a local file or directory, applies sync ignore rules,
+  compares server state, and uploads source files to global _repo. Use it when
+  local disk is the source of truth. A pushed file lands at the same relative
+  path under _repo, based on the directory where you run the command. To place a
+  file at _repo/workflows/foo.py, run from the workspace root and push
+  workflows/foo.py. `bifrost files write` writes exactly one path through the
+  Files API. Use it for one-off writes, scripts, arbitrary local-to-remote path
+  copies with --from-file, or Solution runtime file data with --solution.
 
 Examples:
   bifrost run workflow.py -w greet
@@ -1795,6 +1826,13 @@ Non-interactive: pass --yes/-y, set BIFROST_NONINTERACTIVE=1, or run without a
 TTY (e.g. in CI) to skip the selection TUI and apply default actions.
 
 Use 'bifrost watch' for continuous file watching.
+A pushed file lands at the same relative path under _repo, based on the
+directory where you run the command. To place a file at _repo/workflows/foo.py,
+run from the workspace root and push workflows/foo.py.
+Use 'bifrost files write <path> --content ...' for a single direct API write
+without walking a local tree or applying sync ignore/diff behavior. To copy a
+local file to an arbitrary remote path, use
+'bifrost files write <remote-path> --from-file <local-file>'.
 
 Examples:
   bifrost push apps/my-app

--- a/api/bifrost/commands/files.py
+++ b/api/bifrost/commands/files.py
@@ -40,7 +40,31 @@ from bifrost.files import files as files_sdk
 
 from .base import entity_group, output_result, pass_resolver, run_async
 
-files_group = entity_group("files", "Read, write, list, search workspace files.")
+_FILES_GROUP_HELP = """Read, write, list, search files and manage file policies.
+
+Without --solution, commands target the global _repo workspace file scope
+(location "workspace" by default). With --solution <slug|id>, read/write/list
+target that Solution install's runtime file scope and default the location to
+"solutions". Solution source files are deployed from the local workspace with
+`bifrost solution deploy`; `bifrost files --solution ...` is for runtime/user
+file bytes after install, not for editing deploy-owned source.
+
+`bifrost files write` writes one explicit file through the Files API. It does
+not walk a local tree, apply the sync ignore rules, compare server state, or
+trigger the push/sync TUI. Use `bifrost push`/`sync`/`watch` when local disk is
+the source of truth for _repo source files; use `files write` for one-off API
+writes, scripts, or Solution runtime file data.
+
+\b
+Examples:
+  bifrost files list workflows/              # global _repo files
+  bifrost files write notes.txt --content hi # one direct API write
+  bifrost files read apps/desk/pages/App.tsx # global _repo file
+  bifrost files list --solution desk         # Solution runtime files
+  bifrost files read notes/today.txt --solution desk
+"""
+
+files_group = entity_group("files", _FILES_GROUP_HELP)
 policies_group = click.Group("policies", help="Manage file access policies.")
 
 

--- a/api/tests/unit/test_cli_surface_smoke.py
+++ b/api/tests/unit/test_cli_surface_smoke.py
@@ -19,7 +19,27 @@ from __future__ import annotations
 import pytest
 from click.testing import CliRunner
 
+from bifrost.cli import main
 from bifrost.commands import ENTITY_GROUPS
+
+
+TOP_LEVEL_COMMANDS = {
+    "sync",
+    "run",
+    "git",
+    "push",
+    "pull",
+    "solution",
+    "deploy",
+    "watch",
+    "api",
+    "migrate-imports",
+    "skill",
+    "login",
+    "logout",
+    "auth",
+    "help",
+}
 
 
 def _group_subcommand_pairs() -> list[tuple[str, str]]:
@@ -68,6 +88,69 @@ def test_every_group_has_json_flag() -> None:
         assert "--json" in result.output, (
             f"{group_name} help does not advertise --json: {result.output}"
         )
+
+
+def test_top_level_help_lists_every_entity_group(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hand-written top-level help must not drift from registered groups."""
+    monkeypatch.setattr("bifrost.cli._check_cli_version", lambda: None)
+    code = main(["--help"])
+    captured = capsys.readouterr()
+    assert code == 0
+    for group_name in sorted(ENTITY_GROUPS):
+        assert f"  {group_name}" in captured.out, (
+            f"top-level help omits registered entity group {group_name!r}"
+        )
+
+
+def test_top_level_help_lists_every_top_level_command(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Top-level command help must stay aligned with main() dispatch."""
+    monkeypatch.setattr("bifrost.cli._check_cli_version", lambda: None)
+    code = main(["--help"])
+    captured = capsys.readouterr()
+    assert code == 0
+    command_section = captured.out.split("Commands:", 1)[1].split("Flags:", 1)[0]
+    for command_name in sorted(TOP_LEVEL_COMMANDS):
+        assert f"  {command_name}" in command_section, (
+            f"top-level help omits command {command_name!r}"
+        )
+
+
+def test_top_level_help_explains_repo_and_solution_file_targets(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Users should be able to discover _repo vs Solution CLI access."""
+    monkeypatch.setattr("bifrost.cli._check_cli_version", lambda: None)
+    code = main(["--help"])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "_repo source files" in captured.out
+    assert "Solution source files" in captured.out
+    assert "Solution runtime files" in captured.out
+    assert "bifrost files list --solution" in captured.out
+    assert "Push vs files write" in captured.out
+    assert "same relative" in captured.out
+    assert "path under _repo" in captured.out
+    assert "writes exactly one" in captured.out
+    assert "arbitrary local-to-remote path" in captured.out
+
+
+def test_nested_help_does_not_check_cli_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nested help must render offline without compatibility probes."""
+    monkeypatch.setattr(
+        "bifrost.cli._check_cli_version",
+        lambda: pytest.fail("help should not check CLI/server compatibility"),
+    )
+    code = main(["files", "--help"])
+    assert code == 0
 
 
 EXPECTED_CRUD_COMMANDS: dict[str, set[str]] = {

--- a/api/tests/unit/test_codex_mirror_sync.py
+++ b/api/tests/unit/test_codex_mirror_sync.py
@@ -13,6 +13,7 @@ and WRITES the two mirror dirs, both writable in-container and on the host.
 """
 
 import hashlib
+import re
 import subprocess
 from pathlib import Path
 
@@ -72,3 +73,23 @@ def test_codex_mirrors_in_sync() -> None:
         "Codex skill mirrors are out of sync with .claude/skills/: "
         f"{', '.join(stale)}.\nRun `scripts/sync-codex-skills.sh` and commit the result."
     )
+
+
+def test_public_plugin_skills_do_not_repeat_plugin_namespace() -> None:
+    """Public Bifrost plugin skills should be named by action only.
+
+    Codex renders plugin display name + skill name. If a bundled skill's
+    frontmatter is already ``bifrost:*``, the UI becomes
+    ``Bifrost: Bifrost: ...``.
+    """
+    public_root = _REPO / "plugins/bifrost/skills"
+    skill_files = sorted(public_root.glob("*/SKILL.md"))
+    assert skill_files, f"no public plugin skills found under {public_root}"
+    for skill_file in skill_files:
+        text = skill_file.read_text(encoding="utf-8")
+        match = re.search(r"^name:\s*(\S+)\s*$", text, flags=re.MULTILINE)
+        assert match is not None, f"{skill_file} has no name frontmatter"
+        assert not match.group(1).startswith("bifrost:"), (
+            f"{skill_file} repeats the plugin namespace in skill name "
+            f"{match.group(1)!r}"
+        )

--- a/plugins/bifrost/skills/bifrost-build/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-build/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:build
+name: build
 description: Build Bifrost workflows, forms, agents, apps, tables, and files for both Solution workspaces (v2) and the global _repo workspace (v1). Supports SDK-first (local dev + git) and MCP-only modes.
 ---
 

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -816,7 +816,28 @@ Options:
 ```
 Usage: files [OPTIONS] COMMAND [ARGS]...
 
-  Read, write, list, search workspace files.
+  Read, write, list, search files and manage file policies.
+
+  Without --solution, commands target the global _repo workspace file scope
+  (location "workspace" by default). With --solution <slug|id>,
+  read/write/list target that Solution install's runtime file scope and
+  default the location to "solutions". Solution source files are deployed from
+  the local workspace with `bifrost solution deploy`; `bifrost files
+  --solution ...` is for runtime/user file bytes after install, not for
+  editing deploy-owned source.
+
+  `bifrost files write` writes one explicit file through the Files API. It
+  does not walk a local tree, apply the sync ignore rules, compare server
+  state, or trigger the push/sync TUI. Use `bifrost push`/`sync`/`watch` when
+  local disk is the source of truth for _repo source files; use `files write`
+  for one-off API writes, scripts, or Solution runtime file data.
+
+  Examples:
+    bifrost files list workflows/              # global _repo files
+    bifrost files write notes.txt --content hi # one direct API write
+    bifrost files read apps/desk/pages/App.tsx # global _repo file
+    bifrost files list --solution desk         # Solution runtime files
+    bifrost files read notes/today.txt --solution desk
 
 Options:
   --json  Emit JSON instead of human-readable output.

--- a/plugins/bifrost/skills/bifrost-copilot-cowork-package/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-copilot-cowork-package/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:copilot-cowork-package
+name: copilot-cowork-package
 description: |
   Use when the user wants to turn a Bifrost agent into a Microsoft 365 Copilot Cowork
   plugin (.zip with manifest.json + skills/SKILL.md + agentConnectors pointing at the

--- a/plugins/bifrost/skills/bifrost-migrate/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-migrate/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:migrate
+name: migrate
 description: Migrate a legacy Bifrost v1 (inline) app and its backing entities into a clean, installable v2 Solution. Use when the user wants to move an existing _repo app into Solutions, modernize a v1 inline app to standalone_v2, capture loose workflows/tables/configs into a Solution, or standardize/rename a messy workspace. Trigger phrases — "migrate this app to a solution", "move X into a solution", "v1 to v2", "/migrate", "convert my app to standalone v2", "capture these workflows into a solution".
 ---
 

--- a/plugins/bifrost/skills/bifrost-setup/SKILL.md
+++ b/plugins/bifrost/skills/bifrost-setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bifrost:setup
+name: setup
 description: Set up Bifrost SDK - install CLI, authenticate, configure MCP server. Use when user needs to get started with Bifrost or has incomplete setup.
 ---
 


### PR DESCRIPTION
## Summary
- rename public Bifrost plugin skill frontmatter to action-only names so Codex renders "Bifrost: Build" instead of "Bifrost: Bifrost: Build"
- document missing CLI entity groups and explain _repo vs Solution file targets
- clarify push vs files write, including same-relative-path push behavior and files write --from-file for exact remote placement

## Tests
- ./test.sh tests/unit/test_cli_surface_smoke.py
- ./test.sh tests/unit/test_cli_surface_smoke.py tests/unit/test_cli_files.py tests/unit/test_codex_mirror_sync.py