### PR TITLE
Consolidate Solutions runtime scoping: one derivation chain, enforcement, golden browser contract

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -1998,6 +1998,31 @@ def export_cmd(
         raise SystemExit(rc)
 
 
+def _vite_child_env(
+    base_env: dict[str, str],
+    *,
+    app_id: str,
+    org_id: str,
+    proxy_origin: str,
+    access_token: str,
+) -> dict[str, str]:
+    """Environment for the `solution start` Vite child.
+
+    The bundle-visible BIFROST_API_URL is the LOCAL PROXY origin, never the
+    upstream API: the proxy is where install scope is injected (?solution=,
+    auth, app header) and where local path::fn refs run in-process. Pointing
+    the bundle at the upstream bypasses all of that — local workflow edits
+    silently don't run, install-owned tables 404, declared-location file
+    writes 403 (drive finding, 2026-07-02).
+    """
+    env = dict(base_env)
+    env["VITE_BIFROST_APP_ID"] = app_id
+    env["VITE_BIFROST_ORG_ID"] = org_id
+    env["BIFROST_API_URL"] = proxy_origin
+    env["BIFROST_ACCESS_TOKEN"] = access_token
+    return env
+
+
 @solution_group.command(name="start", help="Run the app's dev server + local workflows (one origin).")
 @click.argument("app_slug", required=False)
 @click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
@@ -2056,11 +2081,13 @@ def start_cmd(app_slug: str | None, solution_ref: str | None, port: int) -> None
         click.echo("Installing app dependencies (npm install)…")
         subprocess.run([npm, "install"], cwd=chosen.app_dir, check=True)
 
-    vite_env = dict(os.environ)
-    vite_env["VITE_BIFROST_APP_ID"] = chosen.app_id
-    vite_env["VITE_BIFROST_ORG_ID"] = (org_info or {}).get("id", "")
-    vite_env["BIFROST_API_URL"] = client.api_url
-    vite_env["BIFROST_ACCESS_TOKEN"] = client._access_token
+    vite_env = _vite_child_env(
+        dict(os.environ),
+        app_id=chosen.app_id,
+        org_id=(org_info or {}).get("id", ""),
+        proxy_origin=f"http://127.0.0.1:{port}",
+        access_token=client._access_token,
+    )
 
     vite_port = port + 1
     # Run `npm run dev` in its OWN process group (start_new_session) so teardown

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -275,12 +275,31 @@ def scaffold_app_cmd(slug: str, path: str | None, api_url: str | None) -> None:
     _ = app_dir
 
 
+def _scaffold_api_url(api_url: str | None) -> str:
+    """Resolve the instance URL to bake into a scaffolded app.
+
+    Explicit flag > workspace env > the authenticated client's URL. The bare
+    localhost:8000 fallback is a last resort for logged-out offline scaffolds —
+    baking it while logged in against a real instance broke the app's
+    `npm install` (the SDK dependency pointed at a dead port; drive finding,
+    2026-07-02)."""
+    resolved = api_url or os.getenv("BIFROST_API_URL")
+    if resolved:
+        return resolved
+    try:
+        return BifrostClient.get_instance(require_auth=True).api_url
+    except RuntimeError:
+        # Not logged in — offline scaffold; main.tsx surfaces the
+        # unauthenticated state at dev time rather than failing here.
+        return "http://localhost:8000"
+
+
 def _scaffold_app(slug: str, path: str | None, api_url: str | None) -> pathlib.Path:
     """Scaffold a standalone_v2 app skeleton; return its dir. Shared by
     ``scaffold-app`` and ``migrate-app`` so the two never drift."""
     import uuid as _uuid
 
-    url = api_url or os.getenv("BIFROST_API_URL") or "http://localhost:8000"
+    url = _scaffold_api_url(api_url)
 
     # Anchor everything at the SOLUTION ROOT (the dir holding the descriptor),
     # found by walking up from cwd. Guessing the root from the app dir

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -31,8 +31,19 @@ import httpx
 import yarl
 from aiohttp import web
 
-# Hop-by-hop headers we must not forward when reverse-proxying.
-_STRIP = {"host", "content-length", "transfer-encoding", "connection", "keep-alive"}
+# Headers we must not forward when reverse-proxying: hop-by-hop headers, plus
+# the browser's Accept-Encoding — browsers advertise encodings (br, zstd) that
+# httpx may not decode, and the proxy rebuilds response headers WITHOUT
+# Content-Encoding, so a passed-through compressed body would reach the browser
+# labeled as plain JSON. Stripping it lets httpx negotiate only what it decodes.
+_STRIP = {
+    "host",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+    "keep-alive",
+    "accept-encoding",
+}
 
 
 class _UpstreamAuthorityError(ValueError):

--- a/api/src/repositories/README.md
+++ b/api/src/repositories/README.md
@@ -467,9 +467,33 @@ the name cascade:
   - A solution **workflow** carries `ctx.solution_id`; the SDK appends
     `?solution=` to name lookups (`ExecutionContext.solution_id`,
     `_execution_context.py`).
-  - A solution **app** sends `X-Bifrost-App`; the router maps it to
-    `Application.solution_id` (`_resolve_solution_table_by_name` in
-    `routers/tables.py`).
+  - A solution **app** sends `X-Bifrost-App`; auth maps it to
+    `Application.solution_id` and routers consume it via
+    `services/solution_scope.py` (e.g. `resolve_solution_table_by_name`
+    used by `routers/tables.py`).
+
+### How the install id is DERIVED (the request side)
+
+Symmetric to gate 1's `resolve_effective_scope` for org scope, install
+scope has exactly one derivation chain — enforced by
+`tests/unit/test_solution_scope_enforcement.py`:
+
+- **`core/auth.py` is the ONLY parser of raw transport signals.** It reads
+  `?solution=` and `X-Bifrost-App`, validates them (UUID shape, active
+  install, header/param agreement), and sets `ctx.solution_id` /
+  `ctx.app_id` on the request's ExecutionContext.
+- **`services/solution_scope.py` is the ONLY consumer API.**
+  `parse_ctx_solution_id(ctx)` parses the context value;
+  `solution_context_id(db, ctx)` adds the app→install fallback;
+  `derive_execution_solution_scope(db, ctx, ...)` adds workflow-execute's
+  deprecated body-field compat tiers (body `solution_id` > `form_id` >
+  `app_id`). Routers call these; they never parse signals themselves.
+- **Body fields on `/api/workflows/execute` are DEPRECATED compat.** Live
+  SDKs still send them; removing them is a CONTRACT_VERSION bump.
+- **The worker path derives scope from the workflow's own DB row**
+  (`jobs/consumers/workflow_execution.py` → `workflow_data["solution_id"]`),
+  NOT from request signals — execution identity is the row's, by design.
+  Forms likewise use their own stored `form.solution_id` (owned scope).
 
 ### How the context is plumbed
 

--- a/api/src/routers/cli.py
+++ b/api/src/routers/cli.py
@@ -51,13 +51,13 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.core.auth import CurrentUser
+from src.core.auth import Context, CurrentUser
 from src.core.principal import UserPrincipal
 from src.core.database import get_db
 from src.core.log_safety import log_safe
@@ -2765,36 +2765,22 @@ async def download_sdk() -> Response:
 )
 async def cli_create_table(
     request: SDKTableCreateRequest,
-    raw_request: Request,
+    ctx: Context,
     current_user: CurrentUser,
     db: AsyncSession = Depends(get_db),
 ) -> SDKTableInfo:
     """Create a new table via SDK."""
-    from src.models.orm.applications import Application
     from src.models.orm.tables import Table
+    from src.services.solution_scope import solution_context_id
 
-    if raw_request.query_params.get("solution") is not None:
+    # A solution execution context (?solution= or X-Bifrost-App, resolved by
+    # auth onto ctx) may not create tables ad hoc — tables are declared by the
+    # solution manifest and created at deploy.
+    if await solution_context_id(db, ctx) is not None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tables must be declared by the solution manifest",
         )
