### PR TITLE
Fix cold solution workflow module loading

### DIFF
--- a/api/src/core/module_cache.py
+++ b/api/src/core/module_cache.py
@@ -18,6 +18,7 @@ from typing import Awaitable, TypedDict, cast
 from src.core.log_safety import log_safe
 from src.core.redis_client import get_redis_client
 from src.services.repo_storage import RepoStorage
+from src.services.solutions.storage import SOLUTIONS_ROOT, SolutionStorage
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,15 @@ class CachedModule(TypedDict):
     content: str
     path: str
     hash: str
+
+
+async def _read_module_from_storage(path: str) -> bytes:
+    parts = path.split("/", 2)
+    if len(parts) == 3 and parts[0] == SOLUTIONS_ROOT:
+        solution_id, relative_path = parts[1], parts[2]
+        return await SolutionStorage(solution_id).read(relative_path)
+
+    return await RepoStorage().read(path)
 
 
 async def get_module(path: str) -> CachedModule | None:
@@ -56,8 +66,7 @@ async def get_module(path: str) -> CachedModule | None:
 
     # Redis miss — try S3 fallback
     try:
-        repo = RepoStorage()
-        content_bytes = await repo.read(path)
+        content_bytes = await _read_module_from_storage(path)
     except Exception:
         logger.debug(f"Module not in cache or S3: {log_safe(path)}")
         return None

--- a/api/src/core/module_cache_sync.py
+++ b/api/src/core/module_cache_sync.py
@@ -210,7 +210,7 @@ def _fetch_module_from_api(path: str) -> CachedModule | None:
         return None
 
 
-def _fetch_module_index_from_api() -> set[str]:
+def _fetch_module_index_from_api(solution_id: str | None = None) -> set[str]:
     """
     Fetch the module index via GET /api/sdk/modules-index (synchronous).
 
@@ -231,6 +231,7 @@ def _fetch_module_index_from_api() -> set[str]:
         resp = httpx.get(
             f"{api_url}/api/sdk/modules-index",
             headers={"Authorization": f"Bearer {token}"},
+            params={"solution_id": solution_id} if solution_id else None,
             timeout=10.0,
         )
         if resp.status_code != 200:
@@ -493,7 +494,10 @@ def get_module_index_sync() -> set[str]:
 
         # Redis index is empty — try API first
         logger.debug("Module index empty in Redis, falling back to API listing")
-        api_paths = _fetch_module_index_from_api()
+        ctx = get_solution_context()
+        api_paths = _fetch_module_index_from_api(
+            solution_id=ctx.solution_id if ctx is not None else None
+        )
         if api_paths:
             try:
                 client.sadd(MODULE_INDEX_KEY, *api_paths)
@@ -520,27 +524,33 @@ def get_module_index_sync() -> set[str]:
 
 
 def solution_has_submodules(base_path: str) -> bool:
-    """True if the active solution has any object under ``{base_path}/`` in S3.
+    """True if the active solution has any module under ``{base_path}/``.
 
     Namespace-package (PEP 420) detection for solution code can't rely on the
     Redis module index alone: a freshly-deployed module is only indexed once
     it's first loaded, but it can't load until its parent package resolves as a
-    namespace — a chicken-and-egg. So when a solution is active we check S3
-    directly under ``_solutions/{id}/{base_path}/`` (one key is enough).
+    namespace — a chicken-and-egg. So when a solution is active we check the
+    API-backed module index under ``_solutions/{id}/{base_path}/`` first, then
+    direct S3 as the legacy fallback when the child still has S3 credentials.
 
-    Returns False when no solution is active (the _repo/ index path already
-    handles that case) or S3 is unavailable.
+    Returns False when no solution is active (the _repo/ index path already handles
+    that case) or neither fallback can prove a submodule exists.
     """
     ctx = get_solution_context()
     if ctx is None:
         return False
+    prefix = f"{SOLUTIONS_ROOT}/{ctx.solution_id}/{base_path.rstrip('/')}/"
+
+    api_paths = _fetch_module_index_from_api(solution_id=ctx.solution_id)
+    if any(path.startswith(prefix) for path in api_paths):
+        return True
+
     bucket = os.environ.get("BIFROST_S3_BUCKET")
     if not bucket:
         return False
     client = _get_s3_client()
     if client is None:
         return False
-    prefix = f"{SOLUTIONS_ROOT}/{ctx.solution_id}/{base_path.rstrip('/')}/"
     try:
         resp = client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
         return resp.get("KeyCount", 0) > 0 or bool(resp.get("Contents"))

