### PR TITLE
Fix schedule event timezone handling

### DIFF
--- a/api/src/jobs/schedulers/cron_scheduler.py
+++ b/api/src/jobs/schedulers/cron_scheduler.py
@@ -12,6 +12,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import sqlalchemy as sa
 from croniter import croniter
@@ -24,6 +25,41 @@ from src.models.orm.events import Event, EventDelivery, EventSource
 from src.repositories.events import EventSubscriptionRepository
 
 logger = logging.getLogger(__name__)
+
+
+def _get_schedule_zone(timezone_name: str) -> ZoneInfo:
+    try:
+        return ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown timezone: {timezone_name}") from exc
+
+
+def _next_interval_seconds(cron_expression: str, now_utc: datetime, timezone_name: str) -> float:
+    zone = _get_schedule_zone(timezone_name)
+    local_now = now_utc.astimezone(zone)
+    cron = croniter(cron_expression, local_now)
+    first_run = cron.get_next(datetime)
+    second_run = cron.get_next(datetime)
+    return (
+        second_run.astimezone(timezone.utc)
+        - first_run.astimezone(timezone.utc)
+    ).total_seconds()
+
+
+def _latest_due_run_utc(
+    cron_expression: str,
+    now_utc: datetime,
+    timezone_name: str,
+) -> datetime | None:
+    zone = _get_schedule_zone(timezone_name)
+    local_now = now_utc.astimezone(zone)
+    cron_iter = croniter(cron_expression, local_now)
+    prev_run = cron_iter.get_prev(datetime)
+    prev_run_utc = prev_run.astimezone(timezone.utc)
+    seconds_since_last = (now_utc - prev_run_utc).total_seconds()
+    if seconds_since_last >= 60:
+        return None
+    return prev_run_utc
 
 
 async def process_schedule_sources() -> dict[str, Any]:
@@ -65,7 +101,7 @@ async def process_schedule_sources() -> dict[str, Any]:
             sources = result.unique().scalars().all()
 
             results["total_sources"] = len(sources)
-            now = datetime.now(timezone.utc)
+            now_utc = datetime.now(timezone.utc)
 
             for source in sources:
                 try:
@@ -89,10 +125,11 @@ async def process_schedule_sources() -> dict[str, Any]:
 
                     # Check if schedule interval is too frequent
                     try:
-                        cron = croniter(cron_expression, now)
-                        first_run = cron.get_next(datetime)
-                        second_run = cron.get_next(datetime)
-                        interval_seconds = (second_run - first_run).total_seconds()
+                        interval_seconds = _next_interval_seconds(
+                            cron_expression,
+                            now_utc,
+                            ss.timezone,
+                        )
 
                         if interval_seconds < 300:  # Less than 5 minutes
                             logger.warning(
@@ -106,10 +143,24 @@ async def process_schedule_sources() -> dict[str, Any]:
 
                     # Check if the most recent cron match is within our polling window.
                     # We poll every 1 minute, so check if the last match was < 60s ago.
-                    cron_iter = croniter(cron_expression, now)
-                    prev_run = cron_iter.get_prev(datetime)
-                    seconds_since_last = (now - prev_run).total_seconds()
-                    if seconds_since_last >= 60:
+                    try:
+                        scheduled_at_utc = _latest_due_run_utc(
+                            cron_expression,
+                            now_utc,
+                            ss.timezone,
+                        )
+                    except ValueError as e:
+                        logger.warning(
+                            f"Invalid timezone for schedule source {source.id}: {ss.timezone}"
+                        )
+                        results["errors"].append({
+                            "source_id": str(source.id),
+                            "source_name": source.name,
+                            "error": str(e),
+                        })
+                        continue
+
+                    if scheduled_at_utc is None:
                         continue  # Last match was outside our polling window
 
                     # Check overlap policy: skip if a prior delivery is still active.
@@ -158,11 +209,11 @@ async def process_schedule_sources() -> dict[str, Any]:
                         id=uuid.uuid4(),
                         event_source_id=source.id,
                         event_type="schedule.fired",
-                        received_at=now,
+                        received_at=scheduled_at_utc,
                         data={
                             "cron_expression": cron_expression,
                             "timezone": ss.timezone,
-                            "scheduled_time": now.isoformat(),
+                            "scheduled_time": scheduled_at_utc.isoformat(),
                         },
                         status=EventStatus.PROCESSING,
                     )

