### PR TITLE
Repoint docs screenshot pipeline + release skills at gobifrost

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -224,7 +224,7 @@
     "deny": [],
     "ask": [],
     "additionalDirectories": [
-      "~/GitHub/bifrost-integrations-docs/",
+      "~/GitHub/gobifrost/",
       "~/GitHub/gocovi-bifrost-workspace"
     ]
   },

--- a/.claude/skills/bifrost-documentation/SKILL.md
+++ b/.claude/skills/bifrost-documentation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: bifrost-documentation
-description: Refresh the bifrost-integrations-docs site by re-capturing screenshots and (optionally) authoring missing pages. Trigger phrases - "refresh docs", "update screenshots", "/bifrost-documentation", "rebuild docs site". Has three modes - bootstrap (one-shot manifest generation, mandatory first run), diff (default - only refresh entries whose Bifrost source changed), full (re-capture and re-author everything).
+description: Refresh the gobifrost site by re-capturing screenshots and (optionally) authoring missing pages. Trigger phrases - "refresh docs", "update screenshots", "/bifrost-documentation", "rebuild docs site". Has three modes - bootstrap (one-shot manifest generation, mandatory first run), diff (default - only refresh entries whose Bifrost source changed), full (re-capture and re-author everything).
 ---
 
 # Bifrost Documentation Pipeline
 
-Refresh `bifrost-integrations-docs` programmatically: re-capture screenshots, author missing Diátaxis-shaped pages, open a docs PR with a TL;DR.
+Refresh `gobifrost` programmatically: re-capture screenshots, author missing Diátaxis-shaped pages, open a docs PR with a TL;DR.
 
-The docs repo is at `~/GitHub/bifrost-integrations-docs` (or clone it from `git@github.com:jackmusick/bifrost-integrations-docs.git` if missing). The bifrost repo's worktree is the source of truth for the running app.
+The docs repo is at `~/GitHub/gobifrost` (or clone it from `git@github.com:gobifrost/website.git` if missing). The bifrost repo's worktree is the source of truth for the running app.
 
 ## Default behavior — "catch up everything since the last documented commit"
 
@@ -39,13 +39,13 @@ The named modes below are the surgical primitives this default orchestrates. Rea
 ## Workflow
 
 1. **Preflight**
-   - Locate docs repo. Try `~/GitHub/bifrost-integrations-docs` then `/tmp/bifrost-integrations-docs`. If missing, clone to `~/GitHub/`.
+   - Locate docs repo. Try `~/GitHub/gobifrost` then `/tmp/gobifrost`. If missing, clone to `~/GitHub/`.
    - Verify clean tree (`git status --porcelain` empty). If dirty, ask the user to commit/stash before continuing.
    - Pull `main` (`git pull --ff-only origin main`).
    - **Compare last-update timestamps** as a sanity signal:
      ```bash
      BIFROST_LAST=$(cd ~/GitHub/bifrost && git log -1 --format=%cI origin/main)
-     DOCS_LAST=$(cd ~/GitHub/bifrost-integrations-docs && git log -1 --format=%cI origin/main)
+     DOCS_LAST=$(cd ~/GitHub/gobifrost && git log -1 --format=%cI origin/main)
      echo "bifrost: $BIFROST_LAST"
      echo "docs:    $DOCS_LAST"
      ```
@@ -140,7 +140,7 @@ If the user asks for a doc and you can't pick a quadrant in one sentence, ask th
 When you've written a new MDX page and need a screenshot:
 
 1. **Identify the route** in `client/src/App.tsx`. Confirm the route renders empty-state-free with mocked data.
-2. **Find the API endpoints** the page calls. `grep -nE 'apiClient|useQuery' <component>` then look at the route names. For each, write a fixture under `bifrost-integrations-docs/fixtures/`.
+2. **Find the API endpoints** the page calls. `grep -nE 'apiClient|useQuery' <component>` then look at the route names. For each, write a fixture under `gobifrost/fixtures/`.
 3. **Add a manifest entry** to `screenshots.yaml`. **`mocks`, `actions`, `crop`, `callouts`, `fullPage`, `settle_ms` MUST be nested under a `capture:` key — NOT at the entry top level.** The capture spec reads `entry.capture.actions` / `effectiveMocks(entry)` from `capture`; top-level `mocks`/`actions` are silently ignored, which produces a premature screenshot of an empty/loading state that still "passes" (no action ran to fail). Top-level keys are only `id`, `image`, `route`, `auth_as`, `seed`, `external`, `diataxis`, `captured_at`. Always end actions with `wait_for: text="<exact on-page label that only appears once data renders>"` so capture can't fire on the empty state. Mock URLs use playwright glob — include BOTH `**/api/foo` and `**/api/foo?**`. **After capturing, open the PNG and confirm it shows real data, not an empty state** — a passing test does not prove the mock matched.
 4. **Vite proxy collisions:** if the route shares a prefix with a `vite.config.ts` proxy rule (e.g. `/mcp-servers` collides with the `/mcp` rule because of prefix match in dev), use `nav_via: { from: "/", click: "<sidebar-link-text>" }` so the test stack reaches the page via in-app routing instead of hard navigation. For deeper paths after `nav_via`, use the `goto_spa: <path>` action to push the path via the SPA's history without re-triggering proxy rules.
 5. **Capture only the new ids**: `scripts/docs/run-pipeline.sh --ids id1,id2 ...` so existing entries aren't re-run.

