### PR TITLE
Handle expired solution dev CLI tokens

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -31,7 +31,8 @@ from typing import Any
 import click
 import yaml
 
-from bifrost.client import BifrostClient
+from bifrost.client import BifrostClient, refresh_tokens
+from bifrost.credentials import get_credentials
 from bifrost.org_target import org_option, resolve_org_target
 from bifrost.solution_binding import (
     SolutionBindingError,
@@ -2100,6 +2101,16 @@ def _vite_child_env(
     return env
 
 
+async def _refresh_solution_start_access_token(api_url: str) -> str | None:
+    if not await refresh_tokens():
+        return None
+    creds = get_credentials(api_url.rstrip("/"))
+    if not creds:
+        return None
+    token = creds.get("access_token")
+    return str(token) if token else None
+
+
 @solution_group.command(name="start", help="Run the app's dev server + local workflows (one origin).")
 @click.argument("app_slug", required=False)
 @click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
@@ -2645,12 +2656,16 @@ async def _serve(client, chosen, org_info, host, port, vite_port, workspace, sol
     from bifrost.solution_dev.proxy import DevProxyConfig, build_dev_app
     from bifrost.solution_dev.reload import start_function_watch
 
+    async def refresh_token() -> str | None:
+        return await _refresh_solution_start_access_token(client.api_url)
+
     cfg = DevProxyConfig(
         upstream_url=client.api_url.rstrip("/"),
         token=client._access_token,
         app_id=chosen.app_id,
         org_id=(org_info or {}).get("id"),
         solution_id=solution_id,
+        refresh_token=refresh_token,
     )
     app = build_dev_app(cfg, host, vite_url=f"http://127.0.0.1:{vite_port}")
     runner = web.AppRunner(app)

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -23,8 +23,10 @@ side closes, the bridge tears down both sockets (no half-open pump leaks).
 from __future__ import annotations
 
 import asyncio
+import html
 import re
 from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
 
 import aiohttp
 import httpx
@@ -48,6 +50,9 @@ _STRIP = {
 
 class _UpstreamAuthorityError(ValueError):
     """The constructed proxy target's authority is not the trusted base's."""
+
+
+DEV_AUTH_EXPIRED_DETAIL = "Your CLI token has expired. Restart `bifrost solution start`."
 
 
 def _join_upstream(base_url: str, rel_url: yarl.URL) -> str:
@@ -83,13 +88,17 @@ def _join_upstream(base_url: str, rel_url: yarl.URL) -> str:
     return result
 
 
-@dataclass(frozen=True)
+@dataclass
 class DevProxyConfig:
     upstream_url: str   # the dev API, e.g. http://localhost:37791
     token: str          # CLI access token
     app_id: str         # chosen app's manifest UUID
     org_id: str | None  # bound install org id (or None for a global install)
     solution_id: str | None = None  # bound Solution install id
+    refresh_token: Callable[[], Awaitable[str | None]] | None = None
+    auth_expired: bool = False
+    branding: dict[str, Any] | None = None
+    branding_loaded: bool = False
 
 
 # Typed app keys (avoid aiohttp's NotAppKeyWarning for plain-string keys).
@@ -145,6 +154,342 @@ def _passthrough_headers(resp, default_content_type: str) -> dict[str, str]:
     if location:
         headers["location"] = location
     return headers
+
+
+async def _refresh_cli_token(cfg: DevProxyConfig) -> bool:
+    if cfg.refresh_token is None:
+        cfg.auth_expired = True
+        return False
+    try:
+        token = await cfg.refresh_token()
+    except Exception:
+        token = None
+    if not token:
+        cfg.auth_expired = True
+        return False
+    cfg.token = token
+    cfg.auth_expired = False
+    return True
+
+
+async def _authed_upstream_request(
+    request: web.Request,
+    method: str,
+    url: str,
+    **kwargs,
+) -> httpx.Response | None:
+    cfg: DevProxyConfig = request.app[_CFG]
+    http: httpx.AsyncClient = request.app[_HTTP]
+    resp = await http.request(
+        method,
+        url,
+        headers=_auth_headers(cfg, request.headers),
+        **kwargs,
+    )
+    if resp.status_code != 401:
+        return resp
+    if not await _refresh_cli_token(cfg):
+        return None
+    retry = await http.request(
+        method,
+        url,
+        headers=_auth_headers(cfg, request.headers),
+        **kwargs,
+    )
+    if retry.status_code == 401:
+        cfg.auth_expired = True
+        return None
+    return retry
+
+
+def _dev_auth_expired_json_response() -> web.Response:
+    return web.json_response(
+        {
+            "error": "bifrost_dev_auth_expired",
+            "detail": DEV_AUTH_EXPIRED_DETAIL,
+        },
+        status=401,
+        headers={"X-Bifrost-Dev-Auth": "expired"},
+    )
+
+
+async def _get_branding(request: web.Request) -> dict[str, Any]:
+    cfg: DevProxyConfig = request.app[_CFG]
+    if cfg.branding_loaded:
+        return cfg.branding or {}
+    cfg.branding_loaded = True
+    try:
+        resp = await request.app[_HTTP].get(f"{cfg.upstream_url}/api/branding")
+        if resp.status_code == 200:
+            data = resp.json()
+            if isinstance(data, dict):
+                cfg.branding = data
+    except (httpx.HTTPError, ValueError):
+        cfg.branding = None
+    return cfg.branding or {}
+
+
+def _clean_brand_color(value: Any) -> str:
+    if isinstance(value, str) and re.fullmatch(r"#[0-9a-fA-F]{6}", value):
+        return value
+    return "#0066CC"
+
+
+def _clean_brand_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return "Bifrost"
+    value = value.strip()
+    return value or "Bifrost"
+
+
+async def _dev_auth_expired_page_response(request: web.Request) -> web.Response:
+    branding = await _get_branding(request)
+    product_name = _clean_brand_text(branding.get("application_name"))
+    primary_color = _clean_brand_color(branding.get("primary_color"))
+    escaped_product_name = html.escape(product_name)
+    escaped_primary_color = html.escape(primary_color, quote=True)
+    escaped_detail = html.escape(DEV_AUTH_EXPIRED_DETAIL)
+    page_html = f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{escaped_product_name} Dev Auth Expired</title>
+    <script>
+      try {{
+        if ((localStorage.getItem("theme") || "dark") === "dark") {{
+          document.documentElement.classList.add("dark");
+        }}
+      }} catch (_) {{
+        document.documentElement.classList.add("dark");
+      }}
+    </script>
+    <style>
+      :root {{ color-scheme: light dark; }}
+      body {{
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #ffffff;
+        color: #0f172a;
+        padding: 16px;
+        box-sizing: border-box;
+      }}
+      .shell {{
+        width: min(672px, 100%);
+      }}
+      main {{
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 24px;
+        background: #ffffff;
+        box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+        overflow: hidden;
+      }}
+      .header {{
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 20px 20px 0;
+      }}
+      .icon {{
+        flex: 0 0 auto;
+        display: flex;
+        width: 48px;
+        height: 48px;
+        align-items: center;
+        justify-content: center;
+        border-radius: 8px;
+        background: rgba(220, 38, 38, 0.1);
+        color: #dc2626;
+      }}
+      h1 {{
+        margin: 0 0 4px;
+        color: #0f172a;
+        font-size: 1rem;
+        font-weight: 500;
+        line-height: 1.25;
+        letter-spacing: 0;
+      }}
+      p {{
+        margin: 0;
+        color: #475569;
+        line-height: 1.55;
+      }}
+      .description {{
+        font-size: 0.875rem;
+      }}
+      .content {{
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: 20px;
+      }}
+      .alert {{
+        border: 1px solid rgba(220, 38, 38, 0.22);
+        border-radius: 16px;
+        background: #ffffff;
+        color: #dc2626;
+        padding: 12px 16px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.875rem;
+        line-height: 1.5;
+      }}
+      .actions {{
+        border-radius: 8px;
+        background: #f4f4f5;
+        padding: 16px;
+      }}
+      h2 {{
+        margin: 0 0 8px;
+        color: #0f172a;
+        font-size: 0.875rem;
+        font-weight: 500;
+        letter-spacing: 0;
+      }}
+      ul {{
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        color: #71717a;
+        font-size: 0.875rem;
+        line-height: 1.55;
+      }}
+      li + li {{
+        margin-top: 4px;
+      }}
+      code {{
+        border: 1px solid #e2e8f0;
+        border-radius: 6px;
+        background: #f1f5f9;
+        color: #0f172a;
+        padding: 2px 6px;
+        font-size: 0.94em;
+      }}
+      .footer {{
+        display: flex;
+        gap: 8px;
+        padding: 0 20px 20px;
+      }}
+      button, a {{
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 32px;
+        padding: 0 12px;
+        font: inherit;
+        font-size: 0.875rem;
+        font-weight: 500;
+        line-height: 1;
+        text-decoration: none;
+        cursor: pointer;
+      }}
+      button {{
+        border: 1px solid transparent;
+        border-radius: 16px;
+        background: {escaped_primary_color};
+        color: #ffffff;
+      }}
+      a {{
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 16px;
+        background: #ffffff;
+        color: #0f172a;
+      }}
+      button:hover {{
+        filter: brightness(0.94);
+      }}
+      a:hover {{
+        background: #f4f4f5;
+      }}
+      .dark body {{
+        background: #09090b;
+        color: #fafafa;
+      }}
+      .dark main {{
+        border-color: rgba(250, 250, 250, 0.08);
+        background: #171717;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+      }}
+      .dark h1, .dark h2 {{
+        color: #fafafa;
+      }}
+      .dark p {{
+        color: #a1a1aa;
+      }}
+      .dark .alert {{
+        border-color: rgba(248, 113, 113, 0.26);
+        background: #171717;
+        color: #f87171;
+      }}
+      .dark .actions {{
+        background: #262626;
+      }}
+      .dark ul {{
+        color: #a1a1aa;
+      }}
+      .dark code {{
+        border-color: rgba(250, 250, 250, 0.12);
+        background: #262626;
+        color: #fafafa;
+      }}
+      .dark .actions code {{
+        background: #171717;
+      }}
+      .dark a {{
+        border-color: rgba(250, 250, 250, 0.1);
+        background: #171717;
+        color: #fafafa;
+      }}
+      .dark a:hover {{
+        background: #262626;
+      }}
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <main>
+        <div class="header">
+          <div class="icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="m21.73 18-8-14a2 2 0 0 0-3.46 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"></path>
+              <path d="M12 9v4"></path>
+              <path d="M12 17h.01"></path>
+            </svg>
+          </div>
+          <div>
+            <h1>Something went wrong</h1>
+            <p class="description">The local Solution dev session can no longer authenticate requests.</p>
+          </div>
+        </div>
+        <div class="content">
+          <div class="alert">{escaped_detail}</div>
+          <div class="actions">
+            <h2>What you can do:</h2>
+            <ul>
+              <li>• Stop this server and restart <code>bifrost solution start</code></li>
+              <li>• If restarting does not fix it, run <code>bifrost login</code></li>
+              <li>• Refresh this page after the Solution dev server is running again</li>
+            </ul>
+          </div>
+        </div>
+        <div class="footer">
+          <button type="button" onclick="window.location.reload()">Try Again</button>
+          <a href="/">Go to Home</a>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>
+"""
+    return web.Response(
+        text=page_html,
+        status=401,
+        content_type="text/html",
+        headers={"X-Bifrost-Dev-Auth": "expired"},
+    )
 
 
 def _is_ws_upgrade(request: web.Request) -> bool:
@@ -244,15 +589,18 @@ async def _execute_handler(request: web.Request) -> web.Response:
     if cfg.solution_id:
         body["solution_id"] = cfg.solution_id
     try:
-        resp = await request.app[_HTTP].post(
+        resp = await _authed_upstream_request(
+            request,
+            "POST",
             f"{cfg.upstream_url}/api/workflows/execute",
             json=body,
-            headers=_auth_headers(cfg, request.headers),
         )
     except httpx.HTTPError:
         return web.json_response(
             {"detail": f"Dev API unreachable at {cfg.upstream_url}"}, status=502
         )
+    if resp is None:
+        return _dev_auth_expired_json_response()
     return web.Response(
         body=resp.content, status=resp.status_code,
         headers=_passthrough_headers(resp, "application/json"),
@@ -266,19 +614,21 @@ async def _api_proxy_handler(request: web.Request) -> web.StreamResponse:
         return await _ws_proxy(request, target)
     data = await request.read()
     try:
-        resp = await request.app[_HTTP].request(
+        resp = await _authed_upstream_request(
+            request,
             request.method,
             _join_upstream(
                 cfg.upstream_url,
                 _with_solution_query(request.rel_url, cfg.solution_id),
             ),
             content=data or None,
-            headers=_auth_headers(cfg, request.headers),
         )
     except httpx.HTTPError:
         return web.json_response(
             {"detail": f"Dev API unreachable at {cfg.upstream_url}"}, status=502
         )
+    if resp is None:
+        return _dev_auth_expired_json_response()
     return web.Response(
         body=resp.content, status=resp.status_code,
         headers=_passthrough_headers(resp, "application/json"),
@@ -286,6 +636,11 @@ async def _api_proxy_handler(request: web.Request) -> web.StreamResponse:
 
 
 async def _vite_proxy_handler(request: web.Request) -> web.StreamResponse:
+    cfg: DevProxyConfig = request.app[_CFG]
+    accept = request.headers.get("Accept", "")
+    fetch_dest = request.headers.get("Sec-Fetch-Dest", "")
+    if cfg.auth_expired and ("text/html" in accept or fetch_dest in {"document", "iframe"}):
+        return await _dev_auth_expired_page_response(request)
     vite_url = request.app[_VITE]
     if _is_ws_upgrade(request):
         target = _ws_scheme(_join_upstream(vite_url, request.rel_url))

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -146,6 +146,32 @@ def _make_upstream(record):
     return app
 
 
+def _make_auth_refresh_upstream(record):
+    async def auth_me(request):
+        auth = request.headers.get("Authorization")
+        record.setdefault("auth_headers", []).append(auth)
+        if auth == "Bearer fresh-token":
+            return web.json_response({"email": "dev@gobifrost.com", "name": "Dev User"})
+        return web.json_response({"detail": "Not authenticated"}, status=401)
+
+    async def branding(_request):
+        record["branding_requested"] = True
+        return web.json_response(
+            {
+                "application_name": "Covi Ops",
+                "rectangle_logo_url": "/api/branding/logo/rectangle",
+                "square_logo_url": "/api/branding/logo/square",
+                "primary_color": "#aa3366",
+                "terminology": {},
+            }
+        )
+
+    app = web.Application()
+    app.router.add_get("/api/auth/me", auth_me)
+    app.router.add_get("/api/branding", branding)
+    return app
+
+
 async def _serve(app, port):
     runner = web.AppRunner(app)
     await runner.setup()
@@ -284,6 +310,127 @@ async def test_browser_accept_encoding_is_not_forwarded_upstream():
         assert record["other_accept_encoding"] == "identity"
     finally:
         await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_api_proxy_refreshes_cli_token_once_after_401():
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
+    host = _StubHost(set())
+
+    async def refresh_token():
+        record["refresh_called"] = True
+        return "fresh-token"
+
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="stale-token",
+        app_id="A",
+        org_id="O",
+        refresh_token=refresh_token,
+    )
+    dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
+    try:
+        async with httpx.AsyncClient() as c:
+            r = await c.get(f"http://127.0.0.1:{dev_port}/api/auth/me")
+        assert r.status_code == 200
+        assert r.json()["email"] == "dev@gobifrost.com"
+        assert record["refresh_called"] is True
+        assert record["auth_headers"] == ["Bearer stale-token", "Bearer fresh-token"]
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_api_proxy_returns_dev_auth_expired_json_when_refresh_fails():
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
+    host = _StubHost(set())
+
+    async def refresh_token():
+        record["refresh_called"] = True
+        return None
+
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="stale-token",
+        app_id="A",
+        org_id="O",
+        refresh_token=refresh_token,
+    )
+    dev_runner = await _serve(build_dev_app(cfg, host, vite_url="http://127.0.0.1:1"), dev_port)
+    try:
+        async with httpx.AsyncClient() as c:
+            r = await c.get(f"http://127.0.0.1:{dev_port}/api/auth/me")
+        assert r.status_code == 401
+        assert r.headers["x-bifrost-dev-auth"] == "expired"
+        assert r.json() == {
+            "error": "bifrost_dev_auth_expired",
+            "detail": "Your CLI token has expired. Restart `bifrost solution start`.",
+        }
+        assert record["refresh_called"] is True
+        assert record["auth_headers"] == ["Bearer stale-token"]
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()
+
+
+async def test_vite_proxy_serves_branded_auth_expired_page_after_api_auth_failure():
+    record = {}
+    up_port, vite_port, dev_port = _free_port(), _free_port(), _free_port()
+    up_runner = await _serve(_make_auth_refresh_upstream(record), up_port)
+
+    async def index(_request):
+        return web.Response(text="<html><body>Vite app</body></html>", content_type="text/html")
+
+    async def logo(_request):
+        return web.Response(text="<svg></svg>", content_type="image/svg+xml")
+
+    vite = web.Application()
+    vite.router.add_get("/", index)
+    vite.router.add_get("/logo.svg", logo)
+    vite_runner = await _serve(vite, vite_port)
+    host = _StubHost(set())
+
+    async def refresh_token():
+        return None
+
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="stale-token",
+        app_id="A",
+        org_id="O",
+        refresh_token=refresh_token,
+    )
+    dev_runner = await _serve(build_dev_app(cfg, host, vite_url=f"http://127.0.0.1:{vite_port}"), dev_port)
+    try:
+        async with httpx.AsyncClient() as c:
+            api = await c.get(f"http://127.0.0.1:{dev_port}/api/auth/me")
+            page = await c.get(f"http://127.0.0.1:{dev_port}/", headers={"Accept": "text/html"})
+            logo_resp = await c.get(
+                f"http://127.0.0.1:{dev_port}/logo.svg",
+                headers={"Accept": "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8"},
+            )
+        assert api.status_code == 401
+        assert page.status_code == 401
+        assert logo_resp.status_code == 200
+        assert logo_resp.headers["content-type"].startswith("image/svg+xml")
+        assert logo_resp.text == "<svg></svg>"
+        assert record["branding_requested"] is True
+        assert "<title>Covi Ops Dev Auth Expired</title>" in page.text
+        assert "Something went wrong" in page.text
+        assert "What you can do:" in page.text
+        assert "/api/branding/logo/square" not in page.text
+        assert "/api/branding/logo/rectangle" not in page.text
+        assert "#aa3366" in page.text
+        assert "Your CLI token has expired" in page.text
+        assert "bifrost solution start" in page.text
+        assert "Vite app" not in page.text
+    finally:
+        await dev_runner.cleanup()
+        await vite_runner.cleanup()
         await up_runner.cleanup()
 
 

--- a/api/tests/unit/test_solution_start_env.py
+++ b/api/tests/unit/test_solution_start_env.py
@@ -64,3 +64,39 @@ def test_vite_child_env_points_bundle_at_local_proxy():
     assert env["BIFROST_ACCESS_TOKEN"] == "tok"
     # Base env is inherited, not replaced.
     assert env["PATH"] == "/usr/bin"
+
+
+async def test_solution_start_token_refresher_returns_new_token_for_same_api(monkeypatch):
+    state = {"refreshed": False}
+
+    async def _refresh_tokens():
+        state["refreshed"] = True
+        return True
+
+    def _get_credentials(api_url=None):
+        assert api_url == "http://api.example"
+        return {"access_token": "fresh-token"}
+
+    monkeypatch.setattr(solution_cmd, "refresh_tokens", _refresh_tokens)
+    monkeypatch.setattr(solution_cmd, "get_credentials", _get_credentials)
+
+    token = await solution_cmd._refresh_solution_start_access_token("http://api.example")
+
+    assert state["refreshed"] is True
+    assert token == "fresh-token"
+
+
+async def test_solution_start_token_refresher_returns_none_when_refresh_fails(monkeypatch):
+    async def _refresh_tokens():
+        return False
+
+    monkeypatch.setattr(solution_cmd, "refresh_tokens", _refresh_tokens)
+    monkeypatch.setattr(
+        solution_cmd,
+        "get_credentials",
+        lambda api_url=None: {"access_token": "should-not-be-used"},
+    )
+
+    token = await solution_cmd._refresh_solution_start_access_token("http://api.example")
+
+    assert token is None

--- a/client/src/lib/app-sdk/bifrost-header.test.tsx
+++ b/client/src/lib/app-sdk/bifrost-header.test.tsx
@@ -59,6 +59,32 @@ describe("BifrostHeader (SDK, self-contained)", () => {
     expect(screen.getByText("extra")).toBeInTheDocument();
   });
 
+  it("shows expired dev auth instead of the Account fallback", async () => {
+    const expiredAuth: typeof fetch = async () =>
+      new Response(
+        JSON.stringify({
+          error: "bifrost_dev_auth_expired",
+          detail: "Your CLI token has expired. Restart `bifrost solution start`.",
+        }),
+        {
+          status: 401,
+          headers: {
+            "Content-Type": "application/json",
+            "X-Bifrost-Dev-Auth": "expired",
+          },
+        },
+      );
+
+    render(
+      <BifrostProvider baseUrl="https://dev.example" token="t" fetchImpl={expiredAuth}>
+        <BifrostHeader title="X" />
+      </BifrostProvider>,
+    );
+
+    expect(await screen.findByText("Session expired")).toBeInTheDocument();
+    expect(screen.queryByText("Account")).toBeNull();
+  });
+
   it("uses shrinkable and wrapping inline layout for narrow app viewports", () => {
     const { container } = render(
       <BifrostProvider baseUrl="https://dev.example" token="t" fetchImpl={noNetwork} supportsTheme>

--- a/client/src/lib/app-sdk/bifrost-header.tsx
+++ b/client/src/lib/app-sdk/bifrost-header.tsx
@@ -260,6 +260,7 @@ export function BifrostHeader({ title, logo, action, className }: BifrostHeaderP
   ensureStyle(C, themeKey);
 
   const [me, setMe] = useState<Me | null>(null);
+  const [authExpired, setAuthExpired] = useState(false);
   const [fetchedLogo, setFetchedLogo] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -268,8 +269,18 @@ export function BifrostHeader({ title, logo, action, className }: BifrostHeaderP
   useEffect(() => {
     let cancelled = false;
     authedFetch("/api/auth/me")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => !cancelled && d && setMe(d))
+      .then((r) => {
+        if (r.ok) return r.json();
+        if (r.status === 401 && r.headers.get("X-Bifrost-Dev-Auth") === "expired") {
+          setAuthExpired(true);
+        }
+        return null;
+      })
+      .then((d) => {
+        if (cancelled || !d) return;
+        setAuthExpired(false);
+        setMe(d);
+      })
       .catch(() => {});
     return () => {
       cancelled = true;
@@ -315,7 +326,7 @@ export function BifrostHeader({ title, logo, action, className }: BifrostHeaderP
   }, [open]);
 
   const effectiveLogo = logo !== undefined ? logo : fetchedLogo;
-  const name = me?.name || me?.email?.split("@")[0] || "Account";
+  const name = authExpired ? "Session expired" : me?.name || me?.email?.split("@")[0] || "Account";
   const email = me?.email || "";
 
   return (


### PR DESCRIPTION
## Summary
- refresh the CLI access token once when the solution dev proxy receives a 401
- surface a typed expired-dev-auth response when refresh fails
- show an error-boundary-style branded recovery page for HTML navigations and keep assets proxied
- update the standalone SDK header to show Session expired instead of Account for this state

## Test Plan
- ./test.sh tests/unit/test_solution_dev_proxy.py tests/unit/test_solution_start_env.py -v
- ./test.sh client unit src/lib/app-sdk/bifrost-header.test.tsx
- ./test.sh quality api
- Playwright harness screenshot: /tmp/bifrost-dev-auth-expired-error-state.png