### PR TITLE
Fix solution local runtime regressions

### DIFF
--- a/.claude/skills/bifrost-build/references/solutions.md
+++ b/.claude/skills/bifrost-build/references/solutions.md
@@ -96,6 +96,7 @@ These names become policy-addressable file locations for the install. They are t
 - Use business/domain names (`finance`, `documents`, `attachments`), not platform internals.
 - Do not declare `workspace`; it is reserved.
 - Do not create or manage `_solutions/` or `_solution_artifacts/` folders yourself. Those are internal storage prefixes for deployed source and export artifacts.
+- Deploy seeds each declared location with a solution-scoped root `admin_bypass` file policy so platform admins can seed and maintain runtime files. This does not grant ordinary app users access; add explicit file policies for non-admin read/write/list/delete behavior.
 - Runtime files are read and written through the Files SDK (`files`, `useFiles`) or the Files CLI/API with `--solution <install-id-or-slug>`. They are not source files under `apps/` or `functions/`.
 
 ### 6. Install from a zip

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -98,10 +98,11 @@ COPY client/src/lib/app-sdk/provider.tsx \
      client/src/lib/app-sdk/bifrost-header.tsx \
      /app/src/services/sdk_package/sdk_src/
 COPY client/src/lib/app-sdk/index.v2.ts /app/src/services/sdk_package/sdk_src/index.ts
+RUN chmod -R a+rX /app/src/services/sdk_package
 
 # Copy entrypoint script
 COPY api/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
 
 # Don't switch to bifrost here - entrypoint handles user switching
 # This allows the entrypoint to fix volume permissions when needed

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -66,7 +66,7 @@ def _join_upstream(base_url: str, rel_url: yarl.URL) -> str:
     # (scheme://host[:port]) followed by a path. re.fullmatch on an
     # origin-prefixed pattern is the SSRF barrier static analysis recognizes,
     # and it genuinely rejects any authority the request managed to inject.
-    origin = f"{base.scheme}://{base.raw_host}" + (f":{base.port}" if base.port else "")
+    origin = str(base.origin())
     if not re.fullmatch(re.escape(origin) + r"(?:/.*)?", result, re.DOTALL):
         raise _UpstreamAuthorityError(f"proxy target {result!r} escapes upstream {origin!r}")
     return result

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -2589,6 +2589,16 @@ def _to_pep440(version: str) -> str:
     if dirty:
         v = v[: -len("-dirty")]
 
+    # Bifrost release tags use a semver-ish dev release shape
+    # (e.g. "1.0.8-dev.11"). Preserve the actual release instead of treating it
+    # as a no-tag git hash fallback, which makes package tools report
+    # "0.0.0+g1.0.8.dev.11".
+    m = _re.match(r"^(\d+(?:\.\d+)*)-dev\.(\d+)$", v)
+    if m:
+        base, n = m.group(1), m.group(2)
+        pep = f"{base}.dev{n}"
+        return f"{pep}+dirty" if dirty else pep
+
     # Shape: <tag>-<N>-g<sha>
     m = _re.match(r"^(.+)-(\d+)-(g[0-9a-f]+)$", v)
     if m:

--- a/api/src/services/solutions/deploy.py
+++ b/api/src/services/solutions/deploy.py
@@ -31,6 +31,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4, uuid5
 
+from pydantic import ValidationError
 from sqlalchemy import delete, insert, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -872,7 +873,13 @@ class SolutionDeployer:
             seen_names.add(nm)
 
         for mtbl in tables:
-            mtbl_model = ManifestTable(**mtbl)
+            table_label = str(mtbl.get("name") or mtbl.get("id") or "<unknown>")
+            try:
+                mtbl_model = ManifestTable(**mtbl)
+            except ValidationError as exc:
+                raise SolutionDeployConflict(
+                    f"table {table_label!r} manifest invalid: {exc}"
+                ) from exc
             src = mtbl_model.to_orm_values(Destination.INSTALL).direct
             tbl_id = UUID(mtbl["id"])
             name = src["name"]