--- a/api/src/models/contracts/scheduling.py
+++ b/api/src/models/contracts/scheduling.py
@@ -44,6 +44,10 @@ class AsyncExecution(BaseModel):
 class CronValidationRequest(BaseModel):
     """Request model for CRON validation"""
     expression: str = Field(..., description="CRON expression to validate")
+    timezone: str = Field(
+        default="UTC",
+        description="Timezone used to evaluate the CRON expression",
+    )
 
 
 class CronValidationResponse(BaseModel):

--- a/api/src/routers/schedules.py
+++ b/api/src/routers/schedules.py
@@ -7,6 +7,7 @@ Provides CRON expression validation for the event source UI.
 import logging
 from datetime import datetime, timezone
 from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter
 
@@ -26,19 +27,37 @@ router = APIRouter(prefix="/api/schedules", tags=["Schedules"])
 MIN_INTERVAL_SECONDS = 300
 
 
-def _validate_cron(expression: str) -> tuple[Literal["valid", "warning", "error"], str | None]:
+def _get_schedule_zone(timezone_name: str) -> ZoneInfo:
+    try:
+        return ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown timezone: {timezone_name}") from exc
+
+
+def _validate_cron(
+    expression: str,
+    timezone_name: str,
+) -> tuple[Literal["valid", "warning", "error"], str | None]:
     """Validate a CRON expression and return status with optional message."""
     if not is_cron_expression_valid(expression):
         return "error", "Invalid CRON expression"
 
+    try:
+        zone = _get_schedule_zone(timezone_name)
+    except ValueError as e:
+        return "error", str(e)
+
     # Check for too-frequent schedules (warning if < 5 minutes)
     try:
         from croniter import croniter
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).astimezone(zone)
         cron = croniter(expression, now)
         next1 = cron.get_next(datetime)
         next2 = cron.get_next(datetime)
-        interval = (next2 - next1).total_seconds()
+        interval = (
+            next2.astimezone(timezone.utc)
+            - next1.astimezone(timezone.utc)
+        ).total_seconds()
 
         if interval < MIN_INTERVAL_SECONDS:
             return "warning", f"Schedule runs more frequently than {MIN_INTERVAL_SECONDS // 60} minutes"
@@ -70,7 +89,16 @@ async def validate_cron_expression(
             error="CRON expression is required",
         )
 