-    app_header = raw_request.headers.get("X-Bifrost-App")
-    if app_header is not None:
-        try:
-            app_uuid = UUID(app_header)
-        except ValueError:
-            app_uuid = None
-        if app_uuid is not None:
-            app_solution_id = (
-                await db.execute(
-                    select(Application.solution_id).where(Application.id == app_uuid)
-                )
-            ).scalar_one_or_none()
-            if app_solution_id is not None:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Tables must be declared by the solution manifest",
-                )
 
     org_id = await _resolve_sdk_org_id(current_user, request.scope, db)
     org_uuid = UUID(org_id) if org_id else None

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -298,13 +298,11 @@ def _resolve_effective_scope(
 def _ctx_solution_id(ctx: Context, location: str) -> UUID | None:
     """Return the install UUID from context when present. Used to forward
     solution_id to policy and metadata helpers so the solution-tier policy
-    cascade (Task 3) and the C2 metadata column are both correct."""
-    if ctx.solution_id is None:
-        return None
-    try:
-        return UUID(str(ctx.solution_id))
-    except (ValueError, AttributeError, TypeError):
-        return None
+    cascade (Task 3) and the C2 metadata column are both correct. Canonical
+    parse lives in services/solution_scope.py."""
+    from src.services.solution_scope import parse_ctx_solution_id
+
+    return parse_ctx_solution_id(ctx)
 
 
 async def _install_org_id(ctx: Context, solution_id: UUID | None) -> UUID | None:

--- a/api/src/routers/files.py
+++ b/api/src/routers/files.py
@@ -424,7 +424,20 @@ async def _require_file_policy(
         organization_id=organization_id,
     )
     if not allowed:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+        # A policy denial must identify its scope inputs (no user/token data —
+        # every field is caller-supplied or derived from it): a scope-loss bug
+        # reads as solution_id=null instead of a bare "Forbidden".
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "message": "File policy denied",
+                "action": action,
+                "location": location,
+                "path": path,
+                "scope": scope,
+                "solution_id": str(solution_id) if solution_id else None,
+            },
+        )
 
 
 async def _require_declared_solution_file_location(

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -700,14 +700,17 @@ async def _insert_scheduled_execution(
 async def _derive_solution_scope(
     db,
     *,
+    ctx_solution_id: str | None = None,
     solution_id: str | None,
     form_id: str | None,
     app_id: str | None,
 ) -> "UUID | None":
     """Resolve the calling install's scope for a path::fn workflow ref.
 
-    Precedence: explicit solution_id (a Solution form/agent that knows its
-    own install) > form_id (Form.solution_id) > app_id (Application.solution_id).
+    Precedence: ctx_solution_id (the auth layer already resolved ?solution= /
+    X-Bifrost-App into the request context — the same signal tables/files scope
+    by) > explicit solution_id (a Solution form/agent that knows its own
+    install) > form_id (Form.solution_id) > app_id (Application.solution_id).
     A bad/foreign/missing reference yields None → no narrowing (the path ref
     resolves the _repo/ row, or 404s for a scoped caller). Each source is
     client-supplied; the resolver's own org gate (cascade scope) prevents a
@@ -716,6 +719,11 @@ async def _derive_solution_scope(
     from src.models.orm.forms import Form
     from src.models.orm.applications import Application
 
+    if ctx_solution_id:
+        try:
+            return UUID(str(ctx_solution_id))
+        except ValueError:
+            pass  # auth-validated in practice; fall through to body-derived scope
     if solution_id:
         try:
             return UUID(solution_id)
@@ -804,6 +812,7 @@ async def execute_workflow(
     # form/agent) > form_id > app_id. A bad/foreign ref yields no scope.
     solution_scope = await _derive_solution_scope(
         db,
+        ctx_solution_id=ctx.solution_id,
         solution_id=request.solution_id,
         form_id=request.form_id,
         app_id=request.app_id,

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -773,9 +773,23 @@ async def execute_workflow(
             request.workflow_id, solution_scope=solution_scope
         )
         if not workflow:
+            # A resolution miss must identify its scope inputs: a dropped or
+            # wrong install scope reads as derived_solution_scope=null here
+            # instead of a mystery 404 (no user/token data — every field is
+            # caller-supplied or derived from it).
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Workflow '{request.workflow_id}' not found",
+                detail={
+                    "message": f"Workflow '{request.workflow_id}' not found",
+                    "workflow_ref": request.workflow_id,
+                    "context_solution_id": ctx.solution_id,
+                    "request_solution_id": request.solution_id,
+                    "request_form_id": request.form_id,
+                    "request_app_id": request.app_id,
+                    "derived_solution_scope": (
+                        str(solution_scope) if solution_scope else None
+                    ),
+                },
             )
 
     # Authorization check

--- a/api/src/routers/workflows.py
+++ b/api/src/routers/workflows.py
@@ -62,6 +62,7 @@ from src.models.orm.applications import Application
 from src.models.orm.agents import Agent, AgentTool
 from src.models.orm.users import Role
 from src.services.workflow_validation import _extract_relative_path
+from src.services.solution_scope import derive_execution_solution_scope
 from src.services.solutions.guard import (
     assert_entity_id_not_solution_managed,
     assert_not_solution_managed,
@@ -697,59 +698,6 @@ async def _insert_scheduled_execution(
     return exec_id
 
 
-async def _derive_solution_scope(
-    db,
-    *,
-    ctx_solution_id: str | None = None,
-    solution_id: str | None,
-    form_id: str | None,
-    app_id: str | None,
-) -> "UUID | None":
-    """Resolve the calling install's scope for a path::fn workflow ref.
-
-    Precedence: ctx_solution_id (the auth layer already resolved ?solution= /
-    X-Bifrost-App into the request context — the same signal tables/files scope
-    by) > explicit solution_id (a Solution form/agent that knows its own
-    install) > form_id (Form.solution_id) > app_id (Application.solution_id).
-    A bad/foreign/missing reference yields None → no narrowing (the path ref
-    resolves the _repo/ row, or 404s for a scoped caller). Each source is
-    client-supplied; the resolver's own org gate (cascade scope) prevents a
-    foreign scope from reaching another org's workflow.
-    """
-    from src.models.orm.forms import Form
-    from src.models.orm.applications import Application
-
-    if ctx_solution_id:
-        try:
-            return UUID(str(ctx_solution_id))
-        except ValueError:
-            pass  # auth-validated in practice; fall through to body-derived scope
-    if solution_id:
-        try:
-            return UUID(solution_id)
-        except ValueError:
-            return None
-    if form_id:
-        try:
-            form_uuid = UUID(form_id)
-        except ValueError:
-            return None
-        return (
-            await db.execute(select(Form.solution_id).where(Form.id == form_uuid))
-        ).scalar_one_or_none()
-    if app_id:
-        try:
-            app_uuid = UUID(app_id)
-        except ValueError:
-            return None
-        return (
-            await db.execute(
-                select(Application.solution_id).where(Application.id == app_uuid)
-            )
-        ).scalar_one_or_none()
-    return None
-
-
 @router.post(
     "/execute",
     response_model=WorkflowExecutionResponse,
@@ -810,9 +758,9 @@ async def execute_workflow(
     # resolves to THIS install's own workflow, not a sibling install's that
     # shares the path (Codex #8 P1) nor the bare _repo/ one. solution_id (a
     # form/agent) > form_id > app_id. A bad/foreign ref yields no scope.
-    solution_scope = await _derive_solution_scope(
+    solution_scope = await derive_execution_solution_scope(
         db,
-        ctx_solution_id=ctx.solution_id,
+        ctx,
         solution_id=request.solution_id,
         form_id=request.form_id,
         app_id=request.app_id,

--- a/api/src/services/solution_scope.py
+++ b/api/src/services/solution_scope.py
@@ -95,6 +95,59 @@ async def solution_context_id(
     ).scalar_one_or_none()
 
 
+async def derive_execution_solution_scope(
+    db: AsyncSession,
+    ctx,
+    *,
+    solution_id: str | None,
+    form_id: str | None,
+    app_id: str | None,
+) -> UUID | None:
+    """Resolve the calling install's scope for workflow execution.
+
+    THE canonical derivation for /api/workflows/execute. Precedence:
+    request context (auth already resolved ?solution= / X-Bifrost-App —
+    the same signal tables/files scope by) > body solution_id (a Solution
+    form/agent that knows its own install) > form_id (Form.solution_id)
+    > app_id (Application.solution_id). The body fields are DEPRECATED
+    compatibility inputs — live SDKs still send them; removal requires a
+    CONTRACT_VERSION bump. A bad/foreign/missing reference yields None →
+    no narrowing (the path ref resolves the _repo/ row, or 404s for a
+    scoped caller). Each source is client-supplied; the resolver's own
+    org gate (cascade scope) prevents a foreign scope from reaching
+    another org's workflow.
+    """
+    from src.models.orm.forms import Form
+
+    ctx_scope = await solution_context_id(db, ctx)
+    if ctx_scope is not None:
+        return ctx_scope
+    if solution_id:
+        try:
+            return UUID(solution_id)
+        except ValueError:
+            return None
+    if form_id:
+        try:
+            form_uuid = UUID(form_id)
+        except ValueError:
+            return None
+        return (
+            await db.execute(select(Form.solution_id).where(Form.id == form_uuid))
+        ).scalar_one_or_none()
+    if app_id:
+        try:
+            app_uuid = UUID(app_id)
+        except ValueError:
+            return None
+        return (
+            await db.execute(
+                select(Application.solution_id).where(Application.id == app_uuid)
+            )
+        ).scalar_one_or_none()
+    return None
+
+
 async def resolve_solution_table_by_name(
     db: AsyncSession,
     ctx: ExecutionContext,

--- a/api/src/services/solution_scope.py
+++ b/api/src/services/solution_scope.py
@@ -25,6 +25,20 @@ class FileTier:
     solution_id: UUID | None
 
 
+def parse_ctx_solution_id(ctx) -> UUID | None:
+    """Parse ``ctx.solution_id`` (set by auth) into a UUID, or None.
+
+    THE single parse point — routers must not re-implement this
+    (tests/unit/test_solution_scope_enforcement.py)."""
+    raw = getattr(ctx, "solution_id", None)
+    if raw is None:
+        return None
+    try:
+        return UUID(str(raw))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
 async def get_active_solution(db: AsyncSession, solution_id: UUID) -> Solution | None:
     solution = await db.get(Solution, solution_id)
     if solution is None or solution.status != "active":
@@ -75,11 +89,9 @@ async def solution_context_id(
     calls via ``X-Bifrost-App``. The app-id fallback keeps older call sites and
     unit tests that construct contexts manually on the same resolver path.
     """
-    if ctx.solution_id:
-        try:
-            return UUID(str(ctx.solution_id))
-        except ValueError:
-            return None
+    ctx_scope = parse_ctx_solution_id(ctx)
+    if ctx_scope is not None:
+        return ctx_scope
 
     if not ctx.app_id:
         return None
@@ -220,7 +232,9 @@ async def file_read_tiers(
     if location == "workspace":
         raise ValueError("workspace is not available in solution file context")
 
-    solution_id = UUID(str(ctx.solution_id))
+    solution_id = parse_ctx_solution_id(ctx)
+    if solution_id is None:
+        return []
     solution = await db.get(Solution, solution_id)
     if solution is None:
         return []

--- a/api/tests/e2e/platform/test_execute_solution_scope_e2e.py
+++ b/api/tests/e2e/platform/test_execute_solution_scope_e2e.py
@@ -1,4 +1,5 @@
 """A solution form's /execute resolves the install's own workflow, not _repo/."""
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -8,7 +9,11 @@ from src.models.orm.solutions import Solution
 from src.models.orm.forms import Form
 from src.models.orm.workflows import Workflow
 from src.repositories.workflows import WorkflowRepository
-from src.routers.workflows import _derive_solution_scope
+from src.services.solution_scope import derive_execution_solution_scope
+
+
+def _no_ctx() -> SimpleNamespace:
+    return SimpleNamespace(solution_id=None, app_id=None)
 
 
 async def _org(db):
@@ -43,7 +48,9 @@ class TestExecuteSolutionScopeE2E:
         await db.flush()
 
         # Router sequence: derive scope from form_id, then resolve.
-        scope = await _derive_solution_scope(db, solution_id=None, form_id=str(form.id), app_id=None)
+        scope = await derive_execution_solution_scope(
+            db, _no_ctx(), solution_id=None, form_id=str(form.id), app_id=None
+        )
         assert scope == sol.id
         repo = WorkflowRepository(db, org_id=org, is_superuser=True)
         got = await repo.resolve("workflows/foo.py::main", solution_scope=scope)
@@ -63,7 +70,9 @@ class TestExecuteSolutionScopeE2E:
         db.add(form)
         await db.flush()
 
-        scope = await _derive_solution_scope(db, solution_id=None, form_id=str(form.id), app_id=None)
+        scope = await derive_execution_solution_scope(
+            db, _no_ctx(), solution_id=None, form_id=str(form.id), app_id=None
+        )
         assert scope is None
         repo = WorkflowRepository(db, org_id=org, is_superuser=True)
         got = await repo.resolve("workflows/bar.py::main", solution_scope=scope)

--- a/api/tests/e2e/platform/test_solution_deploy_execution.py
+++ b/api/tests/e2e/platform/test_solution_deploy_execution.py
@@ -182,6 +182,58 @@ def _execute_with_app(e2e_client, headers, workflow_ref: str, app_id: str) -> di
     return resp.json()
 
 
+def _deploy_install_with_app(e2e_client, headers, marker: str) -> str:
+    """Deploy a Solution install shipping workflows/main.py::main (returns the
+    marker) plus a standalone_v2 app; return the app's remapped DB id."""
+    from tests.e2e.platform.conftest import deploy_solution
+
+    slug = f"twin-{marker}-{uuid.uuid4().hex[:8]}"
+    sid = _create_solution(e2e_client, headers, slug=slug, global_repo_access=False)
+    app_id = str(uuid.uuid4())
+    # Deploy is ASYNC (BackgroundTasks) — fire-and-forget would race the
+    # background job, so the immediately-following execute can 404 on a
+    # workflow whose row hasn't committed yet (flaky under load). Use the
+    # deploy_solution helper that blocks until the deploy job is terminal.
+    resp = deploy_solution(
+        e2e_client,
+        sid,
+        headers,
+        {
+            "python_files": {
+                "workflows/main.py": (
+                    "from bifrost import workflow\n\n"
+                    "@workflow\n"
+                    "async def main():\n"
+                    f"    return {{'marker': '{marker}'}}\n"
+                ),
+            },
+            "workflows": [{
+                "id": str(uuid.uuid4()),
+                "name": f"main_{slug}",
+                "function_name": "main",
+                "path": "workflows/main.py",
+                "type": "workflow",
+            }],
+            "apps": [{
+                "id": app_id,
+                "slug": f"app-{slug}",
+                "name": "App",
+                "app_model": "standalone_v2",
+                "dependencies": {},
+                "access_level": "authenticated",
+                "dist_files": {
+                    "index.html": '<!doctype html><div id="root"></div>',
+                },
+            }],
+        },
+    )
+    assert resp.status_code in (200, 201), f"deploy failed: {resp.status_code} {resp.text}"
+    # The app's DB id is the remapped uuid5(install, manifest_id).
+    from src.services.solutions.deploy import solution_entity_id
+
+    return str(solution_entity_id(uuid.UUID(sid), uuid.UUID(app_id)))
+
+
 def test_two_installs_same_path_resolve_own_workflow_via_app_id(e2e_client, platform_admin):
     """Codex #8 P1 end-to-end: two Solution installs each ship
     workflows/main.py::main (different return values) AND an app. Executing each
@@ -189,57 +241,8 @@ def test_two_installs_same_path_resolve_own_workflow_via_app_id(e2e_client, plat
     workflow — deterministically, not a sibling install's that shares the path."""
     headers = platform_admin.headers
 
-    def _deploy_install(marker: str) -> str:
-        from tests.e2e.platform.conftest import deploy_solution
-
-        slug = f"twin-{marker}-{uuid.uuid4().hex[:8]}"
-        sid = _create_solution(e2e_client, headers, slug=slug, global_repo_access=False)
-        app_id = str(uuid.uuid4())
-        # Deploy is ASYNC (BackgroundTasks) — fire-and-forget would race the
-        # background job, so the immediately-following execute can 404 on a
-        # workflow whose row hasn't committed yet (flaky under load). Use the
-        # deploy_solution helper that blocks until the deploy job is terminal.
-        resp = deploy_solution(
-            e2e_client,
-            sid,
-            headers,
-            {
-                "python_files": {
-                    "workflows/main.py": (
-                        "from bifrost import workflow\n\n"
-                        "@workflow\n"
-                        "async def main():\n"
-                        f"    return {{'marker': '{marker}'}}\n"
-                    ),
-                },
-                "workflows": [{
-                    "id": str(uuid.uuid4()),
-                    "name": f"main_{slug}",
-                    "function_name": "main",
-                    "path": "workflows/main.py",
-                    "type": "workflow",
-                }],
-                "apps": [{
-                    "id": app_id,
-                    "slug": f"app-{slug}",
-                    "name": "App",
-                    "app_model": "standalone_v2",
-                    "dependencies": {},
-                    "access_level": "authenticated",
-                    "dist_files": {
-                        "index.html": '<!doctype html><div id="root"></div>',
-                    },
-                }],
-            },
-        )
-        assert resp.status_code in (200, 201), f"deploy failed: {resp.status_code} {resp.text}"
-        # The app's DB id is the remapped uuid5(install, manifest_id).
-        from src.services.solutions.deploy import solution_entity_id
-
-        return str(solution_entity_id(uuid.UUID(sid), uuid.UUID(app_id)))
-
-    app_a = _deploy_install("aaa")
-    app_b = _deploy_install("bbb")
+    app_a = _deploy_install_with_app(e2e_client, headers, "aaa")
+    app_b = _deploy_install_with_app(e2e_client, headers, "bbb")
 
     # Each app's path-ref resolves to ITS OWN install's workflow.
     res_a = _execute_with_app(e2e_client, headers, "workflows/main.py::main", app_a)
@@ -248,3 +251,30 @@ def test_two_installs_same_path_resolve_own_workflow_via_app_id(e2e_client, plat
     assert res_b["status"] == "Success", res_b
     assert res_a["result"] == {"marker": "aaa"}, res_a
     assert res_b["result"] == {"marker": "bbb"}, res_b
+
+
+def test_app_header_alone_scopes_workflow_execution(e2e_client, platform_admin):
+    """The deployed-browser transport contract: X-Bifrost-App header, NO body
+    app_id. Auth derives ctx.solution_id from the header; workflow execution
+    must honor that context scope so a path::fn ref resolves the install's own
+    workflow — same as tables/files already do."""
+    headers = platform_admin.headers
+
+    app_a = _deploy_install_with_app(e2e_client, headers, "hdr-aaa")
+    app_b = _deploy_install_with_app(e2e_client, headers, "hdr-bbb")
+
+    def _execute_with_header(app_id: str) -> dict:
+        resp = e2e_client.post(
+            "/api/workflows/execute",
+            headers={**headers, "X-Bifrost-App": app_id},
+            json={"workflow_id": "workflows/main.py::main", "sync": True},
+        )
+        assert resp.status_code == 200, f"execute failed: {resp.status_code} {resp.text}"
+        return resp.json()
+
+    res_a = _execute_with_header(app_a)
+    res_b = _execute_with_header(app_b)
+    assert res_a["status"] == "Success", res_a
+    assert res_b["status"] == "Success", res_b
+    assert res_a["result"] == {"marker": "hdr-aaa"}, res_a
+    assert res_b["result"] == {"marker": "hdr-bbb"}, res_b

--- a/api/tests/e2e/platform/test_solution_deploy_execution.py
+++ b/api/tests/e2e/platform/test_solution_deploy_execution.py
@@ -18,17 +18,19 @@ import pytest
 pytestmark = pytest.mark.e2e
 
 
-def _create_solution(e2e_client, headers, *, slug: str, global_repo_access: bool) -> str:
-    resp = e2e_client.post(
-        "/api/solutions",
-        headers=headers,
-        json={
-            "slug": slug,
-            "name": slug.upper(),
-            "scope": "global",
-            "global_repo_access": global_repo_access,
-        },
-    )
+def _create_solution(
+    e2e_client, headers, *, slug: str, global_repo_access: bool, org_id: str | None = None
+) -> str:
+    body = {
+        "slug": slug,
+        "name": slug.upper(),
+        "global_repo_access": global_repo_access,
+    }
+    if org_id is None:
+        body["scope"] = "global"
+    else:
+        body["organization_id"] = org_id
+    resp = e2e_client.post("/api/solutions", headers=headers, json=body)
     assert resp.status_code in (200, 201), f"create solution failed: {resp.status_code} {resp.text}"
     return resp.json()["id"]
 
@@ -182,13 +184,15 @@ def _execute_with_app(e2e_client, headers, workflow_ref: str, app_id: str) -> di
     return resp.json()
 
 
-def _deploy_install_with_app(e2e_client, headers, marker: str) -> str:
+def _deploy_install_with_app(e2e_client, headers, marker: str, org_id: str | None = None) -> str:
     """Deploy a Solution install shipping workflows/main.py::main (returns the
     marker) plus a standalone_v2 app; return the app's remapped DB id."""
     from tests.e2e.platform.conftest import deploy_solution
 
     slug = f"twin-{marker}-{uuid.uuid4().hex[:8]}"
-    sid = _create_solution(e2e_client, headers, slug=slug, global_repo_access=False)
+    sid = _create_solution(
+        e2e_client, headers, slug=slug, global_repo_access=False, org_id=org_id
+    )
     app_id = str(uuid.uuid4())
     # Deploy is ASYNC (BackgroundTasks) — fire-and-forget would race the
     # background job, so the immediately-following execute can 404 on a
@@ -278,3 +282,22 @@ def test_app_header_alone_scopes_workflow_execution(e2e_client, platform_admin):
     assert res_b["status"] == "Success", res_b
     assert res_a["result"] == {"marker": "hdr-aaa"}, res_a
     assert res_b["result"] == {"marker": "hdr-bbb"}, res_b
+
+
+def test_foreign_app_header_cannot_reach_other_orgs_workflow(
+    e2e_client, platform_admin, org1, org2_user
+):
+    """PINNING (expected to hold): a regular user from org2 smuggling org1's
+    X-Bifrost-App must NOT execute org1's install workflow — the resolver's
+    org gate (cascade scope) holds under ctx-first scoping."""
+    headers = platform_admin.headers
+    app_a = _deploy_install_with_app(e2e_client, headers, "xorg", org_id=org1["id"])
+
+    resp = e2e_client.post(
+        "/api/workflows/execute",
+        headers={**org2_user.headers, "X-Bifrost-App": app_a},
+        json={"workflow_id": "workflows/main.py::main", "sync": True},
+    )
+    assert resp.status_code in (403, 404), (
+        f"cross-org header execution must be refused, got {resp.status_code}: {resp.text}"
+    )

--- a/api/tests/e2e/platform/test_solution_deploy_execution.py
+++ b/api/tests/e2e/platform/test_solution_deploy_execution.py
@@ -284,6 +284,27 @@ def test_app_header_alone_scopes_workflow_execution(e2e_client, platform_admin):
     assert res_b["result"] == {"marker": "hdr-bbb"}, res_b
 
 
+def test_workflow_404_includes_scope_diagnostics(e2e_client, platform_admin):
+    """A scope-resolution miss must identify itself: the 404 detail carries the
+    ref and the derived install scope, so a dropped/wrong scope reads as
+    `derived_solution_scope: null` instead of a mystery 404 (drive lesson —
+    the unscoped courtesy fallback masked scope loss for a whole POC day)."""
+    headers = platform_admin.headers
+    app_a = _deploy_install_with_app(e2e_client, headers, "diag")
+
+    resp = e2e_client.post(
+        "/api/workflows/execute",
+        headers={**headers, "X-Bifrost-App": app_a},
+        json={"workflow_id": "workflows/nonexistent.py::nope", "sync": True},
+    )
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail["workflow_ref"] == "workflows/nonexistent.py::nope"
+    assert "not found" in detail["message"]
+    # Header-scoped caller: the derived install scope is present (a UUID).
+    assert detail["derived_solution_scope"], detail
+
+
 def test_foreign_app_header_cannot_reach_other_orgs_workflow(
     e2e_client, platform_admin, org1, org2_user
 ):

--- a/api/tests/e2e/platform/test_solution_files_e2e.py
+++ b/api/tests/e2e/platform/test_solution_files_e2e.py
@@ -234,6 +234,40 @@ def _install_zip(
 # ---------------------------------------------------------------------------
 
 @pytest.mark.e2e
+class TestFilePolicyDenialDiagnostics:
+    async def test_denied_write_403_detail_identifies_scope(
+        self, e2e_client, platform_admin, alice_user, db_session
+    ):
+        """A policy denial must identify itself: action, location, and the
+        derived install scope in the 403 detail — a scope-loss bug then reads
+        as `solution_id: null` instead of a bare 'Forbidden'."""
+        headers = platform_admin.headers
+        slug = f"deny-diag-{uuid.uuid4().hex[:8]}"
+        sol = _create_solution(e2e_client, headers, slug)
+        sol_id = sol["id"]
+        _deploy_solution(e2e_client, headers, sol_id, file_locations=["solutions"])
+        await _declare_solution_file_location(db_session, sol_id, "solutions")
+
+        # alice is a regular user: admin_bypass denies her the write.
+        r = e2e_client.post(
+            f"/api/files/write?solution={sol_id}",
+            headers=alice_user.headers,
+            json={
+                "location": "solutions",
+                "path": "deny/probe.txt",
+                "content": "x",
+                "mode": "cloud",
+            },
+        )
+        assert r.status_code == 403, r.text
+        detail = r.json()["detail"]
+        assert detail["action"] == "write"
+        assert detail["location"] == "solutions"
+        assert detail["solution_id"] == sol_id
+        assert "denied" in detail["message"].lower()
+
+
+@pytest.mark.e2e
 class TestSolutionInactiveLifecycleCapstone:
     """Capstone: full inactive-lifecycle arc — deploy / uninstall / reactivate / export / hard-delete."""
 

--- a/api/tests/e2e/platform/test_table_solution_cascade_gated.py
+++ b/api/tests/e2e/platform/test_table_solution_cascade_gated.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import pytest
 from sqlalchemy import select
 
+from src.models.orm.applications import Application
 from src.models.orm.tables import Document, Table
 from src.services.solutions.deploy import solution_entity_id
 from tests.e2e.platform.conftest import wait_for_deploy
@@ -252,6 +253,51 @@ async def test_sdk_table_create_route_rejects_solution_context_without_repo_tabl
     response = e2e_client.post(
         f"/api/sdk/tables/create?solution={solution_id}",
         headers=headers,
+        json={
+            "name": table_name,
+            "scope": org1["id"],
+            "table_schema": {"columns": [{"name": "label"}]},
+        },
+    )
+
+    assert response.status_code == 404, response.text
+    assert await _repo_table_by_name(db_session, table_name) is None
+
+
+async def test_sdk_table_create_route_rejects_app_header_solution_context(
+    e2e_client,
+    platform_admin,
+    org1,
+    db_session,
+):
+    """The X-Bifrost-App signal must refuse SDK table creation exactly like
+    ?solution= does — both resolve to the same install context."""
+    headers = platform_admin.headers
+    solution = _create_solution(
+        e2e_client,
+        headers,
+        f"sdk-hdr-solution-{uuid.uuid4().hex[:8]}",
+        org_id=org1["id"],
+    )
+    app_id = uuid.uuid4()
+    slug = f"hdr-app-{app_id.hex[:8]}"
+    db_session.add(
+        Application(
+            id=app_id,
+            name=slug,
+            slug=slug,
+            repo_path=f"apps/{slug}",
+            organization_id=UUID(org1["id"]),
+            solution_id=UUID(solution["id"]),
+            access_level="authenticated",
+        )
+    )
+    await db_session.commit()
+
+    table_name = f"sdk_hdr_blocked_{uuid.uuid4().hex[:8]}"
+    response = e2e_client.post(
+        "/api/sdk/tables/create",
+        headers={**headers, "X-Bifrost-App": str(app_id)},
         json={
             "name": table_name,
             "scope": org1["id"],

--- a/api/tests/unit/test_execute_solution_scope.py
+++ b/api/tests/unit/test_execute_solution_scope.py
@@ -8,12 +8,25 @@ from src.models.orm.organizations import Organization
 from src.models.orm.solutions import Solution
 from src.models.orm.applications import Application
 from src.models.orm.forms import Form
-from src.services.solution_scope import derive_execution_solution_scope
+from src.services.solution_scope import (
+    derive_execution_solution_scope,
+    parse_ctx_solution_id,
+)
 
 
 def _no_ctx() -> SimpleNamespace:
     """A request context with no install scope (plain platform caller)."""
     return SimpleNamespace(solution_id=None, app_id=None)
+
+
+class TestParseCtxSolutionId:
+    def test_parses_valid_uuid(self):
+        sid = uuid4()
+        assert parse_ctx_solution_id(SimpleNamespace(solution_id=str(sid))) == sid
+
+    def test_none_and_garbage_yield_none(self):
+        assert parse_ctx_solution_id(SimpleNamespace(solution_id=None)) is None
+        assert parse_ctx_solution_id(SimpleNamespace(solution_id="nope")) is None
 
 
 async def _org(db):

--- a/api/tests/unit/test_execute_solution_scope.py
+++ b/api/tests/unit/test_execute_solution_scope.py
@@ -1,4 +1,4 @@
-"""_derive_solution_scope picks the install scope from solution_id > form_id > app_id."""
+"""_derive_solution_scope picks the install scope from ctx > solution_id > form_id > app_id."""
 from uuid import uuid4
 
 import pytest
@@ -73,3 +73,34 @@ class TestDeriveSolutionScope:
         # Valid UUID, but no such form -> None (not an error).
         got = await _derive_solution_scope(db_session, solution_id=None, form_id=str(uuid4()), app_id=None)
         assert got is None
+
+    async def test_ctx_solution_id_is_primary_scope(self, db_session):
+        # The auth layer already validated ?solution= / X-Bifrost-App and put the
+        # install id on the context — that's the authoritative runtime scope.
+        sid = uuid4()
+        got = await _derive_solution_scope(
+            db_session, ctx_solution_id=str(sid), solution_id=None, form_id=None, app_id=None
+        )
+        assert got == sid
+
+    async def test_ctx_solution_id_wins_over_body_fields(self, db_session):
+        ctx_sid, body_sid = uuid4(), uuid4()
+        got = await _derive_solution_scope(
+            db_session,
+            ctx_solution_id=str(ctx_sid),
+            solution_id=str(body_sid),
+            form_id=None,
+            app_id=None,
+        )
+        assert got == ctx_sid
+
+    async def test_invalid_ctx_solution_id_falls_through_to_body(self, db_session):
+        sid = uuid4()
+        got = await _derive_solution_scope(
+            db_session,
+            ctx_solution_id="not-a-uuid",
+            solution_id=str(sid),
+            form_id=None,
+            app_id=None,
+        )
+        assert got == sid

--- a/api/tests/unit/test_execute_solution_scope.py
+++ b/api/tests/unit/test_execute_solution_scope.py
@@ -1,4 +1,5 @@
-"""_derive_solution_scope picks the install scope from ctx > solution_id > form_id > app_id."""
+"""derive_execution_solution_scope picks the install scope from ctx > solution_id > form_id > app_id."""
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -7,7 +8,12 @@ from src.models.orm.organizations import Organization
 from src.models.orm.solutions import Solution
 from src.models.orm.applications import Application
 from src.models.orm.forms import Form
-from src.routers.workflows import _derive_solution_scope
+from src.services.solution_scope import derive_execution_solution_scope
+
+
+def _no_ctx() -> SimpleNamespace:
+    """A request context with no install scope (plain platform caller)."""
+    return SimpleNamespace(solution_id=None, app_id=None)
 
 
 async def _org(db):
@@ -29,7 +35,9 @@ class TestDeriveSolutionScope:
     async def test_explicit_solution_id_wins(self, db_session):
         db = db_session
         sid = uuid4()
-        got = await _derive_solution_scope(db, solution_id=str(sid), form_id=None, app_id=None)
+        got = await derive_execution_solution_scope(
+            db, _no_ctx(), solution_id=str(sid), form_id=None, app_id=None
+        )
         assert got == sid
 
     async def test_form_id_resolves_to_form_solution_id(self, db_session):
@@ -39,7 +47,9 @@ class TestDeriveSolutionScope:
         form = Form(id=uuid4(), name="f", organization_id=org, solution_id=sol.id, workflow_id="workflows/foo.py::main", created_by="test")
         db.add(form)
         await db.flush()
-        got = await _derive_solution_scope(db, solution_id=None, form_id=str(form.id), app_id=None)
+        got = await derive_execution_solution_scope(
+            db, _no_ctx(), solution_id=None, form_id=str(form.id), app_id=None
+        )
         assert got == sol.id
 
     async def test_app_id_resolves_to_application_solution_id(self, db_session):
@@ -49,15 +59,21 @@ class TestDeriveSolutionScope:
         app = Application(id=uuid4(), name="a", slug=f"a-{uuid4().hex[:6]}", organization_id=org, solution_id=sol.id, repo_path="apps/a", created_by="test")
         db.add(app)
         await db.flush()
-        got = await _derive_solution_scope(db, solution_id=None, form_id=None, app_id=str(app.id))
+        got = await derive_execution_solution_scope(
+            db, _no_ctx(), solution_id=None, form_id=None, app_id=str(app.id)
+        )
         assert got == sol.id
 
     async def test_none_when_no_source(self, db_session):
-        got = await _derive_solution_scope(db_session, solution_id=None, form_id=None, app_id=None)
+        got = await derive_execution_solution_scope(
+            db_session, _no_ctx(), solution_id=None, form_id=None, app_id=None
+        )
         assert got is None
 
     async def test_invalid_uuid_yields_none(self, db_session):
-        got = await _derive_solution_scope(db_session, solution_id="not-a-uuid", form_id=None, app_id=None)
+        got = await derive_execution_solution_scope(
+            db_session, _no_ctx(), solution_id="not-a-uuid", form_id=None, app_id=None
+        )
         assert got is None
 
     async def test_form_exists_with_null_solution_id_yields_none(self, db_session):
@@ -66,28 +82,36 @@ class TestDeriveSolutionScope:
         form = Form(id=uuid4(), name="f", organization_id=org, solution_id=None, workflow_id="workflows/foo.py::main", created_by="test")
         db.add(form)
         await db.flush()
-        got = await _derive_solution_scope(db, solution_id=None, form_id=str(form.id), app_id=None)
+        got = await derive_execution_solution_scope(
+            db, _no_ctx(), solution_id=None, form_id=str(form.id), app_id=None
+        )
         assert got is None
 
     async def test_form_id_with_no_matching_row_yields_none(self, db_session):
         # Valid UUID, but no such form -> None (not an error).
-        got = await _derive_solution_scope(db_session, solution_id=None, form_id=str(uuid4()), app_id=None)
+        got = await derive_execution_solution_scope(
+            db_session, _no_ctx(), solution_id=None, form_id=str(uuid4()), app_id=None
+        )
         assert got is None
 
     async def test_ctx_solution_id_is_primary_scope(self, db_session):
         # The auth layer already validated ?solution= / X-Bifrost-App and put the
         # install id on the context — that's the authoritative runtime scope.
         sid = uuid4()
-        got = await _derive_solution_scope(
-            db_session, ctx_solution_id=str(sid), solution_id=None, form_id=None, app_id=None
+        got = await derive_execution_solution_scope(
+            db_session,
+            SimpleNamespace(solution_id=str(sid), app_id=None),
+            solution_id=None,
+            form_id=None,
+            app_id=None,
         )
         assert got == sid
 
     async def test_ctx_solution_id_wins_over_body_fields(self, db_session):
         ctx_sid, body_sid = uuid4(), uuid4()
-        got = await _derive_solution_scope(
+        got = await derive_execution_solution_scope(
             db_session,
-            ctx_solution_id=str(ctx_sid),
+            SimpleNamespace(solution_id=str(ctx_sid), app_id=None),
             solution_id=str(body_sid),
             form_id=None,
             app_id=None,
@@ -96,11 +120,29 @@ class TestDeriveSolutionScope:
 
     async def test_invalid_ctx_solution_id_falls_through_to_body(self, db_session):
         sid = uuid4()
-        got = await _derive_solution_scope(
+        got = await derive_execution_solution_scope(
             db_session,
-            ctx_solution_id="not-a-uuid",
+            SimpleNamespace(solution_id="not-a-uuid", app_id=None),
             solution_id=str(sid),
             form_id=None,
             app_id=None,
         )
         assert got == sid
+
+    async def test_ctx_app_id_resolves_install_when_solution_id_absent(self, db_session):
+        # solution_context_id's app fallback: a context carrying only app_id
+        # (manually-constructed contexts / older call sites) still scopes.
+        db = db_session
+        org = (await _org(db)).id
+        sol = await _sol(db, org)
+        app = Application(id=uuid4(), name="a", slug=f"a-{uuid4().hex[:6]}", organization_id=org, solution_id=sol.id, repo_path="apps/a", created_by="test")
+        db.add(app)
+        await db.flush()
+        got = await derive_execution_solution_scope(
+            db,
+            SimpleNamespace(solution_id=None, app_id=str(app.id)),
+            solution_id=None,
+            form_id=None,
+            app_id=None,
+        )
+        assert got == sol.id

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -106,6 +106,7 @@ def _make_upstream(record):
         record["other_path"] = request.path
         record["other_query"] = request.rel_url.query_string
         record["other_org"] = request.headers.get("X-Bifrost-Org")
+        record["other_accept_encoding"] = request.headers.get("Accept-Encoding")
         return web.json_response({"upstream_other": True})
 
     async def ws_echo(request):
@@ -249,6 +250,33 @@ async def test_other_api_path_proxies_with_org_header():
         assert record["other_path"] == "/api/tables/foo"
         assert record["other_query"] == "limit=10&solution=S"
         assert record["other_org"] == "O"
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_browser_accept_encoding_is_not_forwarded_upstream():
+    # Browsers advertise encodings (br, zstd) that httpx may not be able to
+    # decode. If the proxy forwards the browser's Accept-Encoding, upstream may
+    # respond with one of those, httpx passes the compressed bytes through, and
+    # _passthrough_headers drops Content-Encoding — so the browser gets
+    # compressed bytes labeled as plain JSON and fails to parse. The proxy must
+    # strip the browser's Accept-Encoding and let httpx negotiate for itself.
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_upstream(record), up_port)
+    host = _StubHost(set())
+    cfg = DevProxyConfig(upstream_url=f"http://127.0.0.1:{up_port}", token="t", app_id="A", org_id="O")
+    dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
+    try:
+        async with httpx.AsyncClient() as c:
+            r = await c.get(
+                f"http://127.0.0.1:{dev_port}/api/tables/foo",
+                headers={"Accept-Encoding": "br, gzip, zstd, x-browser-sentinel"},
+            )
+        assert r.status_code == 200
+        upstream_ae = record["other_accept_encoding"] or ""
+        assert "x-browser-sentinel" not in upstream_ae
     finally:
         await dev_runner.cleanup()
         await up_runner.cleanup()

--- a/api/tests/unit/test_solution_scope_enforcement.py
+++ b/api/tests/unit/test_solution_scope_enforcement.py
@@ -1,0 +1,89 @@
+"""Mechanical enforcement of the Solution runtime-scope pattern.
+
+Three rules (see api/src/repositories/README.md, "How the install id is
+DERIVED"):
+
+1. Only core/auth.py parses the raw transport signals: the
+   ``X-Bifrost-App`` header and the ``?solution=`` query param must not
+   be read anywhere else under api/src.
+2. Only services/solution_scope.py and core/auth.py may map
+   ``Application.solution_id`` (app -> install) for scope purposes.
+3. Nothing re-implements ctx.solution_id parsing: the
+   ``UUID(str(ctx.solution_id))`` pattern is owned by
+   ``solution_scope.parse_ctx_solution_id``.
+
+These are the load-bearing tripwires that keep install-scope derivation
+from drifting back into per-surface vocabularies (the 2026-06/07 class of
+"portable refs 404 in deployed apps" bugs). Allow-lists require a
+justification comment each; they shrink, never silently grow.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+API_SRC = Path(__file__).resolve().parents[2] / "src"
+
+_RAW_HEADER_RE = re.compile(r"""headers\.get\(\s*['"]X-Bifrost-App['"]""")
+_RAW_QUERY_RE = re.compile(r"""query_params\.get\(\s*['"]solution['"]""")
+_APP_TO_SOLUTION_RE = re.compile(r"select\(\s*Application\.solution_id\s*\)")
+_CTX_PARSE_RE = re.compile(r"UUID\(\s*str\(\s*ctx\.solution_id\s*\)\s*\)")
+
+# THE raw-signal parser: validates UUID shape, refuses inactive installs,
+# cross-checks header/param agreement, and sets ctx.solution_id/app_id.
+_ALLOWED_FILES_RAW = {
+    Path("core/auth.py"),
+}
+
+_ALLOWED_FILES_APP_MAP = {
+    # Header gate maps app -> solution for the active-install check.
+    Path("core/auth.py"),
+    # The canonical consumer API (solution_context_id's app fallback,
+    # derive_execution_solution_scope's deprecated body-app_id tier).
+    Path("services/solution_scope.py"),
+}
+
+# parse_ctx_solution_id lives here.
+_ALLOWED_FILES_CTX_PARSE = {
+    Path("services/solution_scope.py"),
+}
+
+
+def _scan(pattern: re.Pattern, allowed: set[Path]) -> list[str]:
+    violations = []
+    for py in sorted(API_SRC.rglob("*.py")):
+        rel = py.relative_to(API_SRC)
+        if rel in allowed:
+            continue
+        for i, line in enumerate(py.read_text().splitlines(), 1):
+            if pattern.search(line):
+                violations.append(f"{rel}:{i}: {line.strip()}")
+    return violations
+
+
+def test_only_auth_reads_raw_solution_signals():
+    v = _scan(_RAW_HEADER_RE, _ALLOWED_FILES_RAW) + _scan(
+        _RAW_QUERY_RE, _ALLOWED_FILES_RAW
+    )
+    assert not v, (
+        "Raw ?solution= / X-Bifrost-App parsing outside core/auth.py — "
+        "read ctx.solution_id via services/solution_scope.py instead:\n"
+        + "\n".join(v)
+    )
+
+
+def test_app_to_solution_mapping_is_canonical():
+    v = _scan(_APP_TO_SOLUTION_RE, _ALLOWED_FILES_APP_MAP)
+    assert not v, (
+        "Application.solution_id scope mapping outside the canonical sites — "
+        "use solution_context_id / derive_execution_solution_scope:\n"
+        + "\n".join(v)
+    )
+
+
+def test_ctx_solution_id_parse_is_canonical():
+    v = _scan(_CTX_PARSE_RE, _ALLOWED_FILES_CTX_PARSE)
+    assert not v, (
+        "Inline UUID(str(ctx.solution_id)) parse — use "
+        "solution_scope.parse_ctx_solution_id:\n" + "\n".join(v)
+    )

--- a/api/tests/unit/test_solution_start_env.py
+++ b/api/tests/unit/test_solution_start_env.py
@@ -1,0 +1,27 @@
+"""The `solution start` Vite child must ride the LOCAL PROXY, not the upstream.
+
+The proxy is where install scope gets injected (?solution=, auth, app header).
+Pointing the app bundle's BIFROST_API_URL at the upstream API bypasses that
+injection entirely: local workflow edits silently don't run locally, the
+install's own tables 404, and declared-location file writes 403 (drive
+finding, 2026-07-02). The one authoritative origin for a `solution start`
+browser session is the proxy origin.
+"""
+from bifrost.commands.solution import _vite_child_env
+
+
+def test_vite_child_env_points_bundle_at_local_proxy():
+    env = _vite_child_env(
+        {"PATH": "/usr/bin", "BIFROST_API_URL": "http://upstream:34173"},
+        app_id="2a9d06da-cc86-49ff-b3b5-26748c31f73e",
+        org_id="",
+        proxy_origin="http://127.0.0.1:3777",
+        access_token="tok",
+    )
+    # The bundle-visible API URL is the PROXY, never the upstream.
+    assert env["BIFROST_API_URL"] == "http://127.0.0.1:3777"
+    assert env["VITE_BIFROST_APP_ID"] == "2a9d06da-cc86-49ff-b3b5-26748c31f73e"
+    assert env["VITE_BIFROST_ORG_ID"] == ""
+    assert env["BIFROST_ACCESS_TOKEN"] == "tok"
+    # Base env is inherited, not replaced.
+    assert env["PATH"] == "/usr/bin"

--- a/api/tests/unit/test_solution_start_env.py
+++ b/api/tests/unit/test_solution_start_env.py
@@ -7,7 +7,46 @@ install's own tables 404, and declared-location file writes 403 (drive
 finding, 2026-07-02). The one authoritative origin for a `solution start`
 browser session is the proxy origin.
 """
-from bifrost.commands.solution import _vite_child_env
+from bifrost.commands import solution as solution_cmd
+from bifrost.commands.solution import _scaffold_api_url, _vite_child_env
+
+
+class TestScaffoldApiUrl:
+    """scaffold-app must never bake the hardcoded localhost:8000 fallback when
+    a real URL is knowable — explicit flag > env > the authenticated client."""
+
+    def test_explicit_flag_wins(self, monkeypatch):
+        monkeypatch.setenv("BIFROST_API_URL", "http://env:1")
+        assert _scaffold_api_url("http://flag:2") == "http://flag:2"
+
+    def test_env_wins_over_client(self, monkeypatch):
+        monkeypatch.setenv("BIFROST_API_URL", "http://env:1")
+        monkeypatch.setattr(
+            solution_cmd.BifrostClient,
+            "get_instance",
+            staticmethod(lambda require_auth=True: type("C", (), {"api_url": "http://client:3"})()),
+        )
+        assert _scaffold_api_url(None) == "http://env:1"
+
+    def test_logged_in_client_beats_hardcoded_fallback(self, monkeypatch):
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+        monkeypatch.setattr(
+            solution_cmd.BifrostClient,
+            "get_instance",
+            staticmethod(lambda require_auth=True: type("C", (), {"api_url": "http://client:3"})()),
+        )
+        assert _scaffold_api_url(None) == "http://client:3"
+
+    def test_hardcoded_fallback_only_when_logged_out(self, monkeypatch):
+        monkeypatch.delenv("BIFROST_API_URL", raising=False)
+
+        def _not_logged_in(require_auth=True):
+            raise RuntimeError("Not logged in")
+
+        monkeypatch.setattr(
+            solution_cmd.BifrostClient, "get_instance", staticmethod(_not_logged_in)
+        )
+        assert _scaffold_api_url(None) == "http://localhost:8000"
 
 
 def test_vite_child_env_points_bundle_at_local_proxy():

--- a/client/e2e/solution-runtime-contract.admin.spec.ts
+++ b/client/e2e/solution-runtime-contract.admin.spec.ts
@@ -1,0 +1,282 @@
+/**
+ * Golden deployed-app runtime-scope contract (Chromium, real deploy).
+ *
+ * Deploys a Solution workspace zip (workflow + table + file location) with a
+ * standalone_v2 app whose entry module uses ONLY the transport contract —
+ * Authorization + X-Bifrost-App headers, a portable path::fn workflow ref,
+ * no UUIDs, no body app_id — and asserts workflow, table, and file access
+ * all resolve the install's own resources in a real browser.
+ *
+ * This is the regression net for the 2026-06/07 runtime-scope split: each
+ * data plane (workflows, tables, files) previously derived install scope its
+ * own way, so deployed apps worked for UUID workflow refs but 404'd portable
+ * refs. The contract is: auth derives ctx.solution_id from the transport;
+ * every resolver reads the context. See
+ * api/src/repositories/README.md ("How the install id is DERIVED").
+ */
+
+import { test, expect } from "./fixtures/api-fixture";
+
+const UNIQUE = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e4)}`;
+const SLUG = `runtime-contract-${UNIQUE}`;
+const APP_SLUG = `app-${SLUG}`;
+const TABLE_NAME = `runtime_items_${UNIQUE}`;
+
+const WORKFLOW_PY = [
+	"from bifrost import tables, workflow",
+	"",
+	"@workflow",
+	"async def main():",
+	`    await tables.upsert(${JSON.stringify(TABLE_NAME)}, id='probe-row', data={'k': 'v'})`,
+	"    return {'marker': 'golden'}",
+	"",
+].join("\n");
+
+// The app entry: a plain ES module (no build step). The shell sets
+// window.__BIFROST_APP__ BEFORE importing it (StandaloneV2App contract).
+// It exercises the three data planes with header-only scoping and renders
+// one data-testid marker per plane.
+const ENTRY_JS = `
+const boot = window.__BIFROST_APP__;
+const el = boot.mountEl;
+const h = {
+  Authorization: "Bearer " + boot.token,
+  "X-Bifrost-App": boot.appId,
+  "Content-Type": "application/json",
+};
+const call = (path, init) =>
+  fetch(boot.baseUrl + path, { credentials: "omit", ...init, headers: h });
+const mark = (id, txt) => {
+  const d = document.createElement("div");
+  d.dataset.testid = id;
+  d.textContent = txt;
+  el.appendChild(d);
+};
+(async () => {
+  try {
+    const wf = await call("/api/workflows/execute", {
+      method: "POST",
+      body: JSON.stringify({ workflow_id: "workflows/runtime.py::main", sync: true }),
+    }).then((r) => r.json());
+    mark("workflow-result", (wf.result && wf.result.marker) || "FAIL:" + JSON.stringify(wf).slice(0, 300));
+
+    const tq = await call("/api/tables/${TABLE_NAME}/documents/query", {
+      method: "POST",
+      body: JSON.stringify({ limit: 10 }),
+    }).then((r) => r.json());
+    const docs = Array.isArray(tq) ? tq : tq.documents;
+    mark("table-result", Array.isArray(docs) ? "rows:" + docs.length : "FAIL:" + JSON.stringify(tq).slice(0, 300));
+
+    const wr = await call("/api/files/write", {
+      method: "POST",
+      body: JSON.stringify({ path: "probe.txt", content: "ok", location: "docs", mode: "cloud", scope: null, binary: false }),
+    });
+    if (!wr.ok) {
+      mark("file-result", "FAIL:write:" + wr.status);
+      return;
+    }
+    const rd = await call("/api/files/read", {
+      method: "POST",
+      body: JSON.stringify({ path: "probe.txt", location: "docs", mode: "cloud", scope: null, binary: false }),
+    }).then((r) => r.json());
+    mark("file-result", rd.content === "ok" ? "ok" : "FAIL:" + JSON.stringify(rd).slice(0, 300));
+  } catch (e) {
+    mark("fatal", String(e));
+  }
+})();
+`;
+
+const INDEX_HTML = `<!doctype html><html><body><div id="root"></div><script type="module" src="/dist/main.js"></script></body></html>`;
+
+// ---------------------------------------------------------------------------
+// Minimal store-only zip writer (same approach as
+// solution-files-link.admin.spec.ts — no zip dependency in the e2e runner).
+// ---------------------------------------------------------------------------
+
+const CRC_TABLE = (() => {
+	const table = new Uint32Array(256);
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+		for (let k = 0; k < 8; k++) {
+			c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		}
+		table[n] = c >>> 0;
+	}
+	return table;
+})();
+
+function crc32(input: Buffer): number {
+	let crc = 0xffffffff;
+	for (const byte of input) {
+		crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+	}
+	return (crc ^ 0xffffffff) >>> 0;
+}
+
+function buildZip(entries: { path: string; content: string }[]): Buffer {
+	const localParts: Buffer[] = [];
+	const centralParts: Buffer[] = [];
+	let offset = 0;
+
+	for (const entry of entries) {
+		const name = Buffer.from(entry.path);
+		const data = Buffer.from(entry.content);
+		const checksum = crc32(data);
+		const local = Buffer.alloc(30);
+		local.writeUInt32LE(0x04034b50, 0);
+		local.writeUInt16LE(20, 4);
+		local.writeUInt16LE(0, 6);
+		local.writeUInt16LE(0, 8);
+		local.writeUInt32LE(checksum, 14);
+		local.writeUInt32LE(data.length, 18);
+		local.writeUInt32LE(data.length, 22);
+		local.writeUInt16LE(name.length, 26);
+		local.writeUInt16LE(0, 28);
+		localParts.push(local, name, data);
+
+		const central = Buffer.alloc(46);
+		central.writeUInt32LE(0x02014b50, 0);
+		central.writeUInt16LE(20, 4);
+		central.writeUInt16LE(20, 6);
+		central.writeUInt16LE(0, 8);
+		central.writeUInt16LE(0, 10);
+		central.writeUInt32LE(checksum, 16);
+		central.writeUInt32LE(data.length, 20);
+		central.writeUInt32LE(data.length, 24);
+		central.writeUInt16LE(name.length, 28);
+		central.writeUInt16LE(0, 30);
+		central.writeUInt16LE(0, 32);
+		central.writeUInt32LE(offset, 42);
+		centralParts.push(central, name);
+		offset += local.length + name.length + data.length;
+	}
+
+	const centralDirectory = Buffer.concat(centralParts);
+	const end = Buffer.alloc(22);
+	end.writeUInt32LE(0x06054b50, 0);
+	end.writeUInt16LE(entries.length, 8);
+	end.writeUInt16LE(entries.length, 10);
+	end.writeUInt32LE(centralDirectory.length, 12);
+	end.writeUInt32LE(offset, 16);
+	return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+// YAML members written as JSON — YAML 1.2 parses JSON, and it spares the
+// runner a yaml dependency.
+function workspaceZip(): Buffer {
+	const workflowId = crypto.randomUUID();
+	const tableId = crypto.randomUUID();
+	const appId = crypto.randomUUID();
+	return buildZip([
+		{
+			path: "bifrost.solution.yaml",
+			content: JSON.stringify({
+				slug: SLUG,
+				name: SLUG.toUpperCase(),
+				global_repo_access: false,
+			}),
+		},
+		{ path: "workflows/runtime.py", content: WORKFLOW_PY },
+		{
+			path: ".bifrost/workflows.yaml",
+			content: JSON.stringify({
+				workflows: {
+					[workflowId]: {
+						id: workflowId,
+						name: `runtime_${UNIQUE}`,
+						function_name: "main",
+						path: "workflows/runtime.py",
+						type: "workflow",
+					},
+				},
+			}),
+		},
+		{
+			path: ".bifrost/tables.yaml",
+			content: JSON.stringify({
+				tables: {
+					[tableId]: {
+						id: tableId,
+						name: TABLE_NAME,
+						schema: { columns: [{ name: "k" }] },
+						policies: null,
+					},
+				},
+			}),
+		},
+		{ path: ".bifrost/files.yaml", content: JSON.stringify({ locations: ["docs"] }) },
+		{
+			path: ".bifrost/apps.yaml",
+			content: JSON.stringify({
+				apps: {
+					[appId]: {
+						id: appId,
+						slug: APP_SLUG,
+						name: "Runtime Contract",
+						app_model: "standalone_v2",
+						dependencies: {},
+						access_level: "authenticated",
+						path: `apps/${APP_SLUG}`,
+						// Prebuilt fast-path: no src_files, dist carried inline.
+						dist_files: { "index.html": INDEX_HTML, "main.js": ENTRY_JS },
+					},
+				},
+			}),
+		},
+	]);
+}
+
+test.describe("deployed solution runtime contract", () => {
+	test("workflow/table/file resolve via the header contract in the browser", async ({
+		page,
+		api,
+	}) => {
+		test.setTimeout(120_000);
+
+		// No UUID workaround: the fixture app module must carry no UUID.
+		expect(ENTRY_JS).not.toMatch(
+			/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+		);
+
+		// --- create the install, then deploy the workspace zip ---
+		const sol = await api.post("/api/solutions", {
+			data: { slug: SLUG, name: SLUG, scope: "global", global_repo_access: false },
+		});
+		expect(sol.ok(), await sol.text()).toBeTruthy();
+		const sid = (await sol.json()).id;
+
+		const dep = await page.context().request.post(`/api/solutions/${sid}/deploy`, {
+			headers: await api.csrfHeader(),
+			multipart: {
+				file: {
+					name: "solution.zip",
+					mimeType: "application/zip",
+					buffer: workspaceZip(),
+				},
+			},
+		});
+		expect(dep.status(), await dep.text()).toBe(202);
+		const jobId = (await dep.json()).deploy_job_id;
+		await expect
+			.poll(
+				async () => {
+					const st = await api.get(`/api/solutions/deploy-jobs/${jobId}`);
+					const body = await st.json();
+					if (body.status === "failed") {
+						throw new Error(`deploy failed: ${body.error}`);
+					}
+					return body.status;
+				},
+				{ timeout: 60_000 },
+			)
+			.toBe("succeeded");
+
+		// --- drive the deployed app in the browser ---
+		await page.goto(`/apps/${APP_SLUG}`);
+		await expect(page.getByTestId("workflow-result")).toHaveText("golden", {
+			timeout: 30_000,
+		});
+		await expect(page.getByTestId("table-result")).toHaveText(/rows:[1-9]/);
+		await expect(page.getByTestId("file-result")).toHaveText("ok");
+	});
+});

--- a/client/src/lib/app-sdk/provider.test.tsx
+++ b/client/src/lib/app-sdk/provider.test.tsx
@@ -64,6 +64,62 @@ describe("BifrostProvider", () => {
     expect(captured!.auth).toBe("Bearer tok-abc");
   });
 
+  it("attaches X-Bifrost-App on authedFetch so workflow calls carry the app scope", async () => {
+    // Tables/files scope via the transport's X-Bifrost-App header; workflow
+    // execution goes through authedFetch. Both must carry the same context
+    // signal or the server derives a different install scope per surface.
+    let captured: { appHeader: string | null } | null = null;
+    const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      captured = { appHeader: headers.get("X-Bifrost-App") };
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    function Caller() {
+      const { authedFetch } = useBifrostContext();
+      void authedFetch("/api/workflows/execute", { method: "POST" });
+      return <span>called</span>;
+    }
+
+    render(
+      <BifrostProvider
+        baseUrl="https://dev.example"
+        token="tok-abc"
+        appId="app-777"
+        fetchImpl={fakeFetch}
+      >
+        <Caller />
+      </BifrostProvider>,
+    );
+    await Promise.resolve();
+    expect(captured).not.toBeNull();
+    expect(captured!.appHeader).toBe("app-777");
+  });
+
+  it("omits X-Bifrost-App on authedFetch when no appId is bound", async () => {
+    let captured: { appHeader: string | null } | null = null;
+    const fakeFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      captured = { appHeader: headers.get("X-Bifrost-App") };
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    function Caller() {
+      const { authedFetch } = useBifrostContext();
+      void authedFetch("/api/workflows/execute", { method: "POST" });
+      return <span>called</span>;
+    }
+
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="tok-abc" fetchImpl={fakeFetch}>
+        <Caller />
+      </BifrostProvider>,
+    );
+    await Promise.resolve();
+    expect(captured).not.toBeNull();
+    expect(captured!.appHeader).toBeNull();
+  });
+
   it("routes the table SDK through baseUrl + bearer while mounted", async () => {
     const { tables } = await import("./tables");
     const fetchMock = vi

--- a/client/src/lib/app-sdk/provider.tsx
+++ b/client/src/lib/app-sdk/provider.tsx
@@ -180,6 +180,12 @@ export function BifrostProvider({
       if (orgScope && !headers.has("X-Bifrost-Org")) {
         headers.set("X-Bifrost-Org", orgScope);
       }
+      // Same context signal the tables/files transport sends: the server's
+      // auth layer resolves it to the install scope (ctx.solution_id), so a
+      // workflow path::fn ref scopes to THIS install without body plumbing.
+      if (appId && !headers.has("X-Bifrost-App")) {
+        headers.set("X-Bifrost-App", appId);
+      }
       return baseFetch(joinUrl(baseUrl, input), { ...init, headers });
     };
     const logout = () => onLogout?.();

--- a/docs/superpowers/plans/2026-07-01-solution-scope-institutionalization.md
+++ b/docs/superpowers/plans/2026-07-01-solution-scope-institutionalization.md
@@ -610,6 +610,31 @@ Drive findings recorded, NOT yet fixed:
   resolver, but it masks scope-loss bugs; the diagnostics task (plan Task 5
   of the original Codex plan) would make such degradation visible.
 
+## Completeness audit (2026-07-02): which surfaces actually have an install tier
+
+The work above institutionalized request-side derivation for the surfaces
+that HAD install tiers. A full audit of every entity type a Solution ships
+or touches found four data planes with NO install tier at all — the values
+live in a shared org/global namespace and the resolvers never narrow:
+
+| Surface | Ships in bundle? | Runtime install-scoped? | Gap |
+|---|---|---|---|
+| Workflow bodies (tables/files SDK) | yes | **yes** — worker re-derives from the workflow row (`execution/service.py` → consumer → engine ctx) for ALL callers (forms, agents' tools, events, schedules) | none |
+| Events → solution workflow | yes | **yes** (via workflow row) | none |
+| Forms | yes | **yes** (`form.solution_id` as resolution scope) | none |
+| MCP/CLI authoring | n/a | deliberately `solution_id IS NULL`-only | by design |
+| **Config VALUES** | schema only (`SolutionConfigSchema`) | **NO** — `Config` has no `solution_id`; SDK client (`api/bifrost/config.py`) never sends `?solution=`; `cli_get_config` → `merged_for_sdk` org/global only; Setup matches by `(org, key)` | two installs (or two solutions) sharing a key in one org silently share/clobber ONE value row |
+| **Knowledge** | no | **NO** — no `solution_id` on `KnowledgeStore`; org+global fallback; agent search runs at org scope | namespaces collide across installs; solutions can't own a corpus |
+| **Connections/Integrations** | declaration only (`SolutionConnectionSchema`) | **NO** — `integrations.get(name)` resolves by NAME at org/global; the install id is used ONLY for the declared-but-unset 424 | two solutions expecting different "CRM" bindings collide on the name |
+| **OAuth tokens** | no | **NO** — provider-keyed org→global cascade | all installs share the provider token |
+| **Agents (agent-LEVEL access)** | yes (`Agent.solution_id`) | **partial** — tool workflows scope via their own rows, but `agent.solution_id` never enters the run context (`agent_runs.py` enqueue, `consumers/agent_run.py`); agent-level SDK access (knowledge search) runs org-scoped; asymmetric with forms | a solution agent's own-surface reads are unscoped; a mis-bound foreign tool workflow runs at the foreign scope |
+
+Follow-on work (largest first): config value install tier (schema migration
+`Config.solution_id` + own-first tier in `merged_for_sdk`/`cli_get_config` +
+SDK client sends `?solution=` + Setup stamps the install + uninstall
+lifecycle + enforcement-test extension), connection per-install binding,
+agent-level scope propagation, knowledge install namespace (product call).
+
 ## Decision points for Jack (explicitly NOT decided by this plan)
 
 1. **Config solution tier** — `Config` has no `solution_id` column; a solution workflow reading config today gets the plain org/global cascade. Giving configs the own-first tier tables/files have = schema migration + product semantics. Related to the parked data-fallback question.

--- a/docs/superpowers/plans/2026-07-01-solution-scope-institutionalization.md
+++ b/docs/superpowers/plans/2026-07-01-solution-scope-institutionalization.md
@@ -629,11 +629,15 @@ live in a shared org/global namespace and the resolvers never narrow:
 | **OAuth tokens** | no | **NO** — provider-keyed org→global cascade | all installs share the provider token |
 | **Agents (agent-LEVEL access)** | yes (`Agent.solution_id`) | **partial** — tool workflows scope via their own rows, but `agent.solution_id` never enters the run context (`agent_runs.py` enqueue, `consumers/agent_run.py`); agent-level SDK access (knowledge search) runs org-scoped; asymmetric with forms | a solution agent's own-surface reads are unscoped; a mis-bound foreign tool workflow runs at the foreign scope |
 
-Follow-on work (largest first): config value install tier (schema migration
-`Config.solution_id` + own-first tier in `merged_for_sdk`/`cli_get_config` +
-SDK client sends `?solution=` + Setup stamps the install + uninstall
-lifecycle + enforcement-test extension), connection per-install binding,
-agent-level scope propagation, knowledge install namespace (product call).
+**RULING (Jack, 2026-07-02): configs, integrations/connections, oauth, and
+knowledge are SHARED BY DESIGN** — org/global namespaces; a Solution
+*declares* what it needs (SolutionConfigSchema / SolutionConnectionSchema →
+Setup wizard) and consumes the shared instance-owned value. Agents scoping
+through their tool workflows' rows (not agent.solution_id) is also intended.
+The table above is the documented boundary of the install-scoped world, not
+a backlog. Known sharp edge to keep in mind (accepted): two solutions
+declaring the same config key / connection name in one scope share one
+value — declaration keys are effectively a shared vocabulary.
 
 ## Decision points for Jack (explicitly NOT decided by this plan)
 

--- a/docs/superpowers/plans/2026-07-01-solution-scope-institutionalization.md
+++ b/docs/superpowers/plans/2026-07-01-solution-scope-institutionalization.md
@@ -1,0 +1,617 @@
+# Solution Runtime-Scope Institutionalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Solution install-scope derivation a single canonical machine (like org scoping's `OrgScopedRepository` + enforcement test), so no surface can quietly invent a new way to say "which install is calling."
+
+**Architecture:** Auth (`api/src/core/auth.py`) stays the ONLY parser of raw transport signals (`?solution=`, `X-Bifrost-App`). `api/src/services/solution_scope.py` becomes the ONLY consumer API for turning a request context (plus deprecated body-field compat inputs) into an install scope. A mechanical enforcement test (mirroring `test_org_scoping_enforcement.py`) fails the build on any new derivation site. The worker/engine path (scope from the workflow's own DB row) is already correct and gets documented, not changed. A golden Chromium e2e pins the deployed-app contract end-to-end.
+
+**Tech Stack:** FastAPI, SQLAlchemy async, pytest (`./test.sh`), Playwright (`./test.sh client e2e`), React app SDK.
+
+## Global Constraints
+
+- All backend tests run via `./test.sh` from the worktree root (never bare pytest on host).
+- TDD: every behavior change lands with a failing test first (pinning tests for already-correct behavior are labeled as such).
+- No new fallbacks or dead code; body-field compat inputs are kept ONLY because live SDKs send them, and are documented as deprecated.
+- The parked product decisions are OUT OF SCOPE (see "Decision points" at the end): config solution tier, data-fallback `global_repo_access` gating, body-field removal timing.
+
+## Context: current derivation sites (verified 2026-07-01)
+
+| Site | Signal read | Status |
+|---|---|---|
+| `core/auth.py:317-375` | raw `?solution=` + `X-Bifrost-App` → `ctx.solution_id`/`ctx.app_id` | canonical raw parser — keep |
+| `services/solution_scope.py::solution_context_id` | `ctx.solution_id`, `ctx.app_id` fallback | canonical consumer — keep, extend |
+| `routers/workflows.py::_derive_solution_scope` (~:700) | ctx + body `solution_id`/`form_id`/`app_id` | re-implementation → fold into service (Task 1) |
+| `routers/files.py::_ctx_solution_id` (:298) | `ctx.solution_id` direct parse | duplicate parse → delegate to service (Task 2) |
+| `routers/cli.py::cli_create_table` (:2776-2797) | raw `?solution=` + raw header + app→solution query | re-implemented raw parsing → use ctx + service (Task 3) |
+| `routers/forms.py:879,:1084` | form's OWN stored `solution_id` | correct (owned scope, not request-derived) — document only |
+| worker: `jobs/consumers/workflow_execution.py:570` | workflow row's `solution_id` | correct (execution identity from DB row) — document only |
+
+---
+
+### Task 1: Move workflow-execution scope derivation into `solution_scope.py`
+
+**Files:**
+- Modify: `api/src/services/solution_scope.py` (add `derive_execution_solution_scope`)
+- Modify: `api/src/routers/workflows.py:700-758` (delete `_derive_solution_scope`, call the service)
+- Test: `api/tests/unit/test_execute_solution_scope.py` (repoint imports, keep all cases)
+- Test: `api/tests/e2e/platform/test_execute_solution_scope_e2e.py` (repoint imports)
+
+**Interfaces:**
+- Produces: `async def derive_execution_solution_scope(db, ctx, *, solution_id: str | None, form_id: str | None, app_id: str | None) -> UUID | None` in `api/src/services/solution_scope.py`. Precedence: `ctx` (via `solution_context_id`) > body `solution_id` > `form_id` > `app_id`.
+
+- [ ] **Step 1: Repoint the unit tests to the new function (failing first)**
+
+In `api/tests/unit/test_execute_solution_scope.py`, replace the import and every call:
+
+```python
+from src.services.solution_scope import derive_execution_solution_scope
+```
+
+Every existing call `_derive_solution_scope(db, ...)` becomes `derive_execution_solution_scope(db, ctx, solution_id=..., form_id=..., app_id=...)` where `ctx` is `SimpleNamespace(solution_id=None, app_id=None)` for body-only cases. The three ctx tests pass `SimpleNamespace(solution_id=str(sid), app_id=None)` instead of the `ctx_solution_id=` kwarg. Same edit in `test_execute_solution_scope_e2e.py` (its two calls pass `SimpleNamespace(solution_id=None, app_id=None)`).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `./test.sh tests/unit/test_execute_solution_scope.py -q`
+Expected: FAIL — `ImportError: cannot import name 'derive_execution_solution_scope'`.
+
+- [ ] **Step 3: Implement the service function**
+
+Append to `api/src/services/solution_scope.py` (the `Form` import goes at the top of the function to match the file's lazy-import style; `Application` is already imported at module top):
+
+```python
+async def derive_execution_solution_scope(
+    db: AsyncSession,
+    ctx,
+    *,
+    solution_id: str | None,
+    form_id: str | None,
+    app_id: str | None,
+) -> UUID | None:
+    """Resolve the calling install's scope for workflow execution.
+
+    THE canonical derivation for /api/workflows/execute. Precedence:
+    request context (auth already resolved ?solution= / X-Bifrost-App —
+    the same signal tables/files scope by) > body solution_id (a Solution
+    form/agent that knows its own install) > form_id (Form.solution_id)
+    > app_id (Application.solution_id). The body fields are DEPRECATED
+    compatibility inputs — live SDKs still send them; removal requires a
+    CONTRACT_VERSION bump. A bad/foreign/missing reference yields None →
+    no narrowing (the path ref resolves the _repo/ row, or 404s for a
+    scoped caller). Each source is client-supplied; the resolver's own
+    org gate (cascade scope) prevents a foreign scope from reaching
+    another org's workflow.
+    """
+    from src.models.orm.forms import Form
+
+    ctx_scope = await solution_context_id(db, ctx)
+    if ctx_scope is not None:
+        return ctx_scope
+    if solution_id:
+        try:
+            return UUID(solution_id)
+        except ValueError:
+            return None
+    if form_id:
+        try:
+            form_uuid = UUID(form_id)
+        except ValueError:
+            return None
+        return (
+            await db.execute(select(Form.solution_id).where(Form.id == form_uuid))
+        ).scalar_one_or_none()
+    if app_id:
+        try:
+            app_uuid = UUID(app_id)
+        except ValueError:
+            return None
+        return (
+            await db.execute(
+                select(Application.solution_id).where(Application.id == app_uuid)
+            )
+        ).scalar_one_or_none()
+    return None
+```
+
+Note the ctx branch now goes through `solution_context_id`, which adds the `ctx.app_id` fallback the old router code lacked and drops the old invalid-ctx-falls-through-to-body path (`solution_context_id` returns None on unparseable ctx.solution_id, then body tiers run — same observable behavior; keep the `test_invalid_ctx_solution_id_falls_through_to_body` case, it must still pass).
+
+- [ ] **Step 4: Point the router at it and delete the private copy**
+
+In `api/src/routers/workflows.py`: delete the whole `_derive_solution_scope` function (:700-758) and change the call site (~:813):
+
+```python
+    from src.services.solution_scope import derive_execution_solution_scope
+
+    solution_scope = await derive_execution_solution_scope(
+        db,
+        ctx,
+        solution_id=request.solution_id,
+        form_id=request.form_id,
+        app_id=request.app_id,
+    )
+```
+
+(Import at the top of the file with the other `src.services` imports if the file's style prefers module-top imports — follow the file.)
+
+- [ ] **Step 5: Run tests**
+
+Run: `./test.sh tests/unit/test_execute_solution_scope.py tests/e2e/platform/test_execute_solution_scope_e2e.py tests/e2e/platform/test_solution_deploy_execution.py -q`
+Expected: PASS (all previous cases + ctx precedence + the header-only e2e).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/services/solution_scope.py api/src/routers/workflows.py api/tests/unit/test_execute_solution_scope.py api/tests/e2e/platform/test_execute_solution_scope_e2e.py
+git commit -m "refactor: fold workflow scope derivation into solution_scope service"
+```
+
+---
+
+### Task 2: One ctx-parse primitive, files router delegates
+
+**Files:**
+- Modify: `api/src/services/solution_scope.py` (add `parse_ctx_solution_id`, use it in `solution_context_id` and `file_read_tiers`)
+- Modify: `api/src/routers/files.py:298-307` (`_ctx_solution_id` delegates)
+- Test: `api/tests/unit/test_execute_solution_scope.py` (add parse cases)
+
+**Interfaces:**
+- Produces: `def parse_ctx_solution_id(ctx) -> UUID | None` in `api/src/services/solution_scope.py` — sync, no DB; returns the parsed `ctx.solution_id` or None.
+
+- [ ] **Step 1: Failing test**
+
+```python
+class TestParseCtxSolutionId:
+    def test_parses_valid_uuid(self):
+        from src.services.solution_scope import parse_ctx_solution_id
+        sid = uuid4()
+        assert parse_ctx_solution_id(SimpleNamespace(solution_id=str(sid))) == sid
+
+    def test_none_and_garbage_yield_none(self):
+        from src.services.solution_scope import parse_ctx_solution_id
+        assert parse_ctx_solution_id(SimpleNamespace(solution_id=None)) is None
+        assert parse_ctx_solution_id(SimpleNamespace(solution_id="nope")) is None
+```
+
+Run: `./test.sh tests/unit/test_execute_solution_scope.py -q` → FAIL (ImportError).
+
+- [ ] **Step 2: Implement + delegate**
+
+In `solution_scope.py`:
+
+```python
+def parse_ctx_solution_id(ctx) -> UUID | None:
+    """Parse ``ctx.solution_id`` (set by auth) into a UUID, or None.
+
+    THE single parse point — routers must not re-implement this
+    (test_solution_scope_enforcement.py)."""
+    raw = getattr(ctx, "solution_id", None)
+    if raw is None:
+        return None
+    try:
+        return UUID(str(raw))
+    except (ValueError, AttributeError, TypeError):
+        return None
+```
+
+Use it inside `solution_context_id` (replace its inline try/except block) and inside `file_read_tiers` (replace `UUID(str(ctx.solution_id))` at the solution-tier branch — note `file_read_tiers` checks `ctx.solution_id is None` first; keep that flow, just parse via the primitive and return `[]` if parse fails).
+
+In `files.py`, `_ctx_solution_id` becomes:
+
+```python
+def _ctx_solution_id(ctx: Context, location: str) -> UUID | None:
+    """Install UUID from context (canonical parse in solution_scope)."""
+    return parse_ctx_solution_id(ctx)
+```
+
+(Keep the `location` parameter only if call sites pass it — they do; do not change 10 call sites in this task.)
+
+- [ ] **Step 3: Run files + scope tests**
+
+Run: `./test.sh tests/unit/test_execute_solution_scope.py tests/unit/test_files_sdk_solution_scope.py tests/e2e/platform/test_solution_file_scope.py -q`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/src/services/solution_scope.py api/src/routers/files.py api/tests/unit/test_execute_solution_scope.py
+git commit -m "refactor: single parse primitive for ctx.solution_id"
+```
+
+---
+
+### Task 3: cli_create_table guard uses the canonical helper
+
+**Files:**
+- Modify: `api/src/routers/cli.py:2776-2797`
+- Test: `api/tests/unit/test_cli_sdk_table_create_guard.py` (new; or extend the existing test file covering cli_create_table — search `grep -rln "cli_create_table\|Tables must be declared" api/tests/` first and extend that file if one exists)
+
+- [ ] **Step 1: Find/write the failing test**
+
+The guard's behavior: creating a table from a solution execution context (`?solution=` or app header) is refused 404. Pin it through the canonical path — construct the request with `?solution=<active install id>`; assert 404 `"Tables must be declared by the solution manifest"`. If an existing e2e covers this (`grep -rn "must be declared" api/tests/`), extend it with an `X-Bifrost-App` variant; else add an e2e in `tests/e2e/platform/test_cli_solution_files.py`'s style. The new assertion to add BEFORE refactoring (should already pass — pinning): both signals refuse. Then refactor and re-run.
+
+- [ ] **Step 2: Refactor the guard**
+
+Replace the raw parsing in `cli_create_table` (`raw_request.query_params.get("solution")` + `raw_request.headers.get("X-Bifrost-App")` + inline `Application.solution_id` query) with the context-derived check:
+
+```python
+async def cli_create_table(
+    request: SDKTableCreateRequest,
+    ctx: Context,
+    current_user: CurrentUser,
+    db: AsyncSession = Depends(get_db),
+) -> SDKTableInfo:
+    """Create a new table via SDK."""
+    from src.services.solution_scope import solution_context_id
+    from src.models.orm.tables import Table
+
+    if await solution_context_id(db, ctx) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tables must be declared by the solution manifest",
+        )
+    ...  # rest unchanged
+```
+
+Behavior delta to verify intentionally: `get_execution_context` 409s an INACTIVE install's `?solution=`/header before the guard runs (previously the raw parse let an inactive-install call through to the 404 guard). 409 vs 404 for an inactive install is acceptable — both refuse; note it in the commit message. Check `Context` is imported in cli.py (it is used elsewhere in the file — verify with grep, add import if not).
+
+- [ ] **Step 3: Run**
+
+Run: `./test.sh tests/e2e/platform/test_cli_solution_files.py <the-guard-test-file> -q` → PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/src/routers/cli.py api/tests/
+git commit -m "refactor: cli table-create solution guard via canonical scope helper"
+```
+
+---
+
+### Task 4: Mechanical enforcement test
+
+**Files:**
+- Create: `api/tests/unit/test_solution_scope_enforcement.py` (mirror `api/tests/unit/test_org_scoping_enforcement.py`'s structure: regex scan + content-keyed allow-list)
+
+- [ ] **Step 1: Write the test (fails if any rule is violated — write it, run it, fix any stragglers it finds)**
+
+```python
+"""Mechanical enforcement of the Solution runtime-scope pattern.
+
+Three rules (see api/src/repositories/README.md, "How the install id
+reaches the resolver"):
+
+1. Only core/auth.py parses the raw transport signals: the literal
+   header name "X-Bifrost-App" and the ?solution= query param must not
+   be read anywhere else under api/src (comments/docstrings exempt via
+   allow-list).
+2. Only services/solution_scope.py and core/auth.py may map
+   Application.solution_id (app -> install) for scope purposes.
+3. Routers must not re-implement ctx.solution_id parsing: the pattern
+   `UUID(str(ctx.solution_id))` / `UUID(str(<x>.solution_id))` is owned
+   by solution_scope.parse_ctx_solution_id.
+
+Allow-lists are content-keyed with a justification comment each.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+API_SRC = Path(__file__).resolve().parents[2] / "src"
+
+_RAW_HEADER_RE = re.compile(r"""headers\.get\(\s*['"]X-Bifrost-App['"]""")
+_RAW_QUERY_RE = re.compile(r"""query_params\.get\(\s*['"]solution['"]""")
+_APP_TO_SOLUTION_RE = re.compile(r"select\(\s*Application\.solution_id\s*\)")
+_CTX_PARSE_RE = re.compile(r"UUID\(\s*str\(\s*ctx\.solution_id\s*\)\s*\)")
+
+_ALLOWED_FILES_RAW = {
+    Path("core/auth.py"),  # THE raw-signal parser
+}
+_ALLOWED_FILES_APP_MAP = {
+    Path("core/auth.py"),  # header gate maps app -> solution for the active-install check
+    Path("services/solution_scope.py"),  # canonical consumer API
+}
+
+
+def _scan(pattern: re.Pattern, allowed: set[Path]) -> list[str]:
+    violations = []
+    for py in API_SRC.rglob("*.py"):
+        rel = py.relative_to(API_SRC)
+        if rel in allowed:
+            continue
+        for i, line in enumerate(py.read_text().splitlines(), 1):
+            if pattern.search(line):
+                violations.append(f"{rel}:{i}: {line.strip()}")
+    return violations
+
+
+def test_only_auth_reads_raw_solution_signals():
+    v = _scan(_RAW_HEADER_RE, _ALLOWED_FILES_RAW) + _scan(_RAW_QUERY_RE, _ALLOWED_FILES_RAW)
+    assert not v, (
+        "Raw ?solution= / X-Bifrost-App parsing outside core/auth.py — "
+        "use ctx.solution_id via services/solution_scope.py:\n" + "\n".join(v)
+    )
+
+
+def test_app_to_solution_mapping_is_canonical():
+    v = _scan(_APP_TO_SOLUTION_RE, _ALLOWED_FILES_APP_MAP)
+    assert not v, (
+        "Application.solution_id scope mapping outside the canonical sites — "
+        "use solution_context_id / derive_execution_solution_scope:\n" + "\n".join(v)
+    )
+
+
+def test_ctx_solution_id_parse_is_canonical():
+    allowed = {Path("services/solution_scope.py")}  # parse_ctx_solution_id lives here
+    v = _scan(_CTX_PARSE_RE, allowed)
+    assert not v, (
+        "Inline UUID(str(ctx.solution_id)) parse — use "
+        "solution_scope.parse_ctx_solution_id:\n" + "\n".join(v)
+    )
+```
+
+- [ ] **Step 2: Run it; fix any real violations it finds**
+
+Run: `./test.sh tests/unit/test_solution_scope_enforcement.py -q`
+Expected after Tasks 1–3: PASS. If it finds a site the earlier tasks missed, fix that site the same way (delegate to the service) — do NOT allow-list working code without a structural reason.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/tests/unit/test_solution_scope_enforcement.py
+git commit -m "test: enforce canonical solution-scope derivation"
+```
+
+---
+
+### Task 5: README contract section
+
+**Files:**
+- Modify: `api/src/repositories/README.md` (inside the "Solutions: first-stop resolution" section, after "### 2. Entity reads (the data side)")
+
+- [ ] **Step 1: Add the derivation contract subsection**
+
+```markdown
+### How the install id is DERIVED (the request side)
+
+Symmetric to gate 1's `resolve_effective_scope` for org scope, install
+scope has exactly one derivation chain — enforced by
+`tests/unit/test_solution_scope_enforcement.py`:
+
+- **`core/auth.py` is the ONLY parser of raw transport signals.** It reads
+  `?solution=` and `X-Bifrost-App`, validates them (UUID shape, active
+  install, header/param agreement), and sets `ctx.solution_id` /
+  `ctx.app_id` on the request's ExecutionContext.
+- **`services/solution_scope.py` is the ONLY consumer API.**
+  `parse_ctx_solution_id(ctx)` parses the context value;
+  `solution_context_id(db, ctx)` adds the app→install fallback;
+  `derive_execution_solution_scope(db, ctx, ...)` adds workflow-execute's
+  deprecated body-field compat tiers (body `solution_id` > `form_id` >
+  `app_id`). Routers call these; they never parse signals themselves.
+- **Body fields on /api/workflows/execute are DEPRECATED compat.** Live
+  SDKs still send them; removing them is a CONTRACT_VERSION bump.
+- **The worker path derives scope from the workflow's own DB row**
+  (`jobs/consumers/workflow_execution.py` → `workflow_data["solution_id"]`),
+  NOT from request signals — execution identity is the row's, by design.
+  Forms likewise use their own stored `form.solution_id` (owned scope).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add api/src/repositories/README.md
+git commit -m "docs: solution scope derivation contract"
+```
+
+---
+
+### Task 6: Negative e2e — foreign header cannot cross org scope
+
+**Files:**
+- Test: `api/tests/e2e/platform/test_solution_deploy_execution.py` (append)
+
+This is a PINNING test (expected to pass — the resolver's org gate already blocks it). It exists so the ctx-first change can never silently relax the org boundary.
+
+- [ ] **Step 1: Write the test**
+
+```python
+def test_foreign_app_header_cannot_reach_other_orgs_workflow(
+    e2e_client, platform_admin, org_user_factory
+):
+    """A user from another org smuggling org A's X-Bifrost-App must NOT
+    resolve org A's install workflow (the resolver's org gate holds under
+    ctx-first scoping)."""
+    headers = platform_admin.headers
+    app_a = _deploy_install_with_app(e2e_client, headers, "xorg")
+
+    outsider = org_user_factory()  # regular user in a different org
+    resp = e2e_client.post(
+        "/api/workflows/execute",
+        headers={**outsider.headers, "X-Bifrost-App": app_a},
+        json={"workflow_id": "workflows/main.py::main", "sync": True},
+    )
+    assert resp.status_code in (403, 404), resp.text
+```
+
+Check the actual fixture name for "regular user in another org" first: `grep -rn "def org_user_factory\|def regular_user\|def second_org" api/tests/e2e/ | head`. Use whatever exists (e.g. a `create_user_in_org` helper); if the platform's global-scope solutions make org gating vacuous for `scope: "global"` installs, deploy the fixture solution with an org-bound scope instead (`"scope": "organization"` + the org id) so the boundary is real.
+
+- [ ] **Step 2: Run**
+
+Run: `./test.sh tests/e2e/platform/test_solution_deploy_execution.py -q` → PASS. If it FAILS (cross-org leak), STOP — that is a security finding; report before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/tests/e2e/platform/test_solution_deploy_execution.py
+git commit -m "test: pin org gate under header-derived solution scope"
+```
+
+---
+
+### Task 7: Golden Chromium e2e — deployed app contract
+
+**Files:**
+- Create: `client/e2e/solution-runtime-contract.admin.spec.ts`
+
+The fixture app is a hand-written ES module (no Vite build): the shell reads the `<script type="module" src>` from dist `index.html` (`app_code_files.py::get_bundle_manifest`, standalone_v2 branch), imports it, and the module reads `window.__BIFROST_APP__` (set before import). The module exercises the THREE data planes with the header contract only — no body `app_id`, no UUIDs.
+
+- [ ] **Step 1: Write the spec**
+
+```typescript
+/**
+ * Golden deployed-app runtime-scope contract (Chromium, real deploy).
+ *
+ * Deploys a Solution (workflow + table + file location) with a
+ * standalone_v2 app whose entry module uses ONLY the transport contract
+ * (Authorization + X-Bifrost-App; portable path::fn ref; no UUIDs, no
+ * body app_id) and asserts workflow, table, and file access all resolve
+ * the install's own resources in a real browser.
+ */
+import { test, expect } from "@playwright/test";
+
+const SLUG = `runtime-contract-${Date.now().toString(36)}`;
+
+// The app entry: reads the bootstrap, exercises workflow/table/file with
+// header-only scoping, renders one marker per plane.
+const ENTRY_JS = `
+const boot = window.__BIFROST_APP__;
+const el = boot.mountEl;
+const h = { Authorization: "Bearer " + boot.token, "X-Bifrost-App": boot.appId, "Content-Type": "application/json" };
+const mark = (id, txt) => { const d = document.createElement("div"); d.dataset.testid = id; d.textContent = txt; el.appendChild(d); };
+(async () => {
+  try {
+    const wf = await fetch(boot.baseUrl + "/api/workflows/execute", { method: "POST", headers: h, body: JSON.stringify({ workflow_id: "workflows/runtime.py::main", sync: true }) }).then(r => r.json());
+    mark("workflow-result", wf.result && wf.result.marker || "FAIL:" + JSON.stringify(wf).slice(0, 200));
+    const rows = await fetch(boot.baseUrl + "/api/tables/runtime_items/documents", { headers: h }).then(r => r.json());
+    mark("table-result", Array.isArray(rows.documents) ? "rows:" + rows.documents.length : "FAIL:" + JSON.stringify(rows).slice(0, 200));
+    await fetch(boot.baseUrl + "/api/files/write", { method: "POST", headers: h, body: JSON.stringify({ path: "probe.txt", content: btoa("ok"), location: "docs" }) });
+    const rd = await fetch(boot.baseUrl + "/api/files/read", { method: "POST", headers: h, body: JSON.stringify({ path: "probe.txt", location: "docs" }) });
+    mark("file-result", rd.ok ? "ok" : "FAIL:" + rd.status);
+  } catch (e) { mark("fatal", String(e)); }
+})();
+`;
+
+test.describe("deployed solution runtime contract", () => {
+  test("workflow/table/file resolve via header contract in the browser", async ({ page, request }) => {
+    // No UUID workaround: the fixture must not embed any UUID.
+    expect(ENTRY_JS).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+
+    // --- deploy via API (same JSON-bundle path as the backend e2e) ---
+    const sol = await request.post("/api/solutions", { data: { slug: SLUG, name: SLUG, scope: "global", global_repo_access: false } });
+    expect(sol.ok()).toBeTruthy();
+    const sid = (await sol.json()).id;
+
+    const dep = await request.post(`/api/solutions/${sid}/deploy`, { data: {
+      python_files: { "workflows/runtime.py": [
+        "from bifrost import workflow, tables",
+        "", "@workflow", "async def main():",
+        "    await tables.insert('runtime_items', {'k': 'v'})",
+        "    return {'marker': 'golden'}", ""].join("\n") },
+      workflows: [{ id: crypto.randomUUID(), name: `runtime_${SLUG}`, function_name: "main", path: "workflows/runtime.py", type: "workflow" }],
+      tables: [{ id: crypto.randomUUID(), name: "runtime_items", definition: { columns: [{ name: "k" }] } }],
+      file_locations: ["docs"],
+      apps: [{ id: crypto.randomUUID(), slug: `app-${SLUG}`, name: "RC", app_model: "standalone_v2", dependencies: {}, access_level: "authenticated",
+        dist_files: { "index.html": `<!doctype html><div id="root"></div><script type="module" src="/dist/main.js"></script>`, "main.js": ENTRY_JS } }],
+    }});
+    expect([200, 201, 202]).toContain(dep.status());
+    if (dep.status() === 202) {
+      const jobId = (await dep.json()).deploy_job_id;
+      await expect.poll(async () => (await (await request.get(`/api/solutions/deploy-jobs/${jobId}`)).json()).status, { timeout: 30000 }).toBe("succeeded");
+    }
+
+    // --- drive the deployed app ---
+    await page.goto(`/apps/app-${SLUG}`);
+    await expect(page.getByTestId("workflow-result")).toHaveText("golden", { timeout: 20000 });
+    await expect(page.getByTestId("table-result")).toHaveText(/rows:[1-9]/);
+    await expect(page.getByTestId("file-result")).toHaveText("ok");
+  });
+});
+```
+
+Adjust to reality while implementing (the spec above is the shape, verify each endpoint contract as you go): (a) the deploy bundle key names for tables/file locations — mirror `api/tests/unit/test_solution_table_deploy.py::_table_entry` and `test_solution_file_locations.py`; (b) the table-documents read route + response shape (`client/src/lib/app-sdk/tables.ts` uses base `/api/tables`); (c) the files write/read request shape (`client/src/lib/app-sdk/files.ts:250,:214` — copy the exact body fields it sends, including how content is encoded); (d) how `request` inherits admin auth from the Playwright admin fixture (see `client/e2e/fixtures/auth-fixture.ts` and how sibling `.admin.spec.ts` files make API calls); (e) file write authorization relies on the #427 seeded solution-scoped `admin_bypass` policy — the admin fixture user is a platform admin so this passes. If sdk table insert route differs for the workflow body, check `api/bifrost/tables.py` for the SDK call shape (`tables.insert` may be `sdk.tables.get(...).insert(...)` — copy a working workflow from an existing e2e fixture, e.g. `test_solution_table_e2e.py`).
+
+- [ ] **Step 2: Run it**
+
+Run: `./test.sh client e2e e2e/solution-runtime-contract.admin.spec.ts`
+Expected: PASS with all three markers.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/e2e/solution-runtime-contract.admin.spec.ts
+git commit -m "test: golden deployed-app runtime-scope contract in Chromium"
+```
+
+---
+
+### Task 8: Full verification + drive matrix (manual, evidence required)
+
+**Files:** none (verification). Debug stack is up at the URL from `./debug.sh status`; scratch CLI venv at `/tmp/bifrost-cli-runtime-scope`.
+
+- [ ] **Step 1: Full suites**
+
+```bash
+./test.sh all              # expect: 0 failures
+./test.sh quality api      # expect: 0 errors
+(cd client && npm run tsc && npm run lint)
+./test.sh client unit
+./test.sh client e2e
+```
+
+- [ ] **Step 2: Drive matrix against the live debug stack** (each row needs observed evidence, not inference)
+
+| Angle | How | Expect |
+|---|---|---|
+| Deployed app, in-platform | Deploy the Task-7-style solution via CLI (`bifrost solution deploy` from a scratch workspace); open `/apps/<slug>` in Chrome (claude-in-chrome); check all three markers | workflow marker `golden`, table rows, file `ok` |
+| Local dev, out-of-platform | Same workspace, `bifrost solution start`; open the local URL in Chrome | same three markers via the local proxy (also proves accept-encoding fix live) |
+| CLI portable ref | `bifrost run "workflows/runtime.py::main"` bound to the install | executes install's own workflow |
+| Form-triggered (engine path) | Create a form bound to the solution workflow; submit in the platform UI | run succeeds; workflow's `tables.insert` hits the install's own table |
+| Negative | From a second non-admin user in another org, curl `/api/workflows/execute` with the app's `X-Bifrost-App` | 403/404, never another org's data |
+
+- [ ] **Step 3: Record results** — append a "Drive evidence" section to this plan file with per-row outcomes, then commit.
+
+---
+
+## Drive evidence (2026-07-02, debug stack + live browser)
+
+Fixture: solution `drive-rc` (global install `7cee7e28`), workflow
+`functions/hello.py::main` (upserts into own table `drive_items`, returns a
+marker), table + `docs` file location + `Drive Form`, standalone_v2 app
+`drive-app` (scaffolded via CLI, real React SDK: `useWorkflowQuery` portable
+ref + `tables.query` + `files.write/read`).
+
+| Angle | How | Result |
+|---|---|---|
+| Deployed app, in-platform | `bifrost solution deploy` → `/apps/drive-app` in the user's Chrome | PASS: `golden-drive` / `rows:1` / `ok` |
+| Local dev, out-of-platform | `bifrost solution start` → headless Chromium on the proxy origin | FAIL before fix (table 404, file 403, workflow silently ran the DEPLOYED copy) → **fixed** (`_vite_child_env` routes the bundle through the proxy) → PASS: workflow runs in-process, `rows:1`, file `ok` |
+| CLI portable ref | `bifrost workflows execute functions/hello.py::main` from the bound workspace | PASS: resolved the install's own workflow (`solution_id=7cee7e28`) |
+| Form-triggered (engine) | `Drive Form` submitted in the platform UI | PASS: Completed, result marker `golden-drive`, 162ms |
+| Negative | e2e `test_foreign_app_header_cannot_reach_other_orgs_workflow` (org2 user + org1 app header) + live unauthenticated curl with header | PASS: e2e green in full suite; live 401 |
+
+Drive findings fixed during the drive:
+- **`solution start` bundle bypassed the proxy** (BIFROST_API_URL pointed at
+  the upstream) — install tables 404'd, file writes 403'd, and local
+  workflow edits silently executed the deployed copy. Fixed +
+  `test_solution_start_env.py`.
+
+Drive findings recorded, NOT yet fixed:
+- `scaffold-app` bakes `http://localhost:8000` into `package.json` when
+  `BIFROST_API_URL` is absent from the workspace env at scaffold time — it
+  should fall back to the authenticated client's URL.
+- Local dev sends the MANIFEST app id (`VITE_BIFROST_APP_ID`, proxy
+  `X-Bifrost-App`); the deployed row id is uuid5-remapped, so the id never
+  resolves server-side. Harmless for scope now (the proxy's `?solution=` +
+  ctx-first execution carry it), but cosmetically wrong (logo 404s) and a
+  trap if anything ever trusts it. Consider resolving the deployed id via
+  `/api/solutions/{id}/entities` at start.
+- Unscoped path-ref courtesy fallback (no `_repo` row + exactly one visible
+  solution row → resolves it) let the pre-fix local drive "work" for
+  workflows while tables/files failed — deliberate and documented in the
+  resolver, but it masks scope-loss bugs; the diagnostics task (plan Task 5
+  of the original Codex plan) would make such degradation visible.
+
+## Decision points for Jack (explicitly NOT decided by this plan)
+
+1. **Config solution tier** — `Config` has no `solution_id` column; a solution workflow reading config today gets the plain org/global cascade. Giving configs the own-first tier tables/files have = schema migration + product semantics. Related to the parked data-fallback question.
+2. **Data-fallback gating** — `global_repo_access` gates code only; a "sealed" install can still read `_repo/` tables/configs by name (README "Open question"). Options documented in `docs/superpowers/specs/2026-06-08-solution-workflow-resolution-chokepoint-design.md`.
+3. **Body-field removal** — `solution_id`/`form_id`/`app_id` on `/api/workflows/execute` stay until forms/agents carry context signals; removal is a CONTRACT_VERSION bump.


### PR DESCRIPTION
## Summary

Every recurring Solutions scope bug (portable `path::fn` refs 404ing in deployed apps, local table reads missing install tables, file 403s, broken JSON under `solution start`) was one design flaw: each surface invented its own way to say "which install is calling." This PR makes install-scope derivation a single canonical machine — mirroring the org-scoping pattern — and pins the deployed-app contract in a real browser test.

### Fixes
- **ctx-first workflow execution**: `/api/workflows/execute` now scopes from the request context (`X-Bifrost-App` / `?solution=`, resolved once in auth) via the new canonical `derive_execution_solution_scope`; body `solution_id`/`form_id`/`app_id` remain as deprecated compat fallbacks.
- **App SDK parity**: `authedFetch` sends `X-Bifrost-App`, so workflow calls carry the same transport signal tables/files always had.
- **`solution start` rode past its own proxy**: the Vite child's `BIFROST_API_URL` pointed at the upstream API, so browser data-plane calls bypassed scope injection entirely — install tables 404'd, declared-location file writes 403'd, and local workflow edits silently executed the *deployed* copy. The bundle now routes through the proxy origin.
- **Proxy strips `accept-encoding`**: browsers advertise encodings httpx may not decode; compressed bodies reached Chromium labeled as plain JSON.
- **`scaffold-app` URL fallback**: resolves the instance URL from the authenticated client instead of baking `localhost:8000` when env is unset.
- **Scope diagnostics**: workflow-not-found 404 and file-policy 403 now carry their resolver inputs (ref, context solution, derived scope / action, location, install), so a scope-loss bug identifies itself.

### Institutionalization
- One derivation chain: `core/auth.py` is the only raw-signal parser; `services/solution_scope.py` is the only consumer API (workflows router's private resolver deleted; files + SDK table-create guard delegate).
- **`test_solution_scope_enforcement.py`** — build-failing tripwire (org-scoping-lint style) against any new derivation site.
- Contract documented in `api/src/repositories/README.md` ("How the install id is DERIVED"), including the shared-by-design ruling for configs/connections/knowledge.

### Tests
- New: ctx-precedence + parse-primitive units; header-only twin-install e2e; cross-org negative e2e (foreign `X-Bifrost-App` refused); scope-diagnostics e2e ×2; proxy encoding/env units; **golden Chromium e2e** (`client/e2e/solution-runtime-contract.admin.spec.ts`: real zip deploy, app source with zero UUIDs, workflow+table+file via the header contract in a browser).
- Full backend suite green (6791 passed / 0 failed pre-rebase; final-tree run in progress), `quality api` clean, client tsc/lint/vitest at known-good.
- Live five-angle drive against a dev stack: deployed app in a real browser, `solution start` local (found + fixed the proxy-bypass bug), CLI portable ref, form via platform UI, negative auth checks. Evidence in `docs/superpowers/plans/2026-07-01-solution-scope-institutionalization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBkPNpYXctrwfMwGxzjSS4