### PR TITLE
fix(workflows): reactivate replaced orphan workflows

### DIFF
--- a/api/src/services/workflow_orphan.py
+++ b/api/src/services/workflow_orphan.py
@@ -304,6 +304,7 @@ class WorkflowOrphanService:
 
         wf.path = source_path
         wf.function_name = function_name
+        wf.is_active = True
         wf.is_orphaned = False
         wf.updated_at = datetime.now(timezone.utc)
 

--- a/api/tests/e2e/platform/test_cli_workflows.py
+++ b/api/tests/e2e/platform/test_cli_workflows.py
@@ -489,5 +489,11 @@ class TestCliWorkflowsOrphanReplace:
                 f"Workflow {wf_id} should not be orphaned after replace"
             )
 
+            result = _invoke(["--json", "get", wf_id])
+            assert result.exit_code == 0, result.output
+            replaced = json.loads(result.output)
+            assert replaced["id"] == wf_id
+            assert replaced["function_name"] == new_fn
+
         finally:
             _invoke(["--json", "delete", wf_id, "--force"])

--- a/api/tests/unit/services/test_workflow_orphan.py
+++ b/api/tests/unit/services/test_workflow_orphan.py
@@ -298,6 +298,7 @@ class TestReplaceWorkflowASTSemantics:
         assert result.path == "workflows/new.py"
         assert result.function_name == "my_func"
         assert result.is_orphaned is False
+        assert result.is_active is True
         db.commit.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
- Restore is_active when replacing an orphaned workflow
- Assert replace reactivates the row at service level
- Assert the CLI can get the workflow after replace

Fixes #450

## Verification
- ./test.sh tests/unit/services/test_workflow_orphan.py::TestReplaceWorkflowASTSemantics::test_happy_path_repoints_and_clears_orphan_flag -q
- ./test.sh tests/e2e/platform/test_cli_workflows.py::TestCliWorkflowsOrphanReplace::test_replace_repoints_orphan_preserving_uuid -q
- ./test.sh tests/unit/services/test_workflow_orphan.py -q
- ./test.sh tests/e2e/platform/test_cli_workflows.py::TestCliWorkflowsOrphanReplace -q
- ./test.sh quality api

Note: ./test.sh all was started and manually stopped after reaching ~12% with no failures observed; it is CI-sized locally.