-    validation_status, validation_message = _validate_cron(expression)
+    try:
+        zone = _get_schedule_zone(body.timezone)
+    except ValueError as e:
+        return CronValidationResponse(
+            valid=False,
+            human_readable="Invalid timezone",
+            error=str(e),
+        )
+
+    validation_status, validation_message = _validate_cron(expression, body.timezone)
 
     if validation_status == "error":
         return CronValidationResponse(
@@ -86,15 +114,20 @@ async def validate_cron_expression(
     interval_seconds: int | None = None
     try:
         from croniter import croniter
-        now = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).astimezone(zone)
         cron = croniter(expression, now)
         runs = []
         for _ in range(5):
             runs.append(cron.get_next(datetime))
-        next_runs = [r.isoformat() for r in runs]
+        next_runs = [r.astimezone(timezone.utc).isoformat() for r in runs]
 
         if len(runs) >= 2:
-            interval_seconds = int((runs[1] - runs[0]).total_seconds())
+            interval_seconds = int(
+                (
+                    runs[1].astimezone(timezone.utc)
+                    - runs[0].astimezone(timezone.utc)
+                ).total_seconds()
+            )
     except (ImportError, ValueError) as e:
         # croniter not installed or expression rejected — return validation without preview
         logger.debug(f"could not compute next runs for {log_safe(expression)!r}: {log_safe(e)}")

--- a/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
+++ b/api/tests/unit/jobs/schedulers/test_cron_scheduler.py
@@ -111,6 +111,54 @@ async def _count_events_for_source(db_session, source_id) -> int:
     return len(rows)
 
 
+async def _events_for_source(db_session, source_id) -> list[Event]:
+    rows = (
+        await db_session.execute(select(Event).where(Event.event_source_id == source_id))
+    ).scalars().all()
+    return list(rows)
+
+
+@pytest.mark.asyncio
+async def test_schedule_evaluates_cron_in_configured_timezone(db_session):
+    """A 9 AM New York schedule should fire at 14:00 UTC during EST."""
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            value = cls(2026, 1, 1, 14, 0, 30, tzinfo=timezone.utc)
+            if tz is None:
+                return value.replace(tzinfo=None)
+            return value.astimezone(tz)
+
+    source, ss, sub = _make_source_and_subscription(cron="0 9 * * *")
+    ss.timezone = "America/New_York"
+    db_session.add(source)
+    db_session.add(ss)
+    db_session.add(sub)
+    await db_session.commit()
+
+    mock_sub_repo = AsyncMock()
+    mock_sub_repo.get_active_for_event = AsyncMock(return_value=[])
+    mock_processor = AsyncMock()
+    mock_processor.queue_event_deliveries = AsyncMock(return_value=0)
+
+    from src.jobs.schedulers.cron_scheduler import process_schedule_sources
+
+    with (
+        patch(PATH_DB_CTX, return_value=_DbCtx(db_session)),
+        patch(PATH_IS_VALID, return_value=True),
+        patch(PATH_SUB_REPO, return_value=mock_sub_repo),
+        patch(PATH_PROCESSOR, return_value=mock_processor),
+        patch("src.jobs.schedulers.cron_scheduler.datetime", FrozenDateTime),
+    ):
+        await process_schedule_sources()
+
+    events = await _events_for_source(db_session, source.id)
+    assert len(events) == 1
+    assert events[0].received_at.isoformat() == "2026-01-01T14:00:00+00:00"
+    assert events[0].data["scheduled_time"] == "2026-01-01T14:00:00+00:00"
+    assert events[0].data["timezone"] == "America/New_York"
+
+
 @pytest.mark.asyncio
 async def test_schedule_fires_when_no_active_executions(db_session):
     """Happy path: no prior executions → event is created for this source."""

--- a/api/tests/unit/routers/test_schedules.py
+++ b/api/tests/unit/routers/test_schedules.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from src.models import CronValidationRequest
+from src.routers.schedules import validate_cron_expression
+
+
+@pytest.mark.asyncio
+async def test_validate_cron_preview_uses_requested_timezone():
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            value = cls(2026, 1, 1, 13, 30, 0, tzinfo=timezone.utc)
+            if tz is None:
+                return value.replace(tzinfo=None)
+            return value.astimezone(tz)
+
+    with patch("src.routers.schedules.datetime", FrozenDateTime):
+        result = await validate_cron_expression(
+            CronValidationRequest(
+                expression="0 9 * * *",
+                timezone="America/New_York",
+            ),
+            ctx=object(),
+            user=object(),
+        )
+
+    assert result.valid is True
+    assert result.next_runs is not None
+    assert result.next_runs[0] == "2026-01-01T14:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_validate_cron_rejects_unknown_timezone():
+    result = await validate_cron_expression(
+        CronValidationRequest(
+            expression="0 9 * * *",
+            timezone="Not/AZone",
+        ),
+        ctx=object(),
+        user=object(),
+    )
+
+    assert result.valid is False
+    assert result.human_readable == "Invalid timezone"
+    assert result.error == "Unknown timezone: Not/AZone"

--- a/client/src/components/events/CreateEventSourceDialog.test.tsx
+++ b/client/src/components/events/CreateEventSourceDialog.test.tsx
@@ -224,6 +224,13 @@ describe("CreateEventSourceDialog — schedule branch", () => {
 		});
 
 		await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+		const validationBody = JSON.parse(
+			mockAuthFetch.mock.calls[0]![1].body as string,
+		);
+		expect(validationBody).toEqual({
+			expression: "0 9 * * *",
+			timezone: "UTC",
+		});
 		expect(
 			await screen.findByText(/every day at 9:00 am/i),
 		).toBeInTheDocument();

--- a/client/src/components/events/CreateEventSourceDialog.tsx
+++ b/client/src/components/events/CreateEventSourceDialog.tsx
@@ -196,7 +196,7 @@ function CreateEventSourceDialogContent({
 			const response = await authFetch("/api/schedules/validate", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ expression: expr }),
+				body: JSON.stringify({ expression: expr, timezone }),
 			});
 			const data = await response.json();
 			setCronValidation(data);
