### PR TITLE
solution CLI polish: root-walking, null orgScope, loud vendoring, capture confirm

### DIFF
--- a/.claude/skills/bifrost-build/generated/cli-reference.md
+++ b/.claude/skills/bifrost-build/generated/cli-reference.md
@@ -1766,6 +1766,8 @@ Options:
                                   no-include-imports]
   --dry-run                       Preview the dependency closure + outside
                                   references; capture nothing.
+  --yes                           Skip the confirmation prompt (capture is
+                                  terminal).
   --help                          Show this message and exit.
 ```
 

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -493,7 +493,7 @@ export default defineConfig(({ command }) => {
           "import.meta.env.VITE_BIFROST_API_URL": JSON.stringify(env.url),
           "import.meta.env.VITE_BIFROST_TOKEN": JSON.stringify(env.token),
           "import.meta.env.VITE_BIFROST_APP_ID": JSON.stringify(process.env.VITE_BIFROST_APP_ID || ""),
-          "import.meta.env.VITE_BIFROST_ORG_ID": JSON.stringify(process.env.VITE_BIFROST_ORG_ID || ""),
+          "import.meta.env.VITE_BIFROST_ORG_ID": JSON.stringify(process.env.VITE_BIFROST_ORG_ID || null),
         }
       : {};
   return {
@@ -2114,7 +2114,7 @@ def _vite_child_env(
     base_env: dict[str, str],
     *,
     app_id: str,
-    org_id: str,
+    org_id: str | None,
     proxy_origin: str,
     access_token: str,
 ) -> dict[str, str]:
@@ -2129,7 +2129,13 @@ def _vite_child_env(
     """
     env = dict(base_env)
     env["VITE_BIFROST_APP_ID"] = app_id
-    env["VITE_BIFROST_ORG_ID"] = org_id
+    # Omit the org var entirely for a global install: "" is not null once it
+    # reaches the app (`?? null` doesn't catch it), and the proxy config uses
+    # None for the same install — the two must agree (issue #463).
+    if org_id:
+        env["VITE_BIFROST_ORG_ID"] = org_id
+    else:
+        env.pop("VITE_BIFROST_ORG_ID", None)
     env["BIFROST_API_URL"] = proxy_origin
     env["BIFROST_ACCESS_TOKEN"] = access_token
     return env
@@ -2225,7 +2231,7 @@ def start_cmd(
     vite_env = _vite_child_env(
         dict(os.environ),
         app_id=chosen.app_id,
-        org_id=(org_info or {}).get("id", ""),
+        org_id=(org_info or {}).get("id"),
         proxy_origin=proxy_origin,
         access_token=client._access_token,
     )

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -1734,6 +1734,26 @@ def _build_deploy_zip(
     return buf.getvalue()
 
 
+def _vendor_repo_reader(client, failures: dict[str, str]):
+    """Reader for ``vendor_shared_deps``: 404 is a legitimate miss (a stdlib/
+    third-party import probe), but any OTHER failure must be recorded — treating
+    it as absence silently drops a shared module from the bundle and the deploy
+    "succeeds" broken (issue #465).
+    """
+
+    async def _read(path: str) -> str | None:
+        resp = await client.post("/api/files/read", json={
+            "path": path, "location": "workspace", "mode": "cloud",
+        })
+        if resp.status_code == 200:
+            return resp.json().get("content")
+        if resp.status_code != 404:
+            failures[path] = f"HTTP {resp.status_code}"
+        return None
+
+    return _read
+
+
 @solution_group.command(name="deploy", help="Deploy the current Solution workspace (full replace, non-interactive).")
 @click.argument("path", type=click.Path(exists=True, file_okay=False), default=".")
 @click.option("--solution", "solution_ref", default=None, help="Install id or unique slug.")
@@ -1791,15 +1811,20 @@ def deploy_cmd(
             # the wait isn't a silent gap before the bundle summary.
             click.echo("Vendoring shared dependencies...")
 
-            async def _repo_read(path: str) -> str | None:
-                resp = await client.post("/api/files/read", json={
-                    "path": path, "location": "workspace", "mode": "cloud",
-                })
-                if resp.status_code != 200:
-                    return None
-                return resp.json().get("content")
-
-            vendored = await vendor_shared_deps(python_files, _repo_read)
+            read_failures: dict[str, str] = {}
+            vendored = await vendor_shared_deps(
+                python_files, _vendor_repo_reader(client, read_failures)
+            )
+            if read_failures:
+                detail = ", ".join(
+                    f"{p} ({err})" for p, err in sorted(read_failures.items())
+                )
+                raise click.ClickException(
+                    f"Could not read {len(read_failures)} shared module(s) from "
+                    f"_repo/: {detail}. Deploying would silently omit them and the "
+                    "Solution would break at runtime — retry; if it persists, check "
+                    "API connectivity and permissions."
+                )
             if vendored:
                 click.echo(f"  vendored {len(vendored)} shared dependency file(s).")
                 bundle_python = {**python_files, **vendored}

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2167,10 +2167,13 @@ def start_cmd(
     from bifrost.solution_dev.function_host import FunctionHost, set_dev_execution_context
     from bifrost.solution_dev.scaffold_check import PATCH_HINT, main_tsx_needs_dev_fallback
 
-    workspace = pathlib.Path(".").resolve()
-    if not is_solution_workspace(workspace):
+    # Walk up to the solution root like scaffold-app and `bifrost run` do —
+    # requiring cwd == root fails from apps/<slug>/ for no reason (issue #462).
+    workspace = find_solution_root(pathlib.Path.cwd())
+    if workspace is None:
         raise click.ClickException(
-            f"Not a Solution workspace (no {DESCRIPTOR_FILENAME}). Run `bifrost solution init` first."
+            f"Not inside a Solution workspace (no {DESCRIPTOR_FILENAME} here or in any "
+            "parent directory). Run `bifrost solution init` first."
         )
     descriptor = load_descriptor(workspace)
 

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -221,6 +221,20 @@ def init_cmd(
     )
 
 
+def _workspace_from_path_arg(path: str) -> pathlib.Path:
+    """Resolve a command's PATH argument to the solution root.
+
+    An explicit path is honored as-is; the implicit default "." walks up like
+    `start` does, so sibling commands (bind/pull/deploy) don't fail one
+    directory deep in the workspace (issue #462).
+    """
+    if path == ".":
+        root = find_solution_root(pathlib.Path.cwd())
+        if root is not None:
+            return root
+    return pathlib.Path(path).resolve()
+
+
 @solution_group.command(
     name="bind",
     help="Bind this local Solution workspace to an existing install.",
@@ -229,7 +243,7 @@ def init_cmd(
 @click.option("--solution", "solution_ref", required=True, help="Install id or unique slug.")
 def bind_cmd(path: str, solution_ref: str) -> None:
     """Bind a local descriptor to an existing remote install without creating one."""
-    workspace = pathlib.Path(path).resolve()
+    workspace = _workspace_from_path_arg(path)
     if not is_solution_workspace(workspace):
         raise click.ClickException(
             f"No {DESCRIPTOR_FILENAME} in {workspace} - not a Solution workspace. "
@@ -1512,7 +1526,7 @@ def pull_cmd(path: str, solution_id: str | None, org: str | None, is_global: boo
     import io
     import zipfile
 
-    workspace = pathlib.Path(path).resolve()
+    workspace = _workspace_from_path_arg(path)
     if not is_solution_workspace(workspace):
         raise click.ClickException(
             f"No {DESCRIPTOR_FILENAME} in {workspace} — not a Solution workspace. "
@@ -1734,6 +1748,30 @@ def _build_deploy_zip(
     return buf.getvalue()
 
 
+def _unresolved_vendor_failures(
+    failures: dict[str, str], bundled: set[str]
+) -> dict[str, str]:
+    """Failures that actually left a module out of the bundle.
+
+    ``vendor_shared_deps`` probes each module at several candidate paths
+    (``pkg.py`` then ``pkg/__init__.py``); a probe that failed on one candidate
+    is irrelevant when the module resolved via its sibling — aborting there
+    would block a deploy whose bundle is complete.
+    """
+    out: dict[str, str] = {}
+    for path, err in failures.items():
+        if path in bundled:
+            continue
+        if path.endswith("/__init__.py"):
+            sibling = path.removesuffix("/__init__.py") + ".py"
+        else:
+            sibling = path.removesuffix(".py") + "/__init__.py"
+        if sibling in bundled:
+            continue
+        out[path] = err
+    return out
+
+
 def _vendor_repo_reader(client, failures: dict[str, str]):
     """Reader for ``vendor_shared_deps``: 404 is a legitimate miss (a stdlib/
     third-party import probe), but any OTHER failure must be recorded — treating
@@ -1762,7 +1800,7 @@ def _vendor_repo_reader(client, failures: dict[str, str]):
 def deploy_cmd(
     path: str, solution_ref: str | None, force: bool
 ) -> None:
-    workspace = pathlib.Path(path).resolve()
+    workspace = _workspace_from_path_arg(path)
     if not is_solution_workspace(workspace):
         raise click.ClickException(
             f"No {DESCRIPTOR_FILENAME} in {workspace} — not a Solution workspace. "
@@ -1814,6 +1852,9 @@ def deploy_cmd(
             read_failures: dict[str, str] = {}
             vendored = await vendor_shared_deps(
                 python_files, _vendor_repo_reader(client, read_failures)
+            )
+            read_failures = _unresolved_vendor_failures(
+                read_failures, set(python_files) | set(vendored)
             )
             if read_failures:
                 detail = ", ".join(
@@ -2196,7 +2237,12 @@ def start_cmd(
     from bifrost.client import BifrostClient
     from bifrost.solution_dev.app_select import AppSelectionError, select_app
     from bifrost.solution_dev.function_host import FunctionHost, set_dev_execution_context
-    from bifrost.solution_dev.scaffold_check import PATCH_HINT, main_tsx_needs_dev_fallback
+    from bifrost.solution_dev.scaffold_check import (
+        ORG_NULL_HINT,
+        PATCH_HINT,
+        main_tsx_needs_dev_fallback,
+        vite_config_needs_org_null,
+    )
 
     # Walk up to the solution root like scaffold-app and `bifrost run` do —
     # requiring cwd == root fails from apps/<slug>/ for no reason (issue #462).
@@ -2226,6 +2272,8 @@ def start_cmd(
     main_tsx = chosen.app_dir / "src" / "main.tsx"
     if main_tsx_needs_dev_fallback(main_tsx):
         click.echo(PATCH_HINT, err=True)
+    if vite_config_needs_org_null(chosen.app_dir / "vite.config.ts"):
+        click.echo(ORG_NULL_HINT, err=True)
 
     click.echo(f"Using Solution install id: {binding.solution_id}")
 
@@ -2402,13 +2450,15 @@ def capture_cmd(
         )
 
     if not dry_run and not yes:
+        # Warning and prompt on the SAME stream (stdout, where click.confirm
+        # prompts) — split streams leave a redirected user staring at a
+        # seemingly hung terminal with the question in their log file.
         click.echo(
             "Capture is terminal: the selected _repo/ entities are adopted into "
             f"install {solution_id} and stop being loose/global. A later "
             "`bifrost deploy` of this Solution replaces captured state that was "
             "never pulled into the workspace. This cannot be undone by "
-            "uninstall. Use --dry-run to preview first.",
-            err=True,
+            "uninstall. Use --dry-run to preview first."
         )
         try:
             proceed = click.confirm("Proceed with capture?")
@@ -2418,7 +2468,9 @@ def capture_cmd(
             proceed = False
         if not proceed:
             click.echo("Aborted — nothing was captured. Re-run with --yes to skip the prompt.")
-            return
+            # Non-zero: a scripted `capture && deploy` chain must not roll on
+            # past a capture that never happened.
+            raise SystemExit(1)
 
     async def _run() -> int:
         client = BifrostClient.get_instance(require_auth=True)

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2376,6 +2376,8 @@ def _print_capture_preview(preview: dict) -> None:
 )
 @click.option("--dry-run", is_flag=True, default=False,
               help="Preview the dependency closure + outside references; capture nothing.")
+@click.option("--yes", is_flag=True, default=False,
+              help="Skip the confirmation prompt (capture is terminal).")
 def capture_cmd(
     solution_id: str,
     workflows: tuple[str, ...],
@@ -2387,6 +2389,7 @@ def capture_cmd(
     configs: tuple[str, ...],
     include_imports: bool,
     dry_run: bool,
+    yes: bool,
 ) -> None:
     raw = {
         "workflows": workflows, "tables": tables, "apps": apps, "forms": forms,
@@ -2397,6 +2400,25 @@ def capture_cmd(
             "no entities selected — pass at least one of "
             "--workflow/--table/--app/--form/--agent/--claim/--config."
         )
+
+    if not dry_run and not yes:
+        click.echo(
+            "Capture is terminal: the selected _repo/ entities are adopted into "
+            f"install {solution_id} and stop being loose/global. A later "
+            "`bifrost deploy` of this Solution replaces captured state that was "
+            "never pulled into the workspace. This cannot be undone by "
+            "uninstall. Use --dry-run to preview first.",
+            err=True,
+        )
+        try:
+            proceed = click.confirm("Proceed with capture?")
+        except click.exceptions.Abort:
+            # EOF / Ctrl-C on the prompt (e.g. scripted use without --yes):
+            # decline, don't traceback — handle_solution doesn't catch Abort.
+            proceed = False
+        if not proceed:
+            click.echo("Aborted — nothing was captured. Re-run with --yes to skip the prompt.")
+            return
 
     async def _run() -> int:
         client = BifrostClient.get_instance(require_auth=True)

--- a/api/bifrost/solution_dev/scaffold_check.py
+++ b/api/bifrost/solution_dev/scaffold_check.py
@@ -17,3 +17,19 @@ def main_tsx_needs_dev_fallback(main_tsx: Path) -> bool:
         return False
     text = main_tsx.read_text(encoding="utf-8")
     return "VITE_BIFROST_APP_ID" not in text
+
+
+ORG_NULL_HINT = (
+    "Your app's vite.config.ts predates the null-orgScope fix: it bakes a "
+    'missing org var to "" (which `?? null` never catches), so a global '
+    "install sees orgScope \"\" instead of null. Change the define to:\n\n"
+    '  "import.meta.env.VITE_BIFROST_ORG_ID": '
+    "JSON.stringify(process.env.VITE_BIFROST_ORG_ID || null),\n"
+)
+
+
+def vite_config_needs_org_null(vite_config: Path) -> bool:
+    """True if the file exists and still coerces a missing org var to ""."""
+    if not vite_config.is_file():
+        return False
+    return 'VITE_BIFROST_ORG_ID || ""' in vite_config.read_text(encoding="utf-8")

--- a/api/tests/unit/test_cli_solution_capture.py
+++ b/api/tests/unit/test_cli_solution_capture.py
@@ -74,10 +74,10 @@ def _make_client(captured: dict) -> mock.AsyncMock:
     return client
 
 
-def _invoke(args: list[str], captured: dict):
+def _invoke(args: list[str], captured: dict, input: str | None = None):
     client = _make_client(captured)
     with mock.patch("bifrost.client.BifrostClient.get_instance", return_value=client):
-        return CliRunner().invoke(solution_group, ["capture", *args])
+        return CliRunner().invoke(solution_group, ["capture", *args], input=input)
 
 
 def test_dry_run_previews_without_applying() -> None:
@@ -98,7 +98,7 @@ def test_dry_run_previews_without_applying() -> None:
 
 def test_apply_captures_and_reports_counts() -> None:
     captured: dict = {}
-    result = _invoke([SOL, "--workflow", WF_ID, "--table", "orders"], captured)
+    result = _invoke([SOL, "--workflow", WF_ID, "--table", "orders", "--yes"], captured)
     assert result.exit_code == 0, result.output
     posted_paths = [p for p, _ in captured["posts"]]
     assert f"/api/solutions/{SOL}/capture" in posted_paths
@@ -110,7 +110,7 @@ def test_apply_captures_and_reports_counts() -> None:
 
 def test_include_imports_flag_forwarded() -> None:
     captured: dict = {}
-    result = _invoke([SOL, "--workflow", WF_ID, "--include-imports"], captured)
+    result = _invoke([SOL, "--workflow", WF_ID, "--include-imports", "--yes"], captured)
     assert result.exit_code == 0, result.output
     body = next(b for p, b in captured["posts"] if p.endswith(f"{SOL}/capture"))
     assert body["include_imports"] is True
@@ -128,3 +128,40 @@ def test_no_selectors_errors() -> None:
     result = _invoke([SOL], captured)
     assert result.exit_code != 0
     assert "no entities" in result.output.lower() or "at least one" in result.output.lower()
+
+
+def test_apply_without_yes_prompts_and_declining_captures_nothing() -> None:
+    """Capture is terminal (a later deploy replaces unpulled captured state),
+    so a bare apply must warn and confirm (issue #466)."""
+    captured: dict = {}
+    result = _invoke([SOL, "--workflow", WF_ID], captured, input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "cannot be undone" in result.output
+    assert "nothing was captured" in result.output.lower()
+    posted_paths = [p for p, _ in captured.get("posts", [])]
+    assert f"/api/solutions/{SOL}/capture" not in posted_paths
+
+
+def test_apply_without_yes_confirming_proceeds() -> None:
+    captured: dict = {}
+    result = _invoke([SOL, "--workflow", WF_ID], captured, input="y\n")
+    assert result.exit_code == 0, result.output
+    posted_paths = [p for p, _ in captured["posts"]]
+    assert f"/api/solutions/{SOL}/capture" in posted_paths
+
+
+def test_apply_without_yes_non_interactive_aborts_cleanly() -> None:
+    # EOF on the prompt (scripted use without --yes) must abort without a
+    # traceback and without capturing.
+    captured: dict = {}
+    result = _invoke([SOL, "--workflow", WF_ID], captured)
+    assert result.exit_code == 0, result.output
+    posted_paths = [p for p, _ in captured.get("posts", [])]
+    assert f"/api/solutions/{SOL}/capture" not in posted_paths
+
+
+def test_dry_run_never_prompts() -> None:
+    captured: dict = {}
+    result = _invoke([SOL, "--workflow", WF_ID, "--dry-run"], captured)
+    assert result.exit_code == 0, result.output
+    assert "cannot be undone" not in result.output

--- a/api/tests/unit/test_cli_solution_capture.py
+++ b/api/tests/unit/test_cli_solution_capture.py
@@ -135,7 +135,9 @@ def test_apply_without_yes_prompts_and_declining_captures_nothing() -> None:
     so a bare apply must warn and confirm (issue #466)."""
     captured: dict = {}
     result = _invoke([SOL, "--workflow", WF_ID], captured, input="n\n")
-    assert result.exit_code == 0, result.output
+    # Non-zero exit: a scripted `capture && deploy` chain must NOT proceed
+    # past a declined capture (review F1).
+    assert result.exit_code == 1, result.output
     assert "cannot be undone" in result.output
     assert "nothing was captured" in result.output.lower()
     posted_paths = [p for p, _ in captured.get("posts", [])]
@@ -155,7 +157,7 @@ def test_apply_without_yes_non_interactive_aborts_cleanly() -> None:
     # traceback and without capturing.
     captured: dict = {}
     result = _invoke([SOL, "--workflow", WF_ID], captured)
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
     posted_paths = [p for p, _ in captured.get("posts", [])]
     assert f"/api/solutions/{SOL}/capture" not in posted_paths
 

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -791,3 +791,17 @@ def test_start_finds_solution_root_from_subdirectory(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     # The host was rooted at the SOLUTION ROOT, not the subdirectory cwd.
     assert hosts and str(hosts[0].workspace) == str(tmp_path.resolve())
+
+
+def test_workspace_from_path_arg_walks_up_only_for_default(tmp_path, monkeypatch):
+    """deploy/pull/bind share start's one-directory-deep friction: the implicit
+    "." walks up to the root, an EXPLICIT path is honored as-is (review F5)."""
+    from bifrost.commands.solution import _workspace_from_path_arg
+
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\n")
+    sub = tmp_path / "apps" / "dash"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+
+    assert str(_workspace_from_path_arg(".")) == str(tmp_path.resolve())
+    assert str(_workspace_from_path_arg(str(sub))) == str(sub.resolve())

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -711,3 +711,83 @@ def test_dev_proxy_config_threads_descriptor_global_repo_access():
     cfg = _dev_proxy_config(_Client(), _Chosen(), None, "install-1", False)
     assert cfg.global_repo_access is False
     assert cfg.org_id is None
+
+
+def test_start_finds_solution_root_from_subdirectory(tmp_path, monkeypatch):
+    """`bifrost solution start` from apps/<slug>/ must walk up to the root.
+
+    scaffold-app and `bifrost run` already use find_solution_root; start
+    requiring cwd == root was an inconsistency that blamed the user for
+    being one directory deep (issue #462).
+    """
+    import shutil
+    import subprocess
+
+    import bifrost.client as client_mod
+    from bifrost.solution_dev import function_host
+
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=s\n"
+        "BIFROST_SOLUTION_ORG_ID=org-1\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
+    (tmp_path / ".bifrost").mkdir()
+    (tmp_path / ".bifrost" / "apps.yaml").write_text(
+        yaml.safe_dump({"apps": {
+            "a": {"id": "a", "slug": "dash", "path": "apps/dash", "app_model": "standalone_v2"},
+        }})
+    )
+    (tmp_path / "apps" / "dash").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path / "apps" / "dash")
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+        user = {"id": "u", "is_superuser": True}
+        api_url = "http://localhost:8000"
+        _access_token = "tok"
+
+    monkeypatch.setattr(client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: _FakeClient()))
+    monkeypatch.setattr(function_host, "set_dev_execution_context", lambda **k: None)
+
+    class _FakeHost:
+        def __init__(self, workspace):
+            self.workspace = workspace
+
+        def reload(self):
+            pass
+
+        def refs(self):
+            return []
+
+        def failures(self):
+            return {}
+
+    hosts: list[object] = []
+    def _make_host(workspace):
+        host = _FakeHost(workspace)
+        hosts.append(host)
+        return host
+
+    monkeypatch.setattr(function_host, "FunctionHost", _make_host)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/npm" if name == "npm" else None)
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: None)
+
+    class _FakeProc:
+        pid = 4242
+
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **k: _FakeProc())
+
+    async def _fake_serve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr(
+        "bifrost.commands.solution._terminate_process_group", lambda proc: None
+    )
+
+    result = CliRunner().invoke(solution_group, ["start"])
+    assert result.exit_code == 0, result.output
+    # The host was rooted at the SOLUTION ROOT, not the subdirectory cwd.
+    assert hosts and str(hosts[0].workspace) == str(tmp_path.resolve())

--- a/api/tests/unit/test_solution_dev_scaffold_check.py
+++ b/api/tests/unit/test_solution_dev_scaffold_check.py
@@ -23,3 +23,22 @@ def test_stale_main_tsx_flagged(tmp_path: Path):
 
 def test_missing_file_is_not_flagged(tmp_path: Path):
     assert main_tsx_needs_dev_fallback(tmp_path / "src" / "main.tsx") is False
+
+
+def test_vite_config_needs_org_null_detects_stale_empty_string(tmp_path):
+    from bifrost.solution_dev.scaffold_check import vite_config_needs_org_null
+
+    stale = tmp_path / "vite.config.ts"
+    stale.write_text(
+        '"import.meta.env.VITE_BIFROST_ORG_ID": '
+        'JSON.stringify(process.env.VITE_BIFROST_ORG_ID || ""),'
+    )
+    assert vite_config_needs_org_null(stale) is True
+
+    fresh = tmp_path / "fresh.config.ts"
+    fresh.write_text(
+        '"import.meta.env.VITE_BIFROST_ORG_ID": '
+        'JSON.stringify(process.env.VITE_BIFROST_ORG_ID || null),'
+    )
+    assert vite_config_needs_org_null(fresh) is False
+    assert vite_config_needs_org_null(tmp_path / "absent.config.ts") is False

--- a/api/tests/unit/test_solution_start_env.py
+++ b/api/tests/unit/test_solution_start_env.py
@@ -53,17 +53,34 @@ def test_vite_child_env_points_bundle_at_local_proxy():
     env = _vite_child_env(
         {"PATH": "/usr/bin", "BIFROST_API_URL": "http://upstream:34173"},
         app_id="2a9d06da-cc86-49ff-b3b5-26748c31f73e",
-        org_id="",
+        org_id="org-1",
         proxy_origin="http://127.0.0.1:3777",
         access_token="tok",
     )
     # The bundle-visible API URL is the PROXY, never the upstream.
     assert env["BIFROST_API_URL"] == "http://127.0.0.1:3777"
     assert env["VITE_BIFROST_APP_ID"] == "2a9d06da-cc86-49ff-b3b5-26748c31f73e"
-    assert env["VITE_BIFROST_ORG_ID"] == ""
+    assert env["VITE_BIFROST_ORG_ID"] == "org-1"
     assert env["BIFROST_ACCESS_TOKEN"] == "tok"
     # Base env is inherited, not replaced.
     assert env["PATH"] == "/usr/bin"
+
+
+def test_vite_child_env_omits_org_var_for_global_installs():
+    """A global install has NO org — the app must see orgScope null, not "".
+
+    Setting VITE_BIFROST_ORG_ID="" flowed an empty-string orgScope into
+    BifrostProvider (`?? null` doesn't catch ""), diverging from the proxy
+    config's None for the same install (issue #463).
+    """
+    env = _vite_child_env(
+        {"PATH": "/usr/bin"},
+        app_id="2a9d06da-cc86-49ff-b3b5-26748c31f73e",
+        org_id=None,
+        proxy_origin="http://127.0.0.1:3777",
+        access_token="tok",
+    )
+    assert "VITE_BIFROST_ORG_ID" not in env
 
 
 async def test_solution_start_token_refresher_returns_new_token_for_same_api(monkeypatch):

--- a/api/tests/unit/test_solution_vendoring.py
+++ b/api/tests/unit/test_solution_vendoring.py
@@ -69,3 +69,35 @@ async def test_from_namespace_pkg_import_submodule() -> None:
     repo = {"shared/calc.py": "VALUE = 1\n"}  # no shared/__init__.py
     out = await vendor_shared_deps(bundle, _reader(repo))
     assert out == {"shared/calc.py": "VALUE = 1\n"}
+
+
+async def test_vendor_repo_reader_distinguishes_absent_from_failed() -> None:
+    """404 = legitimately absent (stdlib/third-party import) — NOT a failure.
+    Any other non-200 must be recorded so deploy can refuse to ship a bundle
+    with silently omitted shared modules (issue #465)."""
+    from bifrost.commands.solution import _vendor_repo_reader
+
+    class _Resp:
+        def __init__(self, status_code, content=None):
+            self.status_code = status_code
+            self._content = content
+
+        def json(self):
+            return {"content": self._content}
+
+    class _FakeClient:
+        async def post(self, path, json=None, **kwargs):
+            target = json["path"]
+            if target == "shared/ok.py":
+                return _Resp(200, "OK_SOURCE")
+            if target == "shared/absent.py":
+                return _Resp(404)
+            return _Resp(503)
+
+    failures: dict[str, str] = {}
+    read = _vendor_repo_reader(_FakeClient(), failures)
+
+    assert await read("shared/ok.py") == "OK_SOURCE"
+    assert await read("shared/absent.py") is None
+    assert await read("shared/flaky.py") is None
+    assert failures == {"shared/flaky.py": "HTTP 503"}

--- a/api/tests/unit/test_solution_vendoring.py
+++ b/api/tests/unit/test_solution_vendoring.py
@@ -101,3 +101,20 @@ async def test_vendor_repo_reader_distinguishes_absent_from_failed() -> None:
     assert await read("shared/absent.py") is None
     assert await read("shared/flaky.py") is None
     assert failures == {"shared/flaky.py": "HTTP 503"}
+
+
+def test_unresolved_vendor_failures_ignores_covered_candidates() -> None:
+    """A probe failure only matters if the module actually missed the bundle:
+    pkg.py failing while pkg/__init__.py vendored fine must not abort (review F2)."""
+    from bifrost.commands.solution import _unresolved_vendor_failures
+
+    failures = {
+        "shared/utils.py": "HTTP 500",        # sibling __init__ WAS vendored
+        "shared/calc.py": "HTTP 503",         # truly unresolved
+        "shared/ok.py": "HTTP 500",           # itself bundled after a retry path
+    }
+    bundled = {"shared/utils/__init__.py", "shared/ok.py", "workflows/main.py"}
+
+    assert _unresolved_vendor_failures(failures, bundled) == {
+        "shared/calc.py": "HTTP 503",
+    }

--- a/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
+++ b/plugins/bifrost/skills/bifrost-build/generated/cli-reference.md
@@ -1766,6 +1766,8 @@ Options:
                                   no-include-imports]
   --dry-run                       Preview the dependency closure + outside
                                   references; capture nothing.
+  --yes                           Skip the confirmation prompt (capture is
+                                  terminal).
   --help                          Show this message and exit.
 ```
 


