### PR TITLE
Fix solution local targeting gaps

### DIFF
--- a/api/bifrost/events.py
+++ b/api/bifrost/events.py
@@ -15,7 +15,7 @@ Usage:
 from __future__ import annotations
 
 from .client import get_client, raise_for_status_with_detail
-from ._context import resolve_scope
+from ._context import resolve_scope, _execution_context
 
 
 class events:
@@ -52,9 +52,14 @@ class events:
         """
         client = get_client()
         resolved = resolve_scope(scope)
+        ctx = _execution_context.get()
+        solution_id = getattr(ctx, "solution_id", None) if ctx is not None else None
+        payload = {"topic": topic, "data": data, "scope": resolved}
+        if solution_id:
+            payload["solution"] = str(solution_id)
         response = await client.post(
             "/api/events/emit",
-            json={"topic": topic, "data": data, "scope": resolved},
+            json=payload,
         )
         raise_for_status_with_detail(response)
         return response.json()

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -32,7 +32,14 @@ import yarl
 from aiohttp import web
 
 # Hop-by-hop headers we must not forward when reverse-proxying.
-_STRIP = {"host", "content-length", "transfer-encoding", "connection", "keep-alive"}
+_STRIP = {
+    "host",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+    "keep-alive",
+    "accept-encoding",
+}
 
 
 class _UpstreamAuthorityError(ValueError):
@@ -110,6 +117,7 @@ def build_dev_app(cfg: DevProxyConfig, host, vite_url: str) -> web.Application:
 def _auth_headers(cfg: DevProxyConfig, incoming) -> dict[str, str]:
     headers = {k: v for k, v in incoming.items() if k.lower() not in _STRIP}
     headers["Authorization"] = f"Bearer {cfg.token}"
+    headers["Accept-Encoding"] = "identity"
     if cfg.org_id:
         headers["X-Bifrost-Org"] = cfg.org_id
     headers["X-Bifrost-App"] = cfg.app_id

--- a/api/bifrost/workflows.py
+++ b/api/bifrost/workflows.py
@@ -119,7 +119,7 @@ class workflows:
         if scheduled_at is not None and scheduled_at.tzinfo is None:
             raise ValueError("'scheduled_at' must be timezone-aware")
 
-        from ._context import get_default_scope
+        from ._context import get_default_scope, _execution_context
 
         # Auto-include org_id from execution context if not explicitly provided,
         # same as tables, config, etc.
@@ -132,6 +132,10 @@ class workflows:
             "input_data": input_data or {},
             "sync": False,
         }
+        ctx = _execution_context.get()
+        solution_id = getattr(ctx, "solution_id", None) if ctx is not None else None
+        if solution_id:
+            payload["solution_id"] = str(solution_id)
         if org_id is not None:
             payload["org_id"] = org_id
         if run_as is not None:

--- a/api/src/models/contracts/events.py
+++ b/api/src/models/contracts/events.py
@@ -668,6 +668,10 @@ class EmitEventRequest(BaseModel):
         default=None,
         description="Organization scope: org UUID string or None for GLOBAL.",
     )
+    solution: str | None = Field(
+        default=None,
+        description="Solution install id from the execution context. When set, topic lookup resolves this install's event source before _repo sources.",
+    )
 
 
 class EmitEventResponse(BaseModel):

--- a/api/src/repositories/events.py
+++ b/api/src/repositories/events.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import case, delete, func, select
 from sqlalchemy.orm import joinedload, selectinload
 
 from src.models.enums import EventDeliveryStatus, EventSourceType, EventStatus
@@ -169,14 +169,31 @@ class EventSourceRepository(BaseRepository[EventSource]):
         result = await self.session.execute(stmt)
         return result.scalar() or 0
 
-    async def get_by_topic(self, topic: str) -> EventSource | None:
-        """Get an active topic EventSource by its event_type string."""
-        result = await self.session.execute(
+    async def get_by_topic(
+        self, topic: str, *, solution_id: UUID | None = None
+    ) -> EventSource | None:
+        """Get an active topic EventSource by event_type.
+
+        Solution callers resolve their own install first, then _repo sources.
+        Loose callers must not accidentally select a solution-managed row.
+        """
+        stmt = (
             select(EventSource)
             .where(EventSource.source_type == EventSourceType.TOPIC)
             .where(EventSource.event_type == topic)
             .where(EventSource.is_active.is_(True))
         )
+        if solution_id is not None:
+            stmt = stmt.where(
+                (EventSource.solution_id == solution_id)
+                | (EventSource.solution_id.is_(None))
+            ).order_by(
+                case((EventSource.solution_id == solution_id, 0), else_=1)
+            )
+        else:
+            stmt = stmt.where(EventSource.solution_id.is_(None))
+
+        result = await self.session.execute(stmt)
         return result.unique().scalar_one_or_none()
 
     async def get_distinct_topic_types(self) -> list[str]:

--- a/api/src/routers/events.py
+++ b/api/src/routers/events.py
@@ -1043,6 +1043,7 @@ async def list_events(
 )
 async def emit_topic_event(
     request: EmitEventRequest,
+    ctx: Context,
     user: CurrentSuperuser,
 ) -> EmitEventResponse:
     """Emit a topic event and return the event_id and subscriber count."""
@@ -1064,10 +1065,22 @@ async def emit_topic_event(
                 detail=f"Invalid scope: must be a UUID or 'GLOBAL', got '{request.scope}'",
             )
 
+    solution_id: UUID | None = None
+    requested_solution = request.solution or ctx.solution_id
+    if requested_solution:
+        try:
+            solution_id = UUID(str(requested_solution))
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid solution: must be a UUID, got '{requested_solution}'",
+            )
+
     event_id, subscribers_notified = await emit_event(
         request.topic,
         request.data,
         organization_id=organization_id,
+        solution_id=solution_id,
         triggered_by=str(user.user_id),
     )
 

--- a/api/src/services/events/__init__.py
+++ b/api/src/services/events/__init__.py
@@ -16,6 +16,7 @@ async def emit_event(
     data: dict,
     *,
     organization_id: UUID | None = None,
+    solution_id: UUID | None = None,
     triggered_by: str | None = None,
 ) -> tuple[UUID, int]:
     """Emit a topic event and return (event_id, subscribers_notified).