--- a/.claude/skills/bifrost-release/SKILL.md
+++ b/.claude/skills/bifrost-release/SKILL.md
@@ -54,7 +54,7 @@ Report: any uncommitted changes, how many commits ahead of origin.
 
 ### 3. Documentation freshness check
 
-Run the helper script — it compares last-commit timestamps on `bifrost` vs `bifrost-integrations-docs` and lists any user-facing files changed since docs were last updated:
+Run the helper script — it compares last-commit timestamps on `bifrost` vs `gobifrost` and lists any user-facing files changed since docs were last updated:
 
 ```bash
 ./scripts/release/check-docs-freshness.sh
@@ -424,7 +424,7 @@ Ask the user:
 cat ~/GitHub/gobifrost/.claude/skills/blog/SKILL.md
 ```
 
-If the file is missing, the gobifrost checkout is stale or absent — `git clone git@github.com:jackmusick/gobifrost.git ~/GitHub/gobifrost` (or `git pull` if it exists) and re-read.
+If the file is missing, the gobifrost checkout is stale or absent — `git clone git@github.com:gobifrost/website.git ~/GitHub/gobifrost` (or `git pull` if it exists) and re-read.
 
 Pass to the skill as **inputs**:
 

--- a/.codex/skills/bifrost-documentation/SKILL.md
+++ b/.codex/skills/bifrost-documentation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: bifrost-documentation
-description: Refresh the bifrost-integrations-docs site by re-capturing screenshots and (optionally) authoring missing pages. Trigger phrases - "refresh docs", "update screenshots", "/bifrost-documentation", "rebuild docs site". Has three modes - bootstrap (one-shot manifest generation, mandatory first run), diff (default - only refresh entries whose Bifrost source changed), full (re-capture and re-author everything).
+description: Refresh the gobifrost site by re-capturing screenshots and (optionally) authoring missing pages. Trigger phrases - "refresh docs", "update screenshots", "/bifrost-documentation", "rebuild docs site". Has three modes - bootstrap (one-shot manifest generation, mandatory first run), diff (default - only refresh entries whose Bifrost source changed), full (re-capture and re-author everything).
 ---
 
 # Bifrost Documentation Pipeline
 
-Refresh `bifrost-integrations-docs` programmatically: re-capture screenshots, author missing Diátaxis-shaped pages, open a docs PR with a TL;DR.
+Refresh `gobifrost` programmatically: re-capture screenshots, author missing Diátaxis-shaped pages, open a docs PR with a TL;DR.
 
-The docs repo is at `~/GitHub/bifrost-integrations-docs` (or clone it from `git@github.com:jackmusick/bifrost-integrations-docs.git` if missing). The bifrost repo's worktree is the source of truth for the running app.
+The docs repo is at `~/GitHub/gobifrost` (or clone it from `git@github.com:gobifrost/website.git` if missing). The bifrost repo's worktree is the source of truth for the running app.
 
 ## Default behavior — "catch up everything since the last documented commit"
 
@@ -39,13 +39,13 @@ The named modes below are the surgical primitives this default orchestrates. Rea
 ## Workflow
 
 1. **Preflight**
-   - Locate docs repo. Try `~/GitHub/bifrost-integrations-docs` then `/tmp/bifrost-integrations-docs`. If missing, clone to `~/GitHub/`.
+   - Locate docs repo. Try `~/GitHub/gobifrost` then `/tmp/gobifrost`. If missing, clone to `~/GitHub/`.
    - Verify clean tree (`git status --porcelain` empty). If dirty, ask the user to commit/stash before continuing.
    - Pull `main` (`git pull --ff-only origin main`).
    - **Compare last-update timestamps** as a sanity signal:
      ```bash
      BIFROST_LAST=$(cd ~/GitHub/bifrost && git log -1 --format=%cI origin/main)
-     DOCS_LAST=$(cd ~/GitHub/bifrost-integrations-docs && git log -1 --format=%cI origin/main)
+     DOCS_LAST=$(cd ~/GitHub/gobifrost && git log -1 --format=%cI origin/main)
      echo "bifrost: $BIFROST_LAST"
      echo "docs:    $DOCS_LAST"
      ```