### PR DESCRIPTION
Four DX fixes from the 2026-07-09 solution-CLI review sweep, plus review-driven hardening.

- **#462**: `solution start` (and `bind`/`pull`/`deploy` for the implicit `.`) walk up to the solution root instead of demanding cwd == root.
- **#463**: global installs get a real `null` orgScope — the org env var is omitted (not `""`) and the scaffold's vite define emits `null`; `start` hints when an existing app's `vite.config.ts` still bakes `""`.
- **#465**: deploy vendoring fails loudly when a `_repo` module can't be read (404 stays a legitimate stdlib/third-party miss; candidate-path siblings are checked so a transient failure on `pkg.py` doesn't abort when `pkg/__init__.py` vendored fine).
- **#466**: `capture` warns about its terminal semantics and confirms before applying; `--yes` for scripts; decline/EOF exits 1 so `capture && deploy` chains stop; `--dry-run` unchanged.

CLI-only (`api/bifrost/` + tests + regenerated CLI-reference appendix). Verified: full unit suite 5211 passed, pyright/ruff clean, high-effort multi-agent review (5 findings, all fixed above), live drive against a debug stack (subdir `start` served a local workflow through the proxy; capture prompt/decline; fresh scaffold emits `|| null`).

Fixes #462
Fixes #463
Fixes #465
Fixes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)