@@ -882,7 +889,12 @@ class SolutionDeployer:
             policies = mtbl.get("policies")
             if policies is not None:
                 access = {"policies": policies}
-                policy_model = TablePolicies.model_validate(access)  # raises on a bad AST
+                try:
+                    policy_model = TablePolicies.model_validate(access)
+                except ValidationError as exc:
+                    raise SolutionDeployConflict(
+                        f"table {name!r} policies invalid: {exc}"
+                    ) from exc
                 from src.routers.tables import _validate_table_policy_claim_refs
 
                 try:

--- a/api/src/services/solutions/file_locations.py
+++ b/api/src/services/solutions/file_locations.py
@@ -7,8 +7,10 @@ from uuid import UUID
 from sqlalchemy import delete, insert, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.models.orm.file_metadata import FileMetadata
+from shared.file_policies_seed import make_seed_admin_bypass_file
+from src.models.orm.file_metadata import FileMetadata, FilePolicy
 from src.models.orm.solution_file_location import SolutionFileLocation
+from src.models.orm.solutions import Solution
 
 
 def normalize_file_locations(
@@ -45,6 +47,11 @@ async def reconcile_solution_file_locations(
     make_error: Callable[[str], Exception] = ValueError,
 ) -> list[str]:
     declared = normalize_file_locations(locations, make_error=make_error)
+    organization_id = (
+        await db.execute(
+            select(Solution.organization_id).where(Solution.id == solution_id)
+        )
+    ).scalar_one_or_none()
     existing = set(
         (
             await db.execute(
@@ -75,6 +82,25 @@ async def reconcile_solution_file_locations(
                     position=position,
                 )
             )
+        existing_policy = (
+            await db.execute(
+                select(FilePolicy.id).where(
+                    FilePolicy.solution_id == solution_id,
+                    FilePolicy.location == location,
+                    FilePolicy.path == "",
+                )
+            )
+        ).scalar_one_or_none()
+        if existing_policy is None:
+            await db.execute(
+                insert(FilePolicy).values(
+                    organization_id=organization_id,
+                    solution_id=solution_id,
+                    location=location,
+                    path="",
+                    policies=make_seed_admin_bypass_file(),
+                )
+            )
 
     stale = existing - set(declared)
     for location in sorted(stale):
@@ -94,6 +120,12 @@ async def reconcile_solution_file_locations(
             )
 
     if stale:
+        await db.execute(
+            delete(FilePolicy).where(
+                FilePolicy.solution_id == solution_id,
+                FilePolicy.location.in_(stale),
+            )
+        )
         await db.execute(
             delete(SolutionFileLocation).where(
                 SolutionFileLocation.solution_id == solution_id,

--- a/api/tests/unit/routers/test_cli_download_version.py
+++ b/api/tests/unit/routers/test_cli_download_version.py
@@ -1,0 +1,12 @@
+"""CLI download package version normalization."""
+
+from src.routers.cli import _to_pep440
+
+
+def test_to_pep440_preserves_dev_release_versions() -> None:
+    assert _to_pep440("1.0.8-dev.11") == "1.0.8.dev11"
+    assert _to_pep440("v1.0.8-dev.11") == "1.0.8.dev11"
+
+
+def test_to_pep440_preserves_dirty_dev_release_versions() -> None:
+    assert _to_pep440("1.0.8-dev.11-dirty") == "1.0.8.dev11+dirty"

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -45,6 +45,37 @@ def test_join_upstream_preserves_flag_style_query():
     assert _join_upstream(base, yarl.URL("/api/x?a=1&b=2")) == "http://127.0.0.1:8000/api/x?a=1&b=2"
 
 
+def test_join_upstream_accepts_default_ports_without_rewriting_origin():
+    """Default HTTP/HTTPS ports are same-origin whether explicit or implicit."""
+    assert (
+        _join_upstream("https://bifrost.gocovi.com", yarl.URL("/api/auth/me"))
+        == "https://bifrost.gocovi.com/api/auth/me"
+    )
+    assert (
+        _join_upstream("https://bifrost.gocovi.com:443", yarl.URL("/api/auth/me"))
+        == "https://bifrost.gocovi.com/api/auth/me"
+    )
+    assert (
+        _join_upstream("http://localhost", yarl.URL("/api/auth/me"))
+        == "http://localhost/api/auth/me"
+    )
+    assert (
+        _join_upstream("http://localhost:80", yarl.URL("/api/auth/me"))
+        == "http://localhost/api/auth/me"
+    )
+
+
+def test_join_upstream_retains_non_default_ports():
+    assert (
+        _join_upstream("http://localhost:8080", yarl.URL("/api/auth/me"))
+        == "http://localhost:8080/api/auth/me"
+    )
+    assert (
+        _join_upstream("https://example.test:8443", yarl.URL("/api/auth/me"))
+        == "https://example.test:8443/api/auth/me"
+    )
+
+
 def _free_port() -> int:
     s = socket.socket()
     s.bind(("127.0.0.1", 0))

--- a/api/tests/unit/test_solution_file_locations.py
+++ b/api/tests/unit/test_solution_file_locations.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy import select
 
 from bifrost.manifest import Manifest, ManifestFiles
-from src.models.orm.file_metadata import FileMetadata
+from src.models.orm.file_metadata import FileMetadata, FilePolicy
 from src.models.orm.solution_file_location import SolutionFileLocation
 from src.models.orm.solutions import Solution
 from src.services.manifest_import import ManifestResolver
@@ -43,6 +43,17 @@ async def _locations(db, solution_id) -> list[tuple[str, int]]:
     return [(row.location, row.position) for row in rows]
 
 
+async def _file_policies(db, solution_id) -> list[tuple[str, str, dict]]:
+    rows = (
+        await db.execute(
+            select(FilePolicy)
+            .where(FilePolicy.solution_id == solution_id)
+            .order_by(FilePolicy.location, FilePolicy.path)
+        )
+    ).scalars().all()
+    return [(row.location, row.path, row.policies) for row in rows]
+
+
 async def test_deploy_persists_and_reconciles_file_locations(db_session) -> None:
     sol = await _make_solution(db_session)
     deployer = SolutionDeployer(db_session)
@@ -61,6 +72,20 @@ async def test_deploy_persists_and_reconciles_file_locations(db_session) -> None
     await db_session.flush()
 
     assert await _locations(db_session, sol.id) == [("invoices", 0)]
+
+
+async def test_deploy_seeds_solution_file_location_admin_policy(db_session) -> None:
+    sol = await _make_solution(db_session)
+
+    await SolutionDeployer(db_session).deploy(
+        SolutionBundle(solution=sol, file_locations=["reports", "invoices"])
+    )
+    await db_session.flush()
+
+    assert await _file_policies(db_session, sol.id) == [
+        ("invoices", "", {"policies": [{"$ref": "admin_bypass"}]}),
+        ("reports", "", {"policies": [{"$ref": "admin_bypass"}]}),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/api/tests/unit/test_solution_table_deploy.py
+++ b/api/tests/unit/test_solution_table_deploy.py
@@ -135,14 +135,32 @@ class TestSolutionTableDeploy:
         ).scalars().all()
         assert set(rows) == {"row-1", "row-2"}
 
-    async def test_malformed_policy_is_rejected_at_deploy(self, db_session) -> None:
-        """A bad policy AST is rejected at deploy, not stored to fail at read
-        time (Codex Sub-plan 3 P2)."""
+    async def test_malformed_policy_manifest_is_rejected_at_deploy(self, db_session) -> None:
+        """A malformed policy entry is rejected as a deploy conflict, not a raw
+        Pydantic validation error."""
         db = db_session
         sol = await self._install(db)
         tid = str(uuid.uuid4())
         bad = {"id": tid, "name": "bad", "schema": {}, "policies": [{"not_a_real_op": 123}]}
-        with pytest.raises(Exception):
+        with pytest.raises(SolutionDeployConflict, match="table 'bad' manifest invalid"):
+            await SolutionDeployer(db).deploy(SolutionBundle(solution=sol, tables=[bad]))
+        await db.rollback()
+
+    async def test_invalid_policy_ast_is_rejected_at_deploy(self, db_session) -> None:
+        """A policy shape accepted by the manifest but rejected by TablePolicies
+        gets a table-specific deploy error instead of a generic async job error."""
+        db = db_session
+        sol = await self._install(db)
+        tid = str(uuid.uuid4())
+        bad = {
+            "id": tid,
+            "name": "bad",
+            "schema": {},
+            "policies": [
+                {"name": "auth", "actions": ["read"], "when": {"user": "is_authenticated"}}
+            ],
+        }
+        with pytest.raises(SolutionDeployConflict, match="table 'bad' policies invalid"):
             await SolutionDeployer(db).deploy(SolutionBundle(solution=sol, tables=[bad]))
         await db.rollback()
 

--- a/plugins/bifrost/skills/bifrost-build/references/solutions.md
+++ b/plugins/bifrost/skills/bifrost-build/references/solutions.md
@@ -96,6 +96,7 @@ These names become policy-addressable file locations for the install. They are t
 - Use business/domain names (`finance`, `documents`, `attachments`), not platform internals.
 - Do not declare `workspace`; it is reserved.
 - Do not create or manage `_solutions/` or `_solution_artifacts/` folders yourself. Those are internal storage prefixes for deployed source and export artifacts.
+- Deploy seeds each declared location with a solution-scoped root `admin_bypass` file policy so platform admins can seed and maintain runtime files. This does not grant ordinary app users access; add explicit file policies for non-admin read/write/list/delete behavior.
 - Runtime files are read and written through the Files SDK (`files`, `useFiles`) or the Files CLI/API with `--solution <install-id-or-slug>`. They are not source files under `apps/` or `functions/`.
 
 ### 6. Install from a zip


### PR DESCRIPTION
## Summary
- Fix local Solution proxy upstream authority checks for default HTTPS ports, which unblocked prod-backed local workflows and table reads.
- Seed solution-scoped root admin-bypass file policies for declared Solution file locations, while preserving explicit policy requirements for non-admin access.
- Improve Solution deploy validation for malformed table policy manifests and preserve CLI dev version metadata.
- Fix dev/test image permissions for `/entrypoint.sh` and packaged SDK source files discovered during verification.
- Update the Bifrost build skill reference for Solution-declared file location policy behavior.

## Live Repro / Confirmation
- Reproduced the proxy authority failure with CRM prod-backed `solution start`; confirmed `/api/auth/me`, table queries, and `functions/mna_crm.py::dashboard` execute after the fix.
- Confirmed Lilly and RTM local table reads after the proxy fix.
- Reproduced RTM seed file write 403; confirmed declared Solution file locations now get a solution-scoped root `admin_bypass` file policy.
- Reproduced invalid table policy deploy as an unhelpful failure; confirmed deploy now reports table-specific policy validation errors.
- Confirmed Vite orphan process issue was not reproducible with current process-group termination behavior.

## Tests
- `./test.sh tests/unit/test_solution_dev_proxy.py -q`
- `./test.sh tests/unit/test_solution_file_locations.py -q`
- `./test.sh tests/unit/test_solution_table_deploy.py::TestSolutionTableDeploy::test_malformed_policy_manifest_is_rejected_at_deploy tests/unit/test_solution_table_deploy.py::TestSolutionTableDeploy::test_invalid_policy_ast_is_rejected_at_deploy -q`
- `./test.sh tests/unit/routers/test_cli_download_version.py -q`
- `./test.sh tests/e2e/api/test_builtin_events.py -q`
- `./test.sh tests/unit/test_sdk_package.py::test_build_sdk_tarball_shape_and_exports tests/unit/test_solution_app_build.py::test_build_runs_vite_when_no_prebuilt_dist -q`
- `./test.sh all` -> `6778 passed, 55 skipped`
- `./test.sh quality api` -> pyright `0 errors`; ruff `All checks passed`
- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/bifrost-build`
- `git diff --check HEAD~1..HEAD`