--- a/api/src/routers/sdk_modules.py
+++ b/api/src/routers/sdk_modules.py
@@ -26,6 +26,7 @@ from fastapi.responses import JSONResponse
 from src.core.auth import get_current_superuser
 from src.core.module_cache import get_all_module_paths, get_module
 from src.core.requirements_cache import get_requirements
+from src.services.solutions.storage import SOLUTIONS_ROOT, SolutionStorage
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,7 @@ async def fetch_module(
 @router.get("/modules-index")
 async def fetch_module_index(
     _user: Annotated[object, Depends(get_current_superuser)],
+    solution_id: str | None = None,
 ) -> JSONResponse:
     """
     Fetch the set of all known workspace module paths.
@@ -80,6 +82,15 @@ async def fetch_module_index(
     the Redis SET is cold.
     """
     paths = await get_all_module_paths()
+    if solution_id:
+        storage = SolutionStorage(solution_id)
+        solution_paths = await storage.list("")
+        solution_prefix = f"{SOLUTIONS_ROOT}/{solution_id}/"
+        paths.update(
+            f"{solution_prefix}{path}"
+            for path in solution_paths
+            if path.endswith(".py")
+        )
     return JSONResponse(content={"paths": sorted(paths)})
 
 

--- a/api/src/services/solutions/storage.py
+++ b/api/src/services/solutions/storage.py
@@ -61,6 +61,14 @@ class SolutionStorage:
             await client.put_object(Bucket=self._bucket, Key=key, Body=content)
             return content_hash
 
+    async def read(self, path: str) -> bytes:
+        """Read a file from this install's prefix."""
+        async with self._get_client() as client:
+            key = self._key(path)
+            response = await client.get_object(Bucket=self._bucket, Key=key)
+            body = response["Body"]
+            return await body.read()
+
     async def delete(self, path: str) -> None:
         """Delete a file from this install's prefix."""
         async with self._get_client() as client:

--- a/api/tests/unit/core/test_module_cache.py
+++ b/api/tests/unit/core/test_module_cache.py
@@ -82,6 +82,37 @@ class TestModuleCacheAsync:
             # Verify re-cached to Redis
             mock_client.setex.assert_called_once()
 
+    async def test_get_module_falls_back_to_solution_storage_for_solution_module(self, mock_redis_client):
+        """Cold solution module lookups read from _solutions storage and re-cache."""
+        mock_client, mock_redis = mock_redis_client
+        mock_client.get.return_value = None
+
+        solution_id = "12345678-1234-5678-1234-567812345678"
+        storage_path = f"_solutions/{solution_id}/workflows/triage.py"
+
+        mock_repo = AsyncMock()
+        mock_repo.read.side_effect = AssertionError("solution modules must not use RepoStorage")
+        mock_solution_storage = AsyncMock()
+        mock_solution_storage.read.return_value = b"print('from solution s3')"
+
+        with (
+            patch("src.core.module_cache.get_redis_client", return_value=mock_client),
+            patch("src.core.module_cache.RepoStorage", return_value=mock_repo),
+            patch("src.core.module_cache.SolutionStorage", return_value=mock_solution_storage) as solution_storage_cls,
+        ):
+            from src.core.module_cache import get_module
+
+            result = await get_module(storage_path)
+
+            assert result is not None
+            assert result["content"] == "print('from solution s3')"
+            assert result["path"] == storage_path
+            assert result["hash"]
+            solution_storage_cls.assert_called_once_with(solution_id)
+            mock_solution_storage.read.assert_called_once_with("workflows/triage.py")
+            mock_client.setex.assert_called_once()
+            mock_redis.sadd.assert_called_once_with("bifrost:module:index", storage_path)
+
     async def test_get_module_s3_not_found(self, mock_redis_client):
         """When both Redis and S3 miss, get_module returns None."""
         mock_client, _ = mock_redis_client

--- a/api/tests/unit/routers/test_sdk_modules.py
+++ b/api/tests/unit/routers/test_sdk_modules.py
@@ -1,0 +1,29 @@
+from unittest.mock import AsyncMock, patch
+
+
+async def test_fetch_module_index_lists_solution_python_paths_when_redis_cold():
+    from src.routers.sdk_modules import fetch_module_index
+
+    solution_id = "12345678-1234-5678-1234-567812345678"
+    solution_storage = AsyncMock()
+    solution_storage.list.return_value = [
+        "workflows/triage.py",
+        "modules/helpers.py",
+        "README.md",
+    ]
+
+    with (
+        patch("src.routers.sdk_modules.get_all_module_paths", new_callable=AsyncMock, return_value=set()),
+        patch("src.routers.sdk_modules.SolutionStorage", return_value=solution_storage) as storage_cls,
+    ):
+        response = await fetch_module_index(_user=object(), solution_id=solution_id)
+
+    assert response.body
+    assert response.status_code == 200
+    assert response.media_type == "application/json"
+    assert response.body.decode() == (
+        '{"paths":["_solutions/12345678-1234-5678-1234-567812345678/modules/helpers.py",'
+        '"_solutions/12345678-1234-5678-1234-567812345678/workflows/triage.py"]}'
+    )
+    storage_cls.assert_called_once_with(solution_id)
+    solution_storage.list.assert_awaited_once_with("")

--- a/api/tests/unit/test_virtual_import_s3_fallback.py
+++ b/api/tests/unit/test_virtual_import_s3_fallback.py
@@ -130,6 +130,28 @@ class TestModuleIndexS3Fallback:
             # Should not try to sadd empty set
             mock_redis.sadd.assert_not_called()
 
+    def test_api_index_fetch_sends_solution_id_param(self):
+        """Solution-scoped child index fetches ask the server for that install."""
+        from src.core.module_cache_sync import _fetch_module_index_from_api
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"paths": ["_solutions/sol-1/modules/helpers.py"]}
+
+        with (
+            patch("src.core.module_cache_sync._get_engine_credentials", return_value=("http://api", "token")),
+            patch("httpx.get", return_value=response) as mock_get,
+        ):
+            result = _fetch_module_index_from_api(solution_id="sol-1")
+
+        assert result == {"_solutions/sol-1/modules/helpers.py"}
+        mock_get.assert_called_once_with(
+            "http://api/api/sdk/modules-index",
+            headers={"Authorization": "Bearer token"},
+            params={"solution_id": "sol-1"},
+            timeout=10.0,
+        )
+
     def test_namespace_package_resolves_via_s3_index_fallback(self):
         """Integration: namespace package lookup succeeds when Redis index is cold but S3 has modules."""
         from src.services.execution.virtual_import import VirtualModuleFinder