@@ -207,7 +207,7 @@ function CreateEventSourceDialogContent({
 				error: "Unable to connect to validation service",
 			});
 		}
-	}, []);
+	}, [timezone]);
 
 	useEffect(() => {
 		if (!cronExpression) {

--- a/client/src/components/events/EditEventSourceDialog.test.tsx
+++ b/client/src/components/events/EditEventSourceDialog.test.tsx
@@ -132,6 +132,14 @@ describe("EditEventSourceDialog — schedule", () => {
 		const body = mockUpdate.mock.calls[0]![0].body;
 		expect(body.name).toBe("Nightly");
 		expect(body.schedule.cron_expression).toBe("0 9 * * *");
+		await waitFor(() => expect(mockAuthFetch).toHaveBeenCalled());
+		const validationBody = JSON.parse(
+			mockAuthFetch.mock.calls[0]![1].body as string,
+		);
+		expect(validationBody).toEqual({
+			expression: "0 9 * * *",
+			timezone: "UTC",
+		});
 	});
 
 	it("renders the overlap policy select with three options and defaults to skip", async () => {

--- a/client/src/components/events/EditEventSourceDialog.tsx
+++ b/client/src/components/events/EditEventSourceDialog.tsx
@@ -143,7 +143,7 @@ function EditEventSourceDialogContent({
 			const response = await authFetch("/api/schedules/validate", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ expression: expr }),
+				body: JSON.stringify({ expression: expr, timezone }),
 			});
 			const data = await response.json();
 			setCronValidation(data);
@@ -154,7 +154,7 @@ function EditEventSourceDialogContent({
 				error: "Unable to connect to validation service",
 			});
 		}
-	}, []);
+	}, [timezone]);
 
 	useEffect(() => {
 		if (!cronExpression.trim()) {

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -12459,6 +12459,12 @@ export interface components {
              * @description CRON expression to validate
              */
             expression: string;
+            /**
+             * Timezone
+             * @description Timezone used to evaluate the CRON expression
+             * @default UTC
+             */
+            timezone: string;
         };
         /**
          * CronValidationResponse


### PR DESCRIPTION
## Summary
- evaluate schedule cron expressions in the configured schedule timezone, then store emitted event timestamps in UTC
- validate schedule previews using the selected timezone and reject unknown timezone IDs
- send the selected timezone from create/edit event source dialogs during cron validation

## Verification
- ./test.sh quality api
- OPENAPI_URL=http://bifrost-debug-schedule-timezone-151-55.netbird.cloud/openapi.json npm run generate:types
- npm run tsc
- npm run lint
- ./test.sh all (6790 passed, 55 skipped)
- ./test.sh client unit (1579 passed)
- ./test.sh client e2e (98 passed, 2 skipped; one workflow-listing test retried and passed)
- post-repair: ./test.sh tests/unit/jobs/schedulers/test_cron_scheduler.py::test_schedule_evaluates_cron_in_configured_timezone tests/unit/routers/test_schedules.py -v (3 passed)
- post-repair: ./test.sh client unit CreateEventSourceDialog.test.tsx EditEventSourceDialog.test.tsx (18 passed)