@@ -140,7 +140,7 @@ If the user asks for a doc and you can't pick a quadrant in one sentence, ask th
 When you've written a new MDX page and need a screenshot:
 
 1. **Identify the route** in `client/src/App.tsx`. Confirm the route renders empty-state-free with mocked data.
-2. **Find the API endpoints** the page calls. `grep -nE 'apiClient|useQuery' <component>` then look at the route names. For each, write a fixture under `bifrost-integrations-docs/fixtures/`.
+2. **Find the API endpoints** the page calls. `grep -nE 'apiClient|useQuery' <component>` then look at the route names. For each, write a fixture under `gobifrost/fixtures/`.
 3. **Add a manifest entry** to `screenshots.yaml`. **`mocks`, `actions`, `crop`, `callouts`, `fullPage`, `settle_ms` MUST be nested under a `capture:` key — NOT at the entry top level.** The capture spec reads `entry.capture.actions` / `effectiveMocks(entry)` from `capture`; top-level `mocks`/`actions` are silently ignored, which produces a premature screenshot of an empty/loading state that still "passes" (no action ran to fail). Top-level keys are only `id`, `image`, `route`, `auth_as`, `seed`, `external`, `diataxis`, `captured_at`. Always end actions with `wait_for: text="<exact on-page label that only appears once data renders>"` so capture can't fire on the empty state. Mock URLs use playwright glob — include BOTH `**/api/foo` and `**/api/foo?**`. **After capturing, open the PNG and confirm it shows real data, not an empty state** — a passing test does not prove the mock matched.
 4. **Vite proxy collisions:** if the route shares a prefix with a `vite.config.ts` proxy rule (e.g. `/mcp-servers` collides with the `/mcp` rule because of prefix match in dev), use `nav_via: { from: "/", click: "<sidebar-link-text>" }` so the test stack reaches the page via in-app routing instead of hard navigation. For deeper paths after `nav_via`, use the `goto_spa: <path>` action to push the path via the SPA's history without re-triggering proxy rules.
 5. **Capture only the new ids**: `scripts/docs/run-pipeline.sh --ids id1,id2 ...` so existing entries aren't re-run.

--- a/.codex/skills/bifrost-release/SKILL.md
+++ b/.codex/skills/bifrost-release/SKILL.md
@@ -54,7 +54,7 @@ Report: any uncommitted changes, how many commits ahead of origin.
 
 ### 3. Documentation freshness check
 
-Run the helper script — it compares last-commit timestamps on `bifrost` vs `bifrost-integrations-docs` and lists any user-facing files changed since docs were last updated:
+Run the helper script — it compares last-commit timestamps on `bifrost` vs `gobifrost` and lists any user-facing files changed since docs were last updated:
 
 ```bash
 ./scripts/release/check-docs-freshness.sh
@@ -424,7 +424,7 @@ Ask the user:
 cat ~/GitHub/gobifrost/.claude/skills/blog/SKILL.md
 ```
 
-If the file is missing, the gobifrost checkout is stale or absent — `git clone git@github.com:jackmusick/gobifrost.git ~/GitHub/gobifrost` (or `git pull` if it exists) and re-read.
+If the file is missing, the gobifrost checkout is stale or absent — `git clone git@github.com:gobifrost/website.git ~/GitHub/gobifrost` (or `git pull` if it exists) and re-read.
 
 Pass to the skill as **inputs**:
 

--- a/client/e2e/docs/manifest.ts
+++ b/client/e2e/docs/manifest.ts
@@ -2,7 +2,7 @@
  * Read and validate the docs screenshot manifest from the mounted docs repo.
  *
  * The same shape is enforced by the Zod schema in