@@ -152,6 +174,27 @@ class TestModuleIndexS3Fallback:
             assert spec is not None
             assert spec.origin is None  # namespace package
             assert spec.submodule_search_locations == ["features"]
+
+    def test_solution_submodule_detection_uses_api_index_when_s3_scrubbed(self):
+        """Solution namespace detection should not require direct S3 credentials."""
+        from src.core import module_cache_sync as mcs
+
+        solution_id = "12345678-1234-5678-1234-567812345678"
+        api_paths = {f"_solutions/{solution_id}/modules/helpers.py"}
+
+        mcs.set_solution_context(solution_id, global_repo_access=False)
+        try:
+            with (
+                patch("src.core.module_cache_sync._fetch_module_index_from_api", return_value=api_paths) as mock_api_index,
+                patch("src.core.module_cache_sync._get_s3_client") as mock_s3_client,
+                patch.dict("os.environ", {}, clear=True),
+            ):
+                assert mcs.solution_has_submodules("modules") is True
+
+            mock_api_index.assert_called_once_with(solution_id=solution_id)
+            mock_s3_client.assert_not_called()
+        finally:
+            mcs.clear_solution_context()
 
 
 class TestS3ClientCaching:

--- a/client/src/lib/v1.d.ts
+++ b/client/src/lib/v1.d.ts
@@ -40468,7 +40468,9 @@ export interface operations {
     };
     fetch_module_index_api_sdk_modules_index_get: {
         parameters: {
-            query?: never;
+            query?: {
+                solution_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -40482,6 +40484,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- make cold _solutions/... module fetches read from SolutionStorage instead of RepoStorage
- make solution namespace/submodule detection use the API-backed solution module index when child S3 credentials are scrubbed
- make /api/sdk/modules-index rebuild solution Python paths from SolutionStorage when Redis is cold
- regenerate OpenAPI client types for the new optional solution_id query parameter

Fixes #445

## Verification
- ./test.sh tests/unit/routers/test_sdk_modules.py tests/unit/test_virtual_import_s3_fallback.py tests/unit/test_solution_import_root.py tests/unit/core/test_module_cache.py -v
- ./test.sh quality api
- OPENAPI_URL=http://bifrost-debug-445-solution-workflow-coldpath-165-20.netbird.cloud/openapi.json npm run generate:types
- npm run tsc
- npm run lint (0 errors; existing FormRenderer warning)
- ./test.sh client unit (218 files, 1583 tests passed)
- ./test.sh all (6871 passed, 55 skipped)