@@ -33,6 +34,7 @@ async def emit_event(
             topic=topic,
             data=data,
             organization_id=organization_id,
+            solution_id=solution_id,
             triggered_by=triggered_by,
         )
         if count > 0:

--- a/api/src/services/events/processor.py
+++ b/api/src/services/events/processor.py
@@ -291,6 +291,7 @@ class EventProcessor:
         topic: str,
         data: dict,
         organization_id: UUID | None = None,
+        solution_id: UUID | None = None,
         triggered_by: str | None = None,
     ) -> tuple[UUID, int]:
         """Emit a topic event. Returns (event_id, subscribers_notified).
@@ -301,7 +302,7 @@ class EventProcessor:
         """
         validate_topic(topic)
 
-        source = await self._source_repo.get_by_topic(topic)
+        source = await self._source_repo.get_by_topic(topic, solution_id=solution_id)
         if source is None:
             logger.info(
                 f"No active topic source for '{log_safe(topic)}'; emit is a no-op",

--- a/api/tests/e2e/platform/test_solution_event_sub_remap.py
+++ b/api/tests/e2e/platform/test_solution_event_sub_remap.py
@@ -95,6 +95,86 @@ async def test_topic_event_source_install_round_trips_event_type(db_session):
     assert es is not None
     assert es.event_type == "ticket.created"
 
-    found = await EventSourceRepository(db_session).get_by_topic("ticket.created")
+    found = await EventSourceRepository(db_session).get_by_topic(
+        "ticket.created", solution_id=sol.id
+    )
     assert found is not None
     assert found.id == installed_id
+
+
+@pytest.mark.asyncio
+async def test_topic_lookup_targets_solution_install_not_sibling(db_session):
+    from src.models.orm.events import EventSource
+    from src.repositories.events import EventSourceRepository
+
+    sol_a = await _make_solution(db_session, "topic-a")
+    sol_b = await _make_solution(db_session, "topic-b")
+    topic = f"ticket.{uuid.uuid4().hex[:8]}"
+    src_id = "55555555-5555-5555-5555-555555555555"
+
+    def bundle(sol):
+        return SolutionBundle(
+            solution=sol,
+            version="0.1.0",
+            events=[{
+                "id": src_id,
+                "name": "on ticket changed",
+                "source_type": "topic",
+                "event_type": topic,
+                "is_active": True,
+                "subscriptions": [],
+            }],
+        )
+
+    await SolutionDeployer(db_session).deploy(bundle(sol_a), force=True)
+    await SolutionDeployer(db_session).deploy(bundle(sol_b), force=True)
+
+    repo = EventSourceRepository(db_session)
+    found_b = await repo.get_by_topic(topic, solution_id=sol_b.id)
+    assert found_b is not None
+    assert found_b.id == solution_entity_id(sol_b.id, uuid.UUID(src_id))
+
+    loose = await repo.get_by_topic(topic)
+    assert loose is None
+
+    assert await db_session.get(EventSource, solution_entity_id(sol_a.id, uuid.UUID(src_id)))
+    assert await db_session.get(EventSource, solution_entity_id(sol_b.id, uuid.UUID(src_id)))
+
+
+@pytest.mark.asyncio
+async def test_topic_emit_targets_solution_install_not_sibling(db_session):
+    from src.models.orm.events import Event
+    from src.services.events.processor import EventProcessor
+
+    sol_a = await _make_solution(db_session, "emit-a")
+    sol_b = await _make_solution(db_session, "emit-b")
+    topic = f"ticket.{uuid.uuid4().hex[:8]}"
+    src_id = "66666666-6666-6666-6666-666666666666"
+
+    def bundle(sol):
+        return SolutionBundle(
+            solution=sol,
+            version="0.1.0",
+            events=[{
+                "id": src_id,
+                "name": "on ticket emitted",
+                "source_type": "topic",
+                "event_type": topic,
+                "is_active": True,
+                "subscriptions": [],
+            }],
+        )
+
+    await SolutionDeployer(db_session).deploy(bundle(sol_a), force=True)
+    await SolutionDeployer(db_session).deploy(bundle(sol_b), force=True)
+
+    event_id, subscribers = await EventProcessor(db_session).emit_topic(
+        topic=topic,
+        data={"ticket_id": "T-1"},
+        solution_id=sol_b.id,
+    )
+
+    event = await db_session.get(Event, event_id)
+    assert event is not None
+    assert subscribers == 0
+    assert event.event_source_id == solution_entity_id(sol_b.id, uuid.UUID(src_id))

--- a/api/tests/unit/sdk/test_workflows_sdk_scheduling.py
+++ b/api/tests/unit/sdk/test_workflows_sdk_scheduling.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from bifrost._context import clear_execution_context, set_execution_context
+from bifrost._execution_context import ExecutionContext, Organization
 from bifrost.workflows import workflows
 
 
@@ -76,3 +78,31 @@ async def test_cancel_calls_endpoint():
     fake.post.assert_awaited_once()
     url = fake.post.await_args.args[0]
     assert url == "/api/workflows/executions/exec-1/cancel"
+
+
+@pytest.mark.asyncio
+async def test_execute_includes_solution_from_execution_context():
+    fake = MagicMock()
+    fake.post = AsyncMock(return_value=_mock_post_response({"execution_id": "e1"}))
+    org = Organization(id="11111111-1111-1111-1111-111111111111", name="Org")
+    solution_id = "22222222-2222-2222-2222-222222222222"
+    ctx = ExecutionContext(
+        user_id="u",
+        email="u@example.com",
+        name="User",
+        scope=org.id,
+        organization=org,
+        is_platform_admin=True,
+        is_function_key=False,
+        execution_id="exec",
+        solution_id=solution_id,
+    )
+    set_execution_context(ctx)
+    try:
+        with patch("bifrost.workflows.get_client", return_value=fake):
+            await workflows.execute("workflows/child.py::main")
+    finally:
+        clear_execution_context()
+
+    payload = fake.post.await_args.kwargs["json"]
+    assert payload["solution_id"] == solution_id

--- a/api/tests/unit/test_bifrost_events_sdk.py
+++ b/api/tests/unit/test_bifrost_events_sdk.py
@@ -4,6 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from bifrost._context import clear_execution_context, set_execution_context
+from bifrost._execution_context import ExecutionContext, Organization
+
 
 @pytest.fixture
 def mock_client():
@@ -82,3 +85,33 @@ async def test_emit_no_scope_resolves_context_scope(mock_client, mock_response_o
         await events.emit("user.invited", {"user_id": "xyz"})
 
     mock_resolve.assert_called_once_with(None)
+
+
+@pytest.mark.asyncio
+async def test_emit_includes_solution_from_execution_context(mock_client, mock_response_ok):
+    mock_client.post.return_value = mock_response_ok
+    solution_id = "22222222-2222-2222-2222-222222222222"
+    org = Organization(id="11111111-1111-1111-1111-111111111111", name="Org")
+    ctx = ExecutionContext(
+        user_id="u",
+        email="u@example.com",
+        name="User",
+        scope=org.id,
+        organization=org,
+        is_platform_admin=True,
+        is_function_key=False,
+        execution_id="exec",
+        solution_id=solution_id,
+    )
+    set_execution_context(ctx)
+    try:
+        with patch("bifrost.events.get_client", return_value=mock_client), \
+             patch("bifrost.events.raise_for_status_with_detail"), \
+             patch("bifrost.events.resolve_scope", return_value=org.id):
+            from bifrost.events import events
+            await events.emit("acme.deal_won", {})
+    finally:
+        clear_execution_context()
+
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["solution"] == solution_id

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -106,6 +106,7 @@ def _make_upstream(record):
         record["other_path"] = request.path
         record["other_query"] = request.rel_url.query_string
         record["other_org"] = request.headers.get("X-Bifrost-Org")
+        record["other_accept_encoding"] = request.headers.get("Accept-Encoding")
         return web.json_response({"upstream_other": True})
 
     async def ws_echo(request):
@@ -249,6 +250,32 @@ async def test_other_api_path_proxies_with_org_header():
         assert record["other_path"] == "/api/tables/foo"
         assert record["other_query"] == "limit=10&solution=S"
         assert record["other_org"] == "O"
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_api_proxy_forces_identity_encoding():
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_upstream(record), up_port)
+    host = _StubHost(set())
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="t",
+        app_id="A",
+        org_id="O",
+        solution_id="S",
+    )
+    dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
+    try:
+        async with httpx.AsyncClient() as c:
+            r = await c.get(
+                f"http://127.0.0.1:{dev_port}/api/auth/me",
+                headers={"Accept-Encoding": "br, gzip"},
+            )
+        assert r.status_code == 200
+        assert record["other_accept_encoding"] == "identity"
     finally:
         await dev_runner.cleanup()
         await up_runner.cleanup()

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -13641,6 +13641,11 @@ export interface components {
              * @description Organization scope: org UUID string or None for GLOBAL.
              */
             scope?: string | null;
+            /**
+             * Solution
+             * @description Solution install id from the execution context. When set, topic lookup resolves this install's event source before _repo sources.
+             */
+            solution?: string | null;
         };
         /**
          * EmitEventResponse


### PR DESCRIPTION
## Summary
- force local solution dev API proxy requests to use identity encoding so compressed upstream bytes are not returned without content-encoding metadata
- propagate `solution_id` through Python SDK workflow chaining and event emits from solution execution context
- scope topic EventSource resolution to the calling solution install first, with `_repo` fallback, and exclude solution-managed topic sources from loose emits
- regenerate OpenAPI TypeScript types for `EmitEventRequest.solution`

## Verification
- `./test.sh quality api` passed: pyright 0 errors, ruff all checks passed
- `OPENAPI_URL=http://bifrost-debug-solution-local-targeting-pass-7-70.netbird.cloud/openapi.json npm run generate:types` passed
- `(cd client && npm run tsc)` passed
- `(cd client && npm run lint)` passed with existing FormRenderer React Hook Form warning, 0 errors
- `./test.sh tests/unit/test_contract_version.py tests/unit/test_solution_dev_proxy.py tests/unit/test_bifrost_events_sdk.py tests/unit/sdk/test_workflows_sdk_scheduling.py tests/e2e/platform/test_solution_event_sub_remap.py -q` passed: 29 passed
- `./test.sh all` was started and manually stopped at 22% after passing relevant event/solution/file/table/workflow-scope areas; no failures before stop
- `./test.sh client unit` hit unrelated cross-file state pollution in `ExecutionHistory.test.tsx`; rerun of `npm test -- src/pages/ExecutionHistory.test.tsx` passed 14/14

## Audit Notes
- Subagent audit found no wider confirmed local browser/app SDK targeting bug beyond the proxy compression issue; websocket table subscriptions are by table id after solution-scoped snapshot resolution.
- Config values are intentionally org/global scoped; Solution config schema rows are declarations only.
- Integrations currently have no `solution_id`, so name-level integration resolution remains global by model design.