- * `bifrost-integrations-docs/scripts/manifest/schema.mjs`. We don't import
+ * `gobifrost/scripts/manifest/schema.mjs`. We don't import
  * Zod here to keep the playwright-runner image lean — light validation
  * inside the capture spec is enough; the docs repo's `npm run lint:manifest`
  * is where strict validation happens.

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -111,7 +111,7 @@ export default defineConfig({
 
 		// =============================================================
 		// Docs screenshot pipeline (.docs.spec.ts files)
-		// Drives the screenshots.yaml manifest in bifrost-integrations-docs
+		// Drives the screenshots.yaml manifest in gobifrost
 		// to capture full-page screenshots, with sharp-based crop/callout
 		// post-processing. Per-entry auth is handled inside the spec via
 		// ensureAuthenticated() so a single project can capture under

--- a/docker-compose.docs.yml
+++ b/docker-compose.docs.yml
@@ -1,11 +1,11 @@
 # Docs-screenshot pipeline overlay for docker-compose.test.yml.
 #
-# Mounts the bifrost-integrations-docs checkout into the playwright-runner
+# Mounts the gobifrost checkout into the playwright-runner
 # at /docs so the .docs.spec.ts capture spec can read screenshots.yaml and
 # write PNGs directly into src/assets/.
 #
 # Usage:
-#   DOCS_REPO_PATH=/abs/path/to/bifrost-integrations-docs \
+#   DOCS_REPO_PATH=/abs/path/to/gobifrost \
 #     docker compose -f docker-compose.test.yml -f docker-compose.docs.yml \
 #       --profile client run --rm playwright-runner \
 #       npx playwright test --project=docs

--- a/scripts/docs/bootstrap-manifest.mjs
+++ b/scripts/docs/bootstrap-manifest.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * Bootstrap a screenshots.yaml manifest for the bifrost-integrations-docs site.
+ * Bootstrap a screenshots.yaml manifest for the gobifrost site.
  *
  * Inputs:
- *   --docs-repo <path>    path to bifrost-integrations-docs checkout
+ *   --docs-repo <path>    path to gobifrost checkout
  *   --bifrost-repo <path> path to this bifrost checkout (defaults to script's repo)
  *   --force               overwrite existing screenshots.yaml
  *

--- a/scripts/docs/package.json
+++ b/scripts/docs/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "version": "0.0.1",
-  "description": "Tooling for the bifrost-integrations-docs screenshot pipeline.",
+  "description": "Tooling for the gobifrost screenshot pipeline.",
   "dependencies": {
     "js-yaml": "^4.2.0",
     "pixelmatch": "^7.1.0",

--- a/scripts/release/check-docs-freshness.sh
+++ b/scripts/release/check-docs-freshness.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Compare last-commit timestamps between bifrost and bifrost-integrations-docs.
+# Compare last-commit timestamps between bifrost and gobifrost.
 # Print drift summary and list user-facing files changed since docs were last updated.
 #
 # Used by the bifrost-release skill (Step 3 dev push, Step 1b full release) to
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 BIFROST_REPO="${BIFROST_REPO:-$HOME/GitHub/bifrost}"
-DOCS_REPO="${DOCS_REPO:-$HOME/GitHub/bifrost-integrations-docs}"
+DOCS_REPO="${DOCS_REPO:-$HOME/GitHub/gobifrost}"
 
 # User-facing surface area. Add to this list when introducing new dirs that
 # affect what's visible in docs/screenshots. Patterns are anchored regex
@@ -35,7 +35,7 @@ fi
 
 if [ ! -d "$DOCS_REPO/.git" ]; then
     echo "warn: docs repo not found at $DOCS_REPO" >&2
-    echo "      clone it: git clone git@github.com:jackmusick/bifrost-integrations-docs.git $DOCS_REPO" >&2
+    echo "      clone it: git clone git@github.com:gobifrost/website.git $DOCS_REPO" >&2
     exit 2
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -344,7 +344,7 @@ client_e2e() {
 client_docs() {
     require_stack_up
     if [ -z "${DOCS_REPO_PATH:-}" ]; then
-        echo "DOCS_REPO_PATH must be set to the absolute path of the bifrost-integrations-docs checkout." >&2
+        echo "DOCS_REPO_PATH must be set to the absolute path of the gobifrost checkout." >&2
         exit 2
     fi
     if [ ! -f "$DOCS_REPO_PATH/screenshots.yaml" ]; then


### PR DESCRIPTION
The docs content moved from `bifrost-integrations-docs` into the gobifrost site repo (`github.com/gobifrost/website`, checked out at `~/GitHub/gobifrost`), which now owns `screenshots.yaml`, `fixtures/`, and `npm run lint:manifest`.

This repoints all **non-historical** references at gobifrost:
- `.claude/` + `.codex/` `bifrost-documentation` & `bifrost-release` skills
- `scripts/release/check-docs-freshness.sh` (`DOCS_REPO` default + clone URL)
- `scripts/docs/bootstrap-manifest.mjs`, `scripts/docs/package.json`
- `client/e2e/docs/manifest.ts`, `client/playwright.config.ts` (comments)
- `docker-compose.docs.yml`, `test.sh`, `.claude/settings.local.json`

Replacements:
- `bifrost-integrations-docs` → `gobifrost` / `~/GitHub/gobifrost`
- `jackmusick/bifrost-integrations-docs.git` → `gobifrost/website.git`
- stale `jackmusick/gobifrost.git` → `gobifrost/website.git`

Pipeline logic is unchanged — it's path-parameterized via `DOCS_REPO_PATH` / `--docs-repo`. Historical `docs/plans` and specs left as-is (dated records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)