### PR TITLE
Fix solution CLI token refresh inside event loop

### DIFF
--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -181,6 +181,31 @@ async def refresh_tokens() -> bool:
         return False
 
 
+def _refresh_tokens_sync() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(refresh_tokens())
+
+    result: bool | None = None
+    error: BaseException | None = None
+
+    def _run() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(refresh_tokens())
+        except BaseException as exc:
+            error = exc
+
+    thread = threading.Thread(target=_run)
+    thread.start()
+    thread.join()
+
+    if error is not None:
+        raise error
+    return bool(result)
+
+
 async def login_flow(api_url: str | None = None, auto_open: bool = True) -> bool:
     """
     Interactive device authorization flow.
@@ -417,18 +442,10 @@ class BifrostClient:
             # Check if token needs refresh
             if creds and is_token_expired():
                 # Try to refresh
-                try:
-                    # Try to get existing event loop
-                    asyncio.get_running_loop()
-                    # We're in an async context, can't use asyncio.run()
-                    # For now, just skip auto-refresh in this case
-                    creds = None  # Will trigger re-login if require_auth=True
-                except RuntimeError:
-                    # No running loop, safe to use asyncio.run()
-                    if asyncio.run(refresh_tokens()):
-                        creds = get_credentials()  # Reload fresh credentials
-                    else:
-                        creds = None  # Refresh failed, need to re-login
+                if _refresh_tokens_sync():
+                    creds = get_credentials()  # Reload fresh credentials
+                else:
+                    creds = None  # Refresh failed, need to re-login
 
             if creds:
                 # Use credentials from file

--- a/api/bifrost/client.py
+++ b/api/bifrost/client.py
@@ -188,13 +188,13 @@ def _refresh_tokens_sync() -> bool:
         return asyncio.run(refresh_tokens())
 
     result: bool | None = None
-    error: BaseException | None = None
+    error: Exception | None = None
 
     def _run() -> None:
         nonlocal result, error
         try:
             result = asyncio.run(refresh_tokens())
-        except BaseException as exc:
+        except Exception as exc:
             error = exc
 
     thread = threading.Thread(target=_run)

--- a/api/tests/unit/test_bifrost_client_credentials.py
+++ b/api/tests/unit/test_bifrost_client_credentials.py
@@ -7,8 +7,11 @@ import pytest
 
 @pytest.fixture
 def isolated_credentials(tmp_path, monkeypatch):
+    from bifrost import client as client_mod
     from bifrost import credentials as creds_mod
 
+    if hasattr(client_mod._thread_local, "bifrost_client"):
+        delattr(client_mod._thread_local, "bifrost_client")
     monkeypatch.setattr(
         creds_mod,
         "get_credentials_path",
@@ -21,6 +24,8 @@ def isolated_credentials(tmp_path, monkeypatch):
     monkeypatch.delenv("BIFROST_ACCESS_TOKEN", raising=False)
     monkeypatch.delenv("BIFROST_REFRESH_TOKEN", raising=False)
     yield creds_mod
+    if hasattr(client_mod._thread_local, "bifrost_client"):
+        delattr(client_mod._thread_local, "bifrost_client")
     creds_mod._reset_persistent_backend_for_tests()
 
 
@@ -28,9 +33,6 @@ def test_get_instance_does_not_report_default_ambiguity_when_env_selects_url(
     isolated_credentials, monkeypatch
 ) -> None:
     from bifrost import client as client_mod
-
-    if hasattr(client_mod._thread_local, "bifrost_client"):
-        delattr(client_mod._thread_local, "bifrost_client")
 
     expired_at = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
     isolated_credentials.save_credentials(
@@ -52,3 +54,37 @@ def test_get_instance_does_not_report_default_ambiguity_when_env_selects_url(
 
     with pytest.raises(RuntimeError, match="Not logged in"):
         client_mod.BifrostClient.get_instance(require_auth=True)
+
+
+@pytest.mark.asyncio
+async def test_get_instance_refreshes_expired_credentials_inside_running_loop(
+    isolated_credentials, monkeypatch
+) -> None:
+    from bifrost import client as client_mod
+
+    expired_at = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+    fresh_at = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
+    isolated_credentials.save_credentials(
+        "https://api.example.com", "expired-access-token", "refresh-token", expired_at
+    )
+
+    refreshed = False
+
+    async def refresh_succeeds() -> bool:
+        nonlocal refreshed
+        refreshed = True
+        isolated_credentials.save_credentials(
+            "https://api.example.com",
+            "fresh-access-token",
+            "fresh-refresh-token",
+            fresh_at,
+        )
+        return True
+
+    monkeypatch.setattr(client_mod, "refresh_tokens", refresh_succeeds)
+
+    client = client_mod.BifrostClient.get_instance(require_auth=True)
+
+    assert refreshed is True
+    assert client.api_url == "https://api.example.com"
+    assert client._access_token == "fresh-access-token"


### PR DESCRIPTION
## Summary
- refresh expired CLI credentials even when BifrostClient.get_instance() is called inside an already-running event loop
- keep failed refresh falling through to the existing Not logged in behavior
- add regression coverage for solution-command-style async invocation

Fixes #444

## Verification
- ./test.sh tests/unit/test_bifrost_client_credentials.py::test_get_instance_refreshes_expired_credentials_inside_running_loop -v
- ./test.sh tests/unit/test_bifrost_client_credentials.py -v
- ./test.sh tests/unit/test_bifrost_client_retry.py -v
- ./test.sh quality api
- ./test.sh all (6868 passed, 55 skipped)