### PR TITLE
Correct bifrost-build skill: workflow names resolve like path refs

### DIFF
--- a/.claude/skills/bifrost-build/references/web-sdk-v2.md
+++ b/.claude/skills/bifrost-build/references/web-sdk-v2.md
@@ -59,7 +59,7 @@ The light/dark toggle only appears when the parent `<BifrostProvider supportsThe
 
 ## Workflow Hooks
 
-Three hooks for running Bifrost workflows from a v2 app. Workflow refs are portable `path::function` strings (e.g. `functions/hello.py::main`) or UUIDs — bare names are not supported because they are not unique.
+Three hooks for running Bifrost workflows from a v2 app. Workflow refs are portable `path::function` strings (e.g. `functions/hello.py::main`), UUIDs, or workflow names — all three resolve identically, scoped to THIS install via the app transport. Prefer `path::function`: it is portable across environments (UUIDs are per-install) and it is the shape `bifrost solution start` executes locally (name/UUID refs proxy to the deployed copy).
 
 ### useWorkflowQuery — READ
 

--- a/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
+++ b/plugins/bifrost/skills/bifrost-build/references/web-sdk-v2.md
@@ -59,7 +59,7 @@ The light/dark toggle only appears when the parent `<BifrostProvider supportsThe
 
 ## Workflow Hooks
 
-Three hooks for running Bifrost workflows from a v2 app. Workflow refs are portable `path::function` strings (e.g. `functions/hello.py::main`) or UUIDs — bare names are not supported because they are not unique.
+Three hooks for running Bifrost workflows from a v2 app. Workflow refs are portable `path::function` strings (e.g. `functions/hello.py::main`), UUIDs, or workflow names — all three resolve identically, scoped to THIS install via the app transport. Prefer `path::function`: it is portable across environments (UUIDs are per-install) and it is the shape `bifrost solution start` executes locally (name/UUID refs proxy to the deployed copy).
 
 ### useWorkflowQuery — READ
 


### PR DESCRIPTION
## Summary

The `bifrost-build` skill's web-sdk-v2 reference told agents/users that bare workflow names are "not supported because they are not unique" and 404. That's false since the runtime-scope consolidation (#430/#431, parity pinned by e2e in #432): UUID, `path::function`, and workflow name all resolve identically, scoped own-install-first through the app transport. The reference now states that, and keeps `path::function` as the recommended shape (portable across environments + the shape `solution start` executes locally). Plugin mirror synced.

## Tests
- `test_codex_mirror_sync.py` / `test_skill_appendix_fresh.py` green (docs-only; no CLI surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBkPNpYXctrwfMwGxzjSS4