### PR TITLE
Fix org-bound install path::fn resolution + bound-workspace app ref preference

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -237,6 +237,11 @@ Usage: apps get [OPTIONS] REF
   UUID then locate the matching record from the list payload so this command
   works with any ref shape :class:`RefResolver` accepts.
 
+  Inside a BOUND solution workspace (BIFROST_SOLUTION_ID set), the install's
+  OWN apps are preferred: a generic ref like "portal" must not silently
+  resolve an unrelated global app when the workspace's app matches by slug or
+  name.
+
 Options:
   --json  Emit JSON instead of human-readable output.
   --help  Show this message and exit.

--- a/api/bifrost/commands/apps.py
+++ b/api/bifrost/commands/apps.py
@@ -113,6 +113,25 @@ async def list_apps(
     output_result(response.json(), ctx=ctx)
 
 
+def _select_bound_app(
+    items: list[dict[str, Any]], ref: str, solution_id: str
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """Pick the bound install's own app for ``ref`` (slug, or name
+    case-insensitively), plus any OTHER apps the ref also matches — so the
+    caller can warn that a generic ref ("portal") is ambiguous across
+    scopes instead of silently resolving an unrelated global app."""
+
+    def _matches(item: dict[str, Any]) -> bool:
+        return item.get("slug") == ref or (
+            str(item.get("name") or "").lower() == ref.lower()
+        )
+
+    matches = [i for i in items if _matches(i)]
+    own = [i for i in matches if str(i.get("solution_id") or "") == solution_id]
+    foreign = [i for i in matches if str(i.get("solution_id") or "") != solution_id]
+    return (own[0] if own else None), (foreign if own else [])
+
+
 @apps_group.command("get")
 @click.argument("ref")
 @click.pass_context
@@ -131,7 +150,13 @@ async def get_app(
     ``GET /api/applications/{slug}`` directly. For UUID / name refs we
     resolve to a UUID then locate the matching record from the list payload
     so this command works with any ref shape :class:`RefResolver` accepts.
+
+    Inside a BOUND solution workspace (BIFROST_SOLUTION_ID set), the
+    install's OWN apps are preferred: a generic ref like "portal" must not
+    silently resolve an unrelated global app when the workspace's app
+    matches by slug or name.
     """
+    import os
     from uuid import UUID
 
     try:
@@ -139,6 +164,24 @@ async def get_app(
         is_uuid = True
     except (TypeError, ValueError):
         is_uuid = False
+
+    bound_solution = os.getenv("BIFROST_SOLUTION_ID")
+    if not is_uuid and bound_solution:
+        list_response = await client.get("/api/applications")
+        list_response.raise_for_status()
+        data = list_response.json()
+        items = data.get("applications", []) if isinstance(data, dict) else data
+        own, foreign = _select_bound_app(items, ref, bound_solution)
+        if own is not None:
+            for other in foreign:
+                click.echo(
+                    f"Warning: {ref!r} also matches app {other.get('slug')!r} "
+                    f"({other.get('id')}) outside this solution — returning this "
+                    "workspace's own app. Use the UUID to target the other one.",
+                    err=True,
+                )
+            output_result(own, ctx=ctx)
+            return
 
     if not is_uuid:
         # Try the slug endpoint first — it's a single round-trip and works

--- a/api/src/repositories/workflows.py
+++ b/api/src/repositories/workflows.py
@@ -127,7 +127,13 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
                 Workflow.solution_id == solution_scope,
                 Workflow.is_active.is_(True),
             )
-            stmt = self._apply_cascade_scope(stmt)
+            # The own-install match is already install-gated by solution_id;
+            # org-gate it only for regular users. Superusers act cross-org
+            # here exactly as resolve_solution_table_by_name does for tables:
+            # an ORG-BOUND install's rows carry the INSTALL's org, which
+            # routinely differs from an admin caller's effective org.
+            if not self.is_superuser:
+                stmt = self._apply_cascade_scope(stmt)
             result = await self.session.execute(stmt)
             own = result.scalar_one_or_none()
             if own is not None:
@@ -150,6 +156,27 @@ class WorkflowRepository(OrgScopedRepository[Workflow]):
         path, _, function_name = ref.rpartition("::")
         if not path or not function_name:
             return None
+
+        if solution_scope is not None:
+            # Own-install first, WITHOUT the caller-org cascade for superusers:
+            # the match is already install-gated by solution_id, and an
+            # ORG-BOUND install's rows carry the INSTALL's org — which
+            # routinely differs from an admin caller's effective org (a demo/
+            # support admin driving a customer install saw 404s here while
+            # global installs, whose rows have organization_id NULL, passed).
+            # Regular users keep the cascade: their org must be the install's
+            # (the cross-org negative below relies on it).
+            own_stmt = select(Workflow).where(
+                Workflow.path == path,
+                Workflow.function_name == function_name,
+                Workflow.is_active.is_(True),
+                Workflow.solution_id == solution_scope,
+            )
+            if not self.is_superuser:
+                own_stmt = self._apply_cascade_scope(own_stmt)
+            own_row = (await self.session.execute(own_stmt)).scalars().first()
+            if own_row is not None:
+                return own_row
 
         stmt = (
             select(Workflow)

--- a/api/tests/e2e/platform/test_solution_deploy_execution.py
+++ b/api/tests/e2e/platform/test_solution_deploy_execution.py
@@ -305,6 +305,29 @@ def test_workflow_404_includes_scope_diagnostics(e2e_client, platform_admin):
     assert detail["derived_solution_scope"], detail
 
 
+def test_admin_resolves_orgbound_install_path_ref_cross_org(
+    e2e_client, platform_admin, org1
+):
+    """Dev14 regression: an ORG-BOUND install's workflows carry the install's
+    org; a platform admin whose effective org differs (the normal demo/support
+    posture) must still resolve the install's own workflow by path::fn via the
+    app header — superusers bypass the caller-org gate on the OWN-install
+    match, exactly like resolve_solution_table_by_name does for tables.
+    Global installs never caught this (their rows have organization_id NULL)."""
+    headers = platform_admin.headers
+    app_a = _deploy_install_with_app(e2e_client, headers, "orgbound", org_id=org1["id"])
+
+    resp = e2e_client.post(
+        "/api/workflows/execute",
+        headers={**headers, "X-Bifrost-App": app_a},
+        json={"workflow_id": "workflows/main.py::main", "sync": True},
+    )
+    assert resp.status_code == 200, f"execute failed: {resp.status_code} {resp.text}"
+    body = resp.json()
+    assert body["status"] == "Success", body
+    assert body["result"] == {"marker": "orgbound"}, body
+
+
 def test_foreign_app_header_cannot_reach_other_orgs_workflow(
     e2e_client, platform_admin, org1, org2_user
 ):

--- a/api/tests/unit/test_cli_apps_get_scope.py
+++ b/api/tests/unit/test_cli_apps_get_scope.py
@@ -1,0 +1,37 @@
+"""`bifrost apps get <ref>` inside a bound solution workspace prefers the
+install's own apps — a generic ref ("portal") must not silently resolve an
+unrelated global app when the workspace's own app matches by slug or name
+(RTM sharp edge, 2026-07-02)."""
+from bifrost.commands.apps import _select_bound_app
+
+SOL = "37937a44-1b0a-448d-a0cc-0896ca6a858c"
+
+ITEMS = [
+    {"id": "aaaa", "slug": "portal", "name": "Covi Portal", "solution_id": None},
+    {"id": "bbbb", "slug": "rtm-dms", "name": "Portal", "solution_id": SOL},
+    {"id": "cccc", "slug": "other", "name": "Other", "solution_id": "1111"},
+]
+
+
+def test_own_install_name_match_wins_over_foreign_slug():
+    match, foreign = _select_bound_app(ITEMS, "portal", SOL)
+    assert match is not None and match["id"] == "bbbb"
+    # The unrelated global slug match is surfaced for a warning.
+    assert [f["id"] for f in foreign] == ["aaaa"]
+
+
+def test_own_install_slug_match():
+    match, foreign = _select_bound_app(ITEMS, "rtm-dms", SOL)
+    assert match is not None and match["id"] == "bbbb"
+    assert foreign == []
+
+
+def test_no_own_match_returns_none():
+    match, foreign = _select_bound_app(ITEMS, "other", SOL)
+    assert match is None
+    assert foreign == []
+
+
+def test_name_match_is_case_insensitive():
+    match, _ = _select_bound_app(ITEMS, "PORTAL", SOL)
+    assert match is not None and match["id"] == "bbbb"

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -237,6 +237,11 @@ Usage: apps get [OPTIONS] REF
   UUID then locate the matching record from the list payload so this command
   works with any ref shape :class:`RefResolver` accepts.
 
+  Inside a BOUND solution workspace (BIFROST_SOLUTION_ID set), the install's
+  OWN apps are preferred: a generic ref like "portal" must not silently
+  resolve an unrelated global app when the workspace's app matches by slug or
+  name.
+
 Options:
   --json  Emit JSON instead of human-readable output.
   --help  Show this message and exit.


### PR DESCRIPTION
## Summary

Two follow-ups from the dev14 retest of #430 (repro notes: gocovi-bifrost-solutions `BIFROST_PLATFORM_ISSUES_2026-06-30.md` §10–11):

1. **Org-bound installs 404'd portable workflow refs.** #430 fixed scope *derivation* (the retest's failure diagnostics showed `derived_solution_scope` correctly populated), but the resolver then applied the **caller-org cascade** to own-install rows. An org-bound install's workflows carry the *install's* org — which routinely differs from a demo/support admin's effective org — so `path::fn` and name refs got filtered out before the own-first pick, while UUID refs worked. Global installs (rows with `organization_id NULL`) never caught it, which is exactly why #430's golden test missed this. Fix mirrors the tables resolver (`resolve_solution_table_by_name`): the own-install match is already install-gated by `solution_id`; the org cascade now applies to it only for regular users. The cross-org negative (foreign regular user refused) is unchanged and still pinned.

2. **`bifrost apps get <ref>` in a bound solution workspace preferred unrelated global apps.** A generic ref like `portal` hit the slug endpoint first and returned the global app instead of the workspace's own (RTM's `rtm-dms`, named "Portal"). Inside a bound workspace the install's own apps now win (slug or case-insensitive name), with a stderr warning when the ref also matches an app outside the solution.

## Tests
- New e2e: cross-org admin + org-bound install resolves `path::fn` via the app header (red on main, green here); existing cross-org negative and twin-install/global tests unchanged.
- New unit tests for the bound-workspace app selection helper.
- Full backend suite: 6812 passed / 0 failed. `quality api` clean. CLI surface smoke + DTO/contract tripwires green; CLI reference appendix regenerated + mirrors synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBkPNpYXctrwfMwGxzjSS4