### PR TITLE
solution start: clean npm errors, deterministic vite lifecycle, Windows tree teardown

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2890,6 +2890,9 @@ def _terminate_process_group(proc: "subprocess.Popen") -> None:
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
+            # taskkill /F already force-killed the tree; a wait timing out
+            # here means Windows is slow to reap — nothing more to do, and
+            # teardown must not raise.
             pass
         return
 

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2324,6 +2324,7 @@ def start_cmd(
     # child, and a plain terminate() of `npm` orphans `vite` (it keeps the port
     # bound). Killing the group reaps both. (POSIX; Windows falls back to a plain
     # terminate of the npm process.)
+    _ensure_port_free(vite_port)
     vite_proc = subprocess.Popen(
         [npm, "run", "dev", "--", "--port", str(vite_port), "--strictPort"],
         cwd=chosen.app_dir, env=vite_env,
@@ -2331,7 +2332,10 @@ def start_cmd(
     )
     try:
         _wait_for_vite(vite_proc, vite_port)
-    except click.ClickException:
+    except BaseException:
+        # BaseException: a Ctrl-C during the (up to 60s) readiness wait must
+        # tear the detached npm+vite group down too, or it survives orphaned
+        # and holds the port for the next start.
         _terminate_process_group(vite_proc)
         raise
 
@@ -2800,17 +2804,36 @@ def swap_slugs_cmd(app_a: str, app_b: str) -> None:
         raise SystemExit(rc)
 
 
-def _wait_for_vite(
-    proc: "subprocess.Popen", port: int, timeout: float = 60.0, grace: float = 1.5
-) -> None:
-    """Block until OUR Vite child serves the port; fail fast if it dies.
+def _ensure_port_free(port: int) -> None:
+    """Refuse to spawn vite onto a port something already serves.
+
+    An orphaned dev server from a previous run holding the port makes the new
+    child die under ``--strictPort`` while readiness probes happily connect to
+    the LEFTOVER — `start` would silently serve the stale app (live-drive
+    finding). Checking before the spawn is deterministic; probing after it is
+    a race against npm's cold start.
+    """
+    import socket
+
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            pass
+    except OSError:
+        return
+    raise click.ClickException(
+        f"Port {port} is already in use — an orphaned app dev server from a "
+        "previous run is the usual cause. Kill the process holding it (or "
+        "pass --port to pick a different pair) and re-run."
+    )
+
+
+def _wait_for_vite(proc: "subprocess.Popen", port: int, timeout: float = 60.0) -> None:
+    """Block until the Vite child accepts TCP connections; fail fast if it dies.
 
     ``--strictPort`` makes Vite exit when its port is taken; without this
     check the proxy serves unexplained 502s while the only clue scrolls past
-    in npm output (issue #460). A connect success alone is NOT readiness: an
-    orphaned vite from a previous run can hold the port while the new child
-    dies — `start` would then silently serve the STALE app (live-drive
-    finding). After connecting, wait ``grace`` and re-check the child.
+    in npm output (issue #460). ``_ensure_port_free`` ran before the spawn,
+    so a connect success here can only be our child.
     """
     import socket
 
@@ -2820,25 +2843,13 @@ def _wait_for_vite(
         if code is not None:
             raise click.ClickException(
                 f"The app dev server (vite) exited with code {code} before "
-                f"serving — see its output above. Is port {port} already in use?"
+                f"serving — see its output above."
             )
         try:
             with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                pass
+                return
         except OSError:
             time.sleep(0.25)
-            continue
-        # Port accepts — make sure it's OUR child serving it, not a leftover.
-        time.sleep(grace)
-        code = proc.poll()
-        if code is not None:
-            raise click.ClickException(
-                f"Port {port} is served by another process but this app's vite "
-                f"exited with code {code} — an orphaned dev server from a "
-                "previous run is likely holding the port. Kill it (or use "
-                "--port to pick a different one) and re-run."
-            )
-        return
     raise click.ClickException(
         f"vite did not start listening on port {port} within {int(timeout)}s — "
         "see its output above."
@@ -2852,11 +2863,17 @@ def _terminate_windows_tree(proc: "subprocess.Popen") -> None:
     orphans its vite child, which keeps the port bound and breaks the next
     start under --strictPort (issue #461). ``taskkill /T`` kills the tree.
     """
-    subprocess.run(
-        ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
-        capture_output=True,
-        check=False,
-    )
+    try:
+        subprocess.run(
+            ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        # taskkill missing from PATH (stripped CI shell): at minimum reap the
+        # direct child like the pre-taskkill code did, rather than crash the
+        # teardown and leave the whole tree running.
+        proc.terminate()
 
 
 def _terminate_process_group(proc: "subprocess.Popen") -> None:
@@ -2877,10 +2894,14 @@ def _terminate_process_group(proc: "subprocess.Popen") -> None:
         return
 
     def _signal_group(sig: int) -> None:
+        # start_new_session=True guarantees pgid == proc.pid, and the group
+        # outlives a reaped leader: os.getpgid(pid) raises ESRCH once poll()
+        # reaps npm, silently skipping the kill while vite lives on. Signal
+        # the group id directly.
         try:
-            os.killpg(os.getpgid(proc.pid), sig)
+            os.killpg(proc.pid, sig)
         except (ProcessLookupError, PermissionError):
-            pass  # already gone / not our group
+            pass  # whole group already gone / not ours
 
     _signal_group(signal.SIGTERM)
     try:

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2800,12 +2800,17 @@ def swap_slugs_cmd(app_a: str, app_b: str) -> None:
         raise SystemExit(rc)
 
 
-def _wait_for_vite(proc: "subprocess.Popen", port: int, timeout: float = 60.0) -> None:
-    """Block until the Vite child accepts TCP connections; fail fast if it dies.
+def _wait_for_vite(
+    proc: "subprocess.Popen", port: int, timeout: float = 60.0, grace: float = 1.5
+) -> None:
+    """Block until OUR Vite child serves the port; fail fast if it dies.
 
     ``--strictPort`` makes Vite exit when its port is taken; without this
     check the proxy serves unexplained 502s while the only clue scrolls past
-    in npm output (issue #460).
+    in npm output (issue #460). A connect success alone is NOT readiness: an
+    orphaned vite from a previous run can hold the port while the new child
+    dies — `start` would then silently serve the STALE app (live-drive
+    finding). After connecting, wait ``grace`` and re-check the child.
     """
     import socket
 
@@ -2819,9 +2824,21 @@ def _wait_for_vite(proc: "subprocess.Popen", port: int, timeout: float = 60.0) -
             )
         try:
             with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                return
+                pass
         except OSError:
             time.sleep(0.25)
+            continue
+        # Port accepts — make sure it's OUR child serving it, not a leftover.
+        time.sleep(grace)
+        code = proc.poll()
+        if code is not None:
+            raise click.ClickException(
+                f"Port {port} is served by another process but this app's vite "
+                f"exited with code {code} — an orphaned dev server from a "
+                "previous run is likely holding the port. Kill it (or use "
+                "--port to pick a different one) and re-run."
+            )
+        return
     raise click.ClickException(
         f"vite did not start listening on port {port} within {int(timeout)}s — "
         "see its output above."

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2298,7 +2298,16 @@ def start_cmd(
         raise click.ClickException("npm not found on PATH — install Node.js to run the dev server.")
     if not (chosen.app_dir / "node_modules").is_dir():
         click.echo("Installing app dependencies (npm install)…")
-        subprocess.run([npm, "install"], cwd=chosen.app_dir, check=True)
+        try:
+            subprocess.run([npm, "install"], cwd=chosen.app_dir, check=True)
+        except subprocess.CalledProcessError as exc:
+            # First run on a fresh machine is when this most likely fails
+            # (registry hiccup, unreachable SDK download) — a one-line error,
+            # never a raw traceback (issue #459).
+            raise click.ClickException(
+                f"npm install failed in {chosen.app_dir} (exit {exc.returncode}) "
+                "— see the npm output above."
+            )
 
     proxy_origin = (public_url or f"http://127.0.0.1:{port}").rstrip("/")
     vite_env = _vite_child_env(
@@ -2320,6 +2329,11 @@ def start_cmd(
         cwd=chosen.app_dir, env=vite_env,
         start_new_session=True,
     )
+    try:
+        _wait_for_vite(vite_proc, vite_port)
+    except click.ClickException:
+        _terminate_process_group(vite_proc)
+        raise
 
     try:
         asyncio.run(
@@ -2786,6 +2800,48 @@ def swap_slugs_cmd(app_a: str, app_b: str) -> None:
         raise SystemExit(rc)
 
 
+def _wait_for_vite(proc: "subprocess.Popen", port: int, timeout: float = 60.0) -> None:
+    """Block until the Vite child accepts TCP connections; fail fast if it dies.
+
+    ``--strictPort`` makes Vite exit when its port is taken; without this
+    check the proxy serves unexplained 502s while the only clue scrolls past
+    in npm output (issue #460).
+    """
+    import socket
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        code = proc.poll()
+        if code is not None:
+            raise click.ClickException(
+                f"The app dev server (vite) exited with code {code} before "
+                f"serving — see its output above. Is port {port} already in use?"
+            )
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.25)
+    raise click.ClickException(
+        f"vite did not start listening on port {port} within {int(timeout)}s — "
+        "see its output above."
+    )
+
+
+def _terminate_windows_tree(proc: "subprocess.Popen") -> None:
+    """Kill the npm process AND its children on Windows.
+
+    There are no process groups there: a bare terminate() reaps npm but
+    orphans its vite child, which keeps the port bound and breaks the next
+    start under --strictPort (issue #461). ``taskkill /T`` kills the tree.
+    """
+    subprocess.run(
+        ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+        capture_output=True,
+        check=False,
+    )
+
+
 def _terminate_process_group(proc: "subprocess.Popen") -> None:
     """Stop a child and any grandchildren it spawned in its process group.
 
@@ -2794,15 +2850,20 @@ def _terminate_process_group(proc: "subprocess.Popen") -> None:
     """
     import signal
 
+    if not hasattr(os, "killpg"):
+        # Windows: no process groups — taskkill the whole tree instead.
+        _terminate_windows_tree(proc)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        return
+
     def _signal_group(sig: int) -> None:
-        if hasattr(os, "killpg"):
-            try:
-                os.killpg(os.getpgid(proc.pid), sig)
-                return
-            except (ProcessLookupError, PermissionError):
-                return  # already gone / not our group — fall through to proc-level
-        # No process groups (Windows): signal the process itself.
-        proc.send_signal(sig)
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError):
+            pass  # already gone / not our group
 
     _signal_group(signal.SIGTERM)
     try:

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -738,7 +738,7 @@ async def _vite_proxy_handler(request: web.Request) -> web.StreamResponse:
             content=data or None,
             headers=headers,
         )
-    except httpx.HTTPError:
+    except httpx.ConnectError:
         # A dead Vite child must be an EXPLAINED 502 (like the API handler's),
         # not a bare 500 — "the page won't load" with no cause was issue #460.
         return web.json_response(
@@ -749,6 +749,14 @@ async def _vite_proxy_handler(request: web.Request) -> web.StreamResponse:
                     "solution start` terminal."
                 )
             },
+            status=502,
+        )
+    except httpx.HTTPError as exc:
+        # A live-but-misbehaving vite (read timeout during cold dependency
+        # pre-bundling, protocol error mid-response) is NOT a startup failure
+        # — say what actually happened instead of sending the user hunting one.
+        return web.json_response(
+            {"detail": f"Error talking to the app dev server (vite): {type(exc).__name__}: {exc}"},
             status=502,
         )
     return web.Response(

--- a/api/bifrost/solution_dev/proxy.py
+++ b/api/bifrost/solution_dev/proxy.py
@@ -731,12 +731,26 @@ async def _vite_proxy_handler(request: web.Request) -> web.StreamResponse:
         return await _ws_proxy(request, target)
     data = await request.read()
     headers = {k: v for k, v in request.headers.items() if k.lower() not in _STRIP}
-    resp = await request.app[_HTTP].request(
-        request.method,
-        _join_upstream(vite_url, request.rel_url),
-        content=data or None,
-        headers=headers,
-    )
+    try:
+        resp = await request.app[_HTTP].request(
+            request.method,
+            _join_upstream(vite_url, request.rel_url),
+            content=data or None,
+            headers=headers,
+        )
+    except httpx.HTTPError:
+        # A dead Vite child must be an EXPLAINED 502 (like the API handler's),
+        # not a bare 500 — "the page won't load" with no cause was issue #460.
+        return web.json_response(
+            {
+                "detail": (
+                    f"App dev server (vite) unreachable at {vite_url} — did it "
+                    "fail to start? Check the npm output in the `bifrost "
+                    "solution start` terminal."
+                )
+            },
+            status=502,
+        )
     return web.Response(
         body=resp.content, status=resp.status_code,
         headers=_passthrough_headers(resp, "text/html"),

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -534,6 +534,7 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
         return None
 
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
     monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
@@ -626,6 +627,7 @@ def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(subprocess, "Popen", _fake_popen)
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
     monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
@@ -785,6 +787,7 @@ def test_start_finds_solution_root_from_subdirectory(tmp_path, monkeypatch):
         return None
 
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
     monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
@@ -811,8 +814,8 @@ def test_workspace_from_path_arg_walks_up_only_for_default(tmp_path, monkeypatch
 
 
 def _start_workspace(tmp_path, monkeypatch):
-    """Shared minimal start_cmd fixture: bound workspace + fakes for network,
-    host, and npm spawns. Returns the `spawned` argv list."""
+    """Shared minimal start_cmd fixture: bound workspace + fakes for network
+    and host. Returns the (monkeypatch-ready) `subprocess` module."""
     import shutil
     import subprocess
 
@@ -956,31 +959,37 @@ def test_terminate_windows_tree_taskkills_the_whole_tree(monkeypatch):
     assert calls == [["taskkill", "/T", "/F", "/PID", "4242"]]
 
 
-def test_wait_for_vite_detects_orphan_serving_the_port():
-    """A connect success is only readiness if OUR child is still alive: an
-    orphaned vite from a previous run can hold the port while the new child
-    dies under --strictPort — serving the STALE app (live-drive finding)."""
+def test_ensure_port_free_rejects_an_occupied_port():
+    """An orphaned vite from a previous run holding the port would make the
+    new child die under --strictPort while readiness probes connect to the
+    LEFTOVER — start must refuse BEFORE spawning (live-drive finding; the
+    post-spawn grace re-check was a race against npm's cold start)."""
     import socket
 
     import click
     import pytest as _pytest
 
-    from bifrost.commands.solution import _wait_for_vite
-
-    class _DiesAfterFirstPoll:
-        def __init__(self):
-            self.polls = 0
-
-        def poll(self):
-            self.polls += 1
-            return None if self.polls <= 1 else 7
+    from bifrost.commands.solution import _ensure_port_free
 
     server = socket.socket()
     server.bind(("127.0.0.1", 0))
     server.listen(1)
     port = server.getsockname()[1]
     try:
-        with _pytest.raises(click.ClickException, match="another process"):
-            _wait_for_vite(_DiesAfterFirstPoll(), port=port, timeout=5, grace=0.1)
+        with _pytest.raises(click.ClickException, match="already in use"):
+            _ensure_port_free(port)
     finally:
         server.close()
+
+
+def test_ensure_port_free_passes_a_free_port():
+    import socket
+
+    from bifrost.commands.solution import _ensure_port_free
+
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    _ensure_port_free(port)  # must not raise

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -534,6 +534,7 @@ def test_start_spawns_npm_via_resolved_path(tmp_path: Path, monkeypatch):
         return None
 
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
     )
@@ -625,6 +626,7 @@ def test_start_accepts_bind_host_and_public_url(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(subprocess, "Popen", _fake_popen)
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
     )
@@ -783,6 +785,7 @@ def test_start_finds_solution_root_from_subdirectory(tmp_path, monkeypatch):
         return None
 
     monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
     monkeypatch.setattr(
         "bifrost.commands.solution._terminate_process_group", lambda proc: None
     )
@@ -805,3 +808,149 @@ def test_workspace_from_path_arg_walks_up_only_for_default(tmp_path, monkeypatch
 
     assert str(_workspace_from_path_arg(".")) == str(tmp_path.resolve())
     assert str(_workspace_from_path_arg(str(sub))) == str(sub.resolve())
+
+
+def _start_workspace(tmp_path, monkeypatch):
+    """Shared minimal start_cmd fixture: bound workspace + fakes for network,
+    host, and npm spawns. Returns the `spawned` argv list."""
+    import shutil
+    import subprocess
+
+    import bifrost.client as client_mod
+    from bifrost.solution_dev import function_host
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "bifrost.solution.yaml").write_text("slug: s\nname: S\nscope: org\n")
+    (tmp_path / ".env").write_text(
+        "BIFROST_SOLUTION_ID=11111111-1111-1111-1111-111111111111\n"
+        "BIFROST_SOLUTION_SLUG=s\n"
+        "BIFROST_SOLUTION_ORG_ID=org-1\n"
+        "BIFROST_SOLUTION_SCOPE=org\n"
+    )
+    (tmp_path / ".bifrost").mkdir()
+    (tmp_path / ".bifrost" / "apps.yaml").write_text(
+        yaml.safe_dump({"apps": {
+            "a": {"id": "a", "slug": "dash", "path": "apps/dash", "app_model": "standalone_v2"},
+        }})
+    )
+    (tmp_path / "apps" / "dash").mkdir(parents=True)
+
+    class _FakeClient:
+        organization = {"id": "org-1"}
+        user = {"id": "u", "is_superuser": True}
+        api_url = "http://localhost:8000"
+        _access_token = "tok"
+
+    monkeypatch.setattr(client_mod.BifrostClient, "get_instance", staticmethod(lambda **k: _FakeClient()))
+    monkeypatch.setattr(function_host, "set_dev_execution_context", lambda **k: None)
+
+    class _FakeHost:
+        def __init__(self, workspace):
+            pass
+
+        def reload(self):
+            pass
+
+        def refs(self):
+            return []
+
+        def failures(self):
+            return {}
+
+    monkeypatch.setattr(function_host, "FunctionHost", _FakeHost)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/npm" if name == "npm" else None)
+    return subprocess
+
+
+def test_start_npm_install_failure_is_a_clean_click_error(tmp_path, monkeypatch):
+    """A failed npm install must be a one-line ClickException, not a raw
+    CalledProcessError traceback (issue #459) — first run on a fresh machine
+    is exactly when the install is most likely to fail."""
+    subprocess = _start_workspace(tmp_path, monkeypatch)
+
+    def _failing_run(argv, **kwargs):
+        raise subprocess.CalledProcessError(returncode=254, cmd=argv)
+
+    monkeypatch.setattr(subprocess, "run", _failing_run)
+
+    result = CliRunner().invoke(solution_group, ["start"])
+    assert result.exit_code == 1, result.output
+    assert "npm install failed" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_wait_for_vite_fails_fast_when_process_dies(monkeypatch):
+    """--strictPort makes vite exit when its port is taken; start must fail
+    with the exit code instead of serving unexplained 502s (issue #460)."""
+    import click
+    import pytest as _pytest
+
+    from bifrost.commands.solution import _wait_for_vite
+
+    class _DeadProc:
+        def poll(self):
+            return 7
+
+    with _pytest.raises(click.ClickException, match="exited with code 7"):
+        _wait_for_vite(_DeadProc(), port=1)
+
+
+def test_wait_for_vite_returns_when_port_accepts():
+    import socket
+
+    from bifrost.commands.solution import _wait_for_vite
+
+    class _LiveProc:
+        def poll(self):
+            return None
+
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    try:
+        _wait_for_vite(_LiveProc(), port=port, timeout=5)
+    finally:
+        server.close()
+
+
+def test_wait_for_vite_times_out_with_clean_error():
+    import socket
+
+    import click
+    import pytest as _pytest
+
+    from bifrost.commands.solution import _wait_for_vite
+
+    class _LiveProc:
+        def poll(self):
+            return None
+
+    # A port nothing listens on: bind-then-close guarantees it's free.
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    with _pytest.raises(click.ClickException, match="did not start listening"):
+        _wait_for_vite(_LiveProc(), port=port, timeout=0.6)
+
+
+def test_terminate_windows_tree_taskkills_the_whole_tree(monkeypatch):
+    """On Windows there are no process groups: a bare terminate() reaps npm but
+    orphans its vite child, which keeps the port bound and breaks the next
+    start under --strictPort (issue #461). taskkill /T kills the tree."""
+    import subprocess as _subprocess
+
+    from bifrost.commands.solution import _terminate_windows_tree
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        _subprocess, "run", lambda argv, **k: calls.append(list(argv))
+    )
+
+    class _Proc:
+        pid = 4242
+
+    _terminate_windows_tree(_Proc())
+    assert calls == [["taskkill", "/T", "/F", "/PID", "4242"]]

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -954,3 +954,33 @@ def test_terminate_windows_tree_taskkills_the_whole_tree(monkeypatch):
 
     _terminate_windows_tree(_Proc())
     assert calls == [["taskkill", "/T", "/F", "/PID", "4242"]]
+
+
+def test_wait_for_vite_detects_orphan_serving_the_port():
+    """A connect success is only readiness if OUR child is still alive: an
+    orphaned vite from a previous run can hold the port while the new child
+    dies under --strictPort — serving the STALE app (live-drive finding)."""
+    import socket
+
+    import click
+    import pytest as _pytest
+
+    from bifrost.commands.solution import _wait_for_vite
+
+    class _DiesAfterFirstPoll:
+        def __init__(self):
+            self.polls = 0
+
+        def poll(self):
+            self.polls += 1
+            return None if self.polls <= 1 else 7
+
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    try:
+        with _pytest.raises(click.ClickException, match="another process"):
+            _wait_for_vite(_DiesAfterFirstPoll(), port=port, timeout=5, grace=0.1)
+    finally:
+        server.close()

--- a/api/tests/unit/test_solution_dev_proxy.py
+++ b/api/tests/unit/test_solution_dev_proxy.py
@@ -680,3 +680,26 @@ async def test_ws_proxy_closes_upstream_when_client_disconnects():
     finally:
         await dev_runner.cleanup()
         await up_runner.cleanup()
+
+
+async def test_vite_proxy_returns_502_when_vite_is_down():
+    """A dead Vite child must surface as an explained 502, not a bare 500 —
+    the API proxy handler already does this; the vite handler didn't (issue #460)."""
+    record = {}
+    up_port, dev_port = _free_port(), _free_port()
+    up_runner = await _serve(_make_upstream(record), up_port)
+    host = _StubHost(set())
+    cfg = DevProxyConfig(
+        upstream_url=f"http://127.0.0.1:{up_port}",
+        token="t", app_id="A", org_id="O",
+    )
+    dead_vite = f"http://127.0.0.1:{_free_port()}"
+    dev_runner = await _serve(build_dev_app(cfg, host, vite_url=dead_vite), dev_port)
+    try:
+        async with httpx.AsyncClient() as c:
+            r = await c.get(f"http://127.0.0.1:{dev_port}/")
+        assert r.status_code == 502
+        assert "vite" in r.json()["detail"].lower()
+    finally:
+        await dev_runner.cleanup()
+        await up_runner.cleanup()


### PR DESCRIPTION
Start-lifecycle fixes from the 2026-07-09 solution-CLI review sweep, hardened by a high-effort review pass (9 findings addressed) and live drives.

- **#459**: `npm install` failure is a one-line ClickException with the exit code, not a raw `CalledProcessError` traceback.
- **#460**: `start` refuses up front when the vite port is already in use (deterministic pre-spawn check — the usual cause is an orphaned dev server from a previous run); after spawning, it waits for vite to accept connections and fails fast with the exit code if the child dies. The proxy's vite handler returns explained 502s: "unreachable — did it fail to start?" for connect errors, the real exception for a live-but-misbehaving vite (timeouts, protocol errors).
- **#461**: Windows teardown uses `taskkill /T /F` to reap npm **and** its vite child (no process groups there — a bare terminate orphaned vite and kept the port bound), falling back to terminating the direct child if taskkill is missing. POSIX teardown now signals `killpg(proc.pid)` directly — `getpgid` raises ESRCH once `poll()` reaps the npm leader, which silently skipped killing a surviving vite.
- Ctrl-C during the readiness wait tears the whole npm+vite group down (previously leaked it for the pre-serve window).

Verified: 5219 unit tests, pyright/ruff clean; live drives of the failure paths (sabotaged npm install → one-line error; genuine orphaned vite on the port → accurate refusal; clean start → local workflow served). **Windows note:** the `taskkill` path is unit-tested (exact argv); live VM verification was blocked by local libvirt instability (the win11-pam guest gets SIGTERM'd minutes after boot — host issue, unrelated to this change).

Fixes #459
Fixes #460
Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)