### PR TITLE
solution start: repoint the scaffolded SDK dependency at the bound instance

### DIFF
--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2296,7 +2296,13 @@ def start_cmd(
     npm = shutil.which("npm")
     if npm is None:
         raise click.ClickException("npm not found on PATH — install Node.js to run the dev server.")
-    if not (chosen.app_dir / "node_modules").is_dir():
+    healed = _heal_sdk_dep(chosen.app_dir, client.api_url)
+    if healed:
+        click.echo(
+            "Repointed the app's `bifrost` SDK dependency at this instance "
+            "(package.json froze the scaffold-time URL) — reinstalling."
+        )
+    if healed or not (chosen.app_dir / "node_modules").is_dir():
         click.echo("Installing app dependencies (npm install)…")
         try:
             subprocess.run([npm, "install"], cwd=chosen.app_dir, check=True)
@@ -2802,6 +2808,40 @@ def swap_slugs_cmd(app_a: str, app_b: str) -> None:
     rc = asyncio.run(_run())
     if rc:
         raise SystemExit(rc)
+
+
+def _heal_sdk_dep(app_dir: pathlib.Path, api_url: str) -> bool:
+    """Repoint the scaffolded ``bifrost`` SDK dependency at the CURRENT instance.
+
+    scaffold freezes ``<api_url>/api/sdk/download`` into package.json at
+    scaffold time; against a dead debug-stack port (or the offline
+    localhost:8000 fallback) ``npm install`` fails days later with nothing
+    connecting the error back to the frozen URL (issue #464). ``start`` knows
+    the bound instance's URL — heal before installing. Only the
+    scaffold-written download-URL shape is touched: a user-pinned ``file:``
+    path or registry range is their choice. Returns True when the file changed.
+    """
+    pkg_file = app_dir / "package.json"
+    if not pkg_file.is_file():
+        return False
+    try:
+        pkg = json.loads(pkg_file.read_text(encoding="utf-8"))
+    except ValueError:
+        return False  # malformed → npm's own parse error is the right message
+    deps = pkg.get("dependencies")
+    if not isinstance(deps, dict):
+        return False
+    current = deps.get("bifrost")
+    expected = f"{api_url.rstrip('/')}/api/sdk/download"
+    if (
+        not isinstance(current, str)
+        or not current.endswith("/api/sdk/download")
+        or current == expected
+    ):
+        return False
+    deps["bifrost"] = expected
+    pkg_file.write_text(json.dumps(pkg, indent=2) + "\n", encoding="utf-8")
+    return True
 
 
 def _ensure_port_free(port: int) -> None:

--- a/api/bifrost/commands/solution.py
+++ b/api/bifrost/commands/solution.py
@@ -2296,24 +2296,46 @@ def start_cmd(
     npm = shutil.which("npm")
     if npm is None:
         raise click.ClickException("npm not found on PATH — install Node.js to run the dev server.")
-    healed = _heal_sdk_dep(chosen.app_dir, client.api_url)
-    if healed:
+    # Cheap, deterministic refusals come BEFORE a possibly-minutes install:
+    # aborting on a busy port after the user sat through npm is hostile.
+    vite_port = port + 1
+    _ensure_port_free(vite_port)
+
+    original_sdk_spec = _heal_sdk_dep(chosen.app_dir, client.api_url)
+    if original_sdk_spec is not None:
         click.echo(
             "Repointed the app's `bifrost` SDK dependency at this instance "
             "(package.json froze the scaffold-time URL) — reinstalling."
         )
-    if healed or not (chosen.app_dir / "node_modules").is_dir():
+    have_node_modules = (chosen.app_dir / "node_modules").is_dir()
+    if original_sdk_spec is not None or not have_node_modules:
         click.echo("Installing app dependencies (npm install)…")
         try:
             subprocess.run([npm, "install"], cwd=chosen.app_dir, check=True)
         except subprocess.CalledProcessError as exc:
-            # First run on a fresh machine is when this most likely fails
-            # (registry hiccup, unreachable SDK download) — a one-line error,
-            # never a raw traceback (issue #459).
-            raise click.ClickException(
-                f"npm install failed in {chosen.app_dir} (exit {exc.returncode}) "
-                "— see the npm output above."
-            )
+            if original_sdk_spec is not None:
+                # Keep the retry signal alive: a healed manifest with a failed
+                # install would otherwise read as "already correct" next run
+                # and the stale SDK would never be replaced.
+                _restore_sdk_dep(chosen.app_dir, client.api_url, original_sdk_spec)
+            if original_sdk_spec is not None and have_node_modules:
+                # The pre-heal state was a WORKING install (possibly offline):
+                # keep the dev server usable rather than hard-failing; the next
+                # start retries the heal + reinstall.
+                click.echo(
+                    "  warning: reinstall after repointing the SDK failed — "
+                    "continuing with the previously installed dependencies "
+                    "(the SDK may be stale until npm install succeeds).",
+                    err=True,
+                )
+            else:
+                # First run on a fresh machine is when this most likely fails
+                # (registry hiccup, unreachable SDK download) — a one-line
+                # error, never a raw traceback (issue #459).
+                raise click.ClickException(
+                    f"npm install failed in {chosen.app_dir} (exit {exc.returncode}) "
+                    "— see the npm output above."
+                )
 
     proxy_origin = (public_url or f"http://127.0.0.1:{port}").rstrip("/")
     vite_env = _vite_child_env(
@@ -2324,13 +2346,11 @@ def start_cmd(
         access_token=client._access_token,
     )
 
-    vite_port = port + 1
     # Run `npm run dev` in its OWN process group (start_new_session) so teardown
     # can signal the WHOLE group: `npm` spawns the real `vite` node process as a
     # child, and a plain terminate() of `npm` orphans `vite` (it keeps the port
     # bound). Killing the group reaps both. (POSIX; Windows falls back to a plain
     # terminate of the npm process.)
-    _ensure_port_free(vite_port)
     vite_proc = subprocess.Popen(
         [npm, "run", "dev", "--", "--port", str(vite_port), "--strictPort"],
         cwd=chosen.app_dir, env=vite_env,
@@ -2810,7 +2830,10 @@ def swap_slugs_cmd(app_a: str, app_b: str) -> None:
         raise SystemExit(rc)
 
 
-def _heal_sdk_dep(app_dir: pathlib.Path, api_url: str) -> bool:
+_SDK_DOWNLOAD_SUFFIX = "/api/sdk/download"
+
+
+def _heal_sdk_dep(app_dir: pathlib.Path, api_url: str) -> str | None:
     """Repoint the scaffolded ``bifrost`` SDK dependency at the CURRENT instance.
 
     scaffold freezes ``<api_url>/api/sdk/download`` into package.json at
@@ -2819,29 +2842,58 @@ def _heal_sdk_dep(app_dir: pathlib.Path, api_url: str) -> bool:
     connecting the error back to the frozen URL (issue #464). ``start`` knows
     the bound instance's URL — heal before installing. Only the
     scaffold-written download-URL shape is touched: a user-pinned ``file:``
-    path or registry range is their choice. Returns True when the file changed.
+    path or registry range is their choice.
+
+    The rewrite is a single-occurrence text replacement, not a JSON re-dump —
+    the file is the USER'S manifest and a one-dep heal must not reformat it or
+    escape their non-ASCII content. Heal is best-effort: unreadable, malformed,
+    or ambiguous manifests are left alone (npm's own error is the message).
+
+    Returns the ORIGINAL dependency spec when the file was changed (the caller
+    reverts it if the reinstall fails, keeping the retry signal alive), else
+    None.
     """
     pkg_file = app_dir / "package.json"
-    if not pkg_file.is_file():
-        return False
     try:
-        pkg = json.loads(pkg_file.read_text(encoding="utf-8"))
-    except ValueError:
-        return False  # malformed → npm's own parse error is the right message
+        # utf-8-sig: Windows editors BOM-prefix manifests npm happily accepts.
+        text = pkg_file.read_text(encoding="utf-8-sig")
+        pkg = json.loads(text)
+    except (OSError, ValueError):
+        return None
     deps = pkg.get("dependencies")
     if not isinstance(deps, dict):
-        return False
+        return None
     current = deps.get("bifrost")
-    expected = f"{api_url.rstrip('/')}/api/sdk/download"
+    expected = f"{api_url.rstrip('/')}{_SDK_DOWNLOAD_SUFFIX}"
     if (
         not isinstance(current, str)
-        or not current.endswith("/api/sdk/download")
+        or not current.endswith(_SDK_DOWNLOAD_SUFFIX)
         or current == expected
+        or text.count(current) != 1
     ):
-        return False
-    deps["bifrost"] = expected
-    pkg_file.write_text(json.dumps(pkg, indent=2) + "\n", encoding="utf-8")
-    return True
+        return None
+    try:
+        pkg_file.write_text(text.replace(current, expected), encoding="utf-8")
+    except OSError:
+        return None
+    return current
+
+
+def _restore_sdk_dep(app_dir: pathlib.Path, api_url: str, original: str) -> None:
+    """Undo a heal whose reinstall failed, so the NEXT start retries both.
+
+    Leaving the healed URL in place with a failed install permanently consumes
+    the reinstall signal: the next run sees a correct manifest plus an existing
+    node_modules and never replaces the stale SDK tarball.
+    """
+    pkg_file = app_dir / "package.json"
+    expected = f"{api_url.rstrip('/')}{_SDK_DOWNLOAD_SUFFIX}"
+    try:
+        text = pkg_file.read_text(encoding="utf-8-sig")
+        if text.count(expected) == 1:
+            pkg_file.write_text(text.replace(expected, original), encoding="utf-8")
+    except OSError:
+        pass  # best-effort: worst case the user re-heals on a later start
 
 
 def _ensure_port_free(port: int) -> None:

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -993,3 +993,99 @@ def test_ensure_port_free_passes_a_free_port():
     probe.close()
 
     _ensure_port_free(port)  # must not raise
+
+
+def test_heal_sdk_dep_repoints_stale_download_url(tmp_path):
+    """scaffold freezes `<api_url>/api/sdk/download` into package.json; against
+    a dead debug-stack port npm install fails days later with no clue back to
+    the scaffold-time URL (issue #464). start knows the right URL — heal it."""
+    import json as _json
+
+    from bifrost.commands.solution import _heal_sdk_dep
+
+    pkg = tmp_path / "package.json"
+    pkg.write_text(_json.dumps({
+        "name": "app",
+        "dependencies": {
+            "bifrost": "http://localhost:39999/api/sdk/download",
+            "react": "^18.2.0",
+        },
+    }, indent=2))
+
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399/") is True
+    data = _json.loads(pkg.read_text())
+    assert data["dependencies"]["bifrost"] == "http://localhost:30399/api/sdk/download"
+    assert data["dependencies"]["react"] == "^18.2.0"  # untouched
+    assert data["name"] == "app"
+
+
+def test_heal_sdk_dep_noop_when_url_already_current(tmp_path):
+    import json as _json
+
+    from bifrost.commands.solution import _heal_sdk_dep
+
+    pkg = tmp_path / "package.json"
+    pkg.write_text(_json.dumps({
+        "dependencies": {"bifrost": "http://localhost:30399/api/sdk/download"},
+    }))
+    before = pkg.read_text()
+
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False
+    assert pkg.read_text() == before  # no rewrite, no reformat
+
+
+def test_heal_sdk_dep_leaves_custom_dep_specs_alone(tmp_path):
+    """Only the scaffold-written download-URL shape is healed — a user-pinned
+    file: path or registry range is their choice, not ours to rewrite."""
+    import json as _json
+
+    from bifrost.commands.solution import _heal_sdk_dep
+
+    for spec in ("file:../sdk/bifrost.tgz", "^2.0.0"):
+        pkg = tmp_path / "package.json"
+        pkg.write_text(_json.dumps({"dependencies": {"bifrost": spec}}))
+        assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False
+        assert _json.loads(pkg.read_text())["dependencies"]["bifrost"] == spec
+
+
+def test_heal_sdk_dep_tolerates_missing_or_malformed_manifest(tmp_path):
+    from bifrost.commands.solution import _heal_sdk_dep
+
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False  # absent
+    (tmp_path / "package.json").write_text("{not json")
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False  # malformed
+
+
+def test_start_reinstalls_after_healing_even_with_node_modules(tmp_path, monkeypatch):
+    """A healed SDK URL must trigger npm install even when node_modules exists
+    — the stale tarball is exactly what needs replacing."""
+    import json as _json
+
+    subprocess = _start_workspace(tmp_path, monkeypatch)
+    app_dir = tmp_path / "apps" / "dash"
+    (app_dir / "node_modules").mkdir(parents=True)
+    (app_dir / "package.json").write_text(_json.dumps({
+        "dependencies": {"bifrost": "http://localhost:39999/api/sdk/download"},
+    }))
+
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: spawned.append(list(argv)))
+
+    class _FakeProc:
+        pid = 4242
+
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **k: _FakeProc())
+
+    async def _fake_serve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
+    monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
+    monkeypatch.setattr("bifrost.commands.solution._terminate_process_group", lambda proc: None)
+
+    result = CliRunner().invoke(solution_group, ["start"])
+    assert result.exit_code == 0, result.output
+    assert any("install" in argv for argv in spawned), spawned
+    healed = _json.loads((app_dir / "package.json").read_text())
+    assert healed["dependencies"]["bifrost"] == "http://localhost:8000/api/sdk/download"

--- a/api/tests/unit/test_solution_dev_command.py
+++ b/api/tests/unit/test_solution_dev_command.py
@@ -1012,7 +1012,8 @@ def test_heal_sdk_dep_repoints_stale_download_url(tmp_path):
         },
     }, indent=2))
 
-    assert _heal_sdk_dep(tmp_path, "http://localhost:30399/") is True
+    original = _heal_sdk_dep(tmp_path, "http://localhost:30399/")
+    assert original == "http://localhost:39999/api/sdk/download"
     data = _json.loads(pkg.read_text())
     assert data["dependencies"]["bifrost"] == "http://localhost:30399/api/sdk/download"
     assert data["dependencies"]["react"] == "^18.2.0"  # untouched
@@ -1030,7 +1031,7 @@ def test_heal_sdk_dep_noop_when_url_already_current(tmp_path):
     }))
     before = pkg.read_text()
 
-    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is None
     assert pkg.read_text() == before  # no rewrite, no reformat
 
 
@@ -1044,16 +1045,16 @@ def test_heal_sdk_dep_leaves_custom_dep_specs_alone(tmp_path):
     for spec in ("file:../sdk/bifrost.tgz", "^2.0.0"):
         pkg = tmp_path / "package.json"
         pkg.write_text(_json.dumps({"dependencies": {"bifrost": spec}}))
-        assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False
+        assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is None
         assert _json.loads(pkg.read_text())["dependencies"]["bifrost"] == spec
 
 
 def test_heal_sdk_dep_tolerates_missing_or_malformed_manifest(tmp_path):
     from bifrost.commands.solution import _heal_sdk_dep
 
-    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False  # absent
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is None  # absent
     (tmp_path / "package.json").write_text("{not json")
-    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is False  # malformed
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is None  # malformed
 
 
 def test_start_reinstalls_after_healing_even_with_node_modules(tmp_path, monkeypatch):
@@ -1089,3 +1090,115 @@ def test_start_reinstalls_after_healing_even_with_node_modules(tmp_path, monkeyp
     assert any("install" in argv for argv in spawned), spawned
     healed = _json.loads((app_dir / "package.json").read_text())
     assert healed["dependencies"]["bifrost"] == "http://localhost:8000/api/sdk/download"
+
+
+def test_heal_sdk_dep_preserves_user_formatting_and_unicode(tmp_path):
+    """The manifest is the USER'S file: healing one dep must not reformat it
+    or escape their non-ASCII content (review finding on the json re-dump)."""
+    from bifrost.commands.solution import _heal_sdk_dep
+
+    pkg = tmp_path / "package.json"
+    pkg.write_text(
+        '{\n'
+        '    "name": "app",\n'
+        '    "author": "Jos\u00e9 \U0001f389",\n'
+        '    "dependencies": {\n'
+        '        "bifrost": "http://localhost:39999/api/sdk/download"\n'
+        '    }\n'
+        '}\n',
+        encoding="utf-8",
+    )
+
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is not None
+    text = pkg.read_text(encoding="utf-8")
+    assert '    "name": "app",' in text          # 4-space indent survives
+    assert "Jos\u00e9 \U0001f389" in text            # unicode NOT escaped
+    assert "http://localhost:30399/api/sdk/download" in text
+
+
+def test_heal_sdk_dep_reads_bom_prefixed_manifests(tmp_path):
+    """Windows editors BOM-prefix package.json; npm tolerates it, so must we
+    — silently skipping the heal leaves the exact #464 symptom unfixed."""
+    import json as _json
+
+    from bifrost.commands.solution import _heal_sdk_dep
+
+    pkg = tmp_path / "package.json"
+    body = _json.dumps({"dependencies": {"bifrost": "http://localhost:39999/api/sdk/download"}})
+    pkg.write_bytes(b"\xef\xbb\xbf" + body.encode("utf-8"))
+
+    assert _heal_sdk_dep(tmp_path, "http://localhost:30399") is not None
+    assert "30399" in pkg.read_text(encoding="utf-8-sig")
+
+
+def test_restore_sdk_dep_reverts_a_heal(tmp_path):
+    import json as _json
+
+    from bifrost.commands.solution import _heal_sdk_dep, _restore_sdk_dep
+
+    pkg = tmp_path / "package.json"
+    pkg.write_text(_json.dumps({"dependencies": {"bifrost": "http://localhost:39999/api/sdk/download"}}))
+    original = _heal_sdk_dep(tmp_path, "http://localhost:30399")
+    assert original is not None
+
+    _restore_sdk_dep(tmp_path, "http://localhost:30399", original)
+    assert _json.loads(pkg.read_text())["dependencies"]["bifrost"] == original
+
+
+def test_start_failed_reinstall_after_heal_reverts_and_continues(tmp_path, monkeypatch):
+    """Install failure after a heal must (a) restore the original spec so the
+    NEXT start retries heal+reinstall, and (b) keep a previously-working
+    node_modules usable (offline starts worked before the heal existed)."""
+    import json as _json
+
+    subprocess = _start_workspace(tmp_path, monkeypatch)
+    app_dir = tmp_path / "apps" / "dash"
+    (app_dir / "node_modules").mkdir(parents=True)
+    (app_dir / "package.json").write_text(_json.dumps({
+        "dependencies": {"bifrost": "http://localhost:39999/api/sdk/download"},
+    }))
+
+    def _failing_run(argv, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=argv)
+
+    monkeypatch.setattr(subprocess, "run", _failing_run)
+
+    class _FakeProc:
+        pid = 4242
+
+    monkeypatch.setattr(subprocess, "Popen", lambda argv, **k: _FakeProc())
+
+    async def _fake_serve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("bifrost.commands.solution._serve", _fake_serve)
+    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", lambda port: None)
+    monkeypatch.setattr("bifrost.commands.solution._wait_for_vite", lambda proc, port: None)
+    monkeypatch.setattr("bifrost.commands.solution._terminate_process_group", lambda proc: None)
+
+    result = CliRunner().invoke(solution_group, ["start"])
+    assert result.exit_code == 0, result.output  # continues with old modules
+    assert "may be stale" in result.output
+    reverted = _json.loads((app_dir / "package.json").read_text())
+    assert reverted["dependencies"]["bifrost"] == "http://localhost:39999/api/sdk/download"
+
+
+def test_start_port_conflict_is_reported_before_any_npm_work(tmp_path, monkeypatch):
+    """The deterministic port refusal must come before a possibly-minutes
+    npm install — aborting AFTER the install wastes the wait and mutates
+    package.json for a command that never starts."""
+    import click
+
+    subprocess = _start_workspace(tmp_path, monkeypatch)
+    spawned: list[list[str]] = []
+    monkeypatch.setattr(subprocess, "run", lambda argv, **k: spawned.append(list(argv)))
+
+    def _busy(port):
+        raise click.ClickException(f"Port {port} is already in use")
+
+    monkeypatch.setattr("bifrost.commands.solution._ensure_port_free", _busy)
+
+    result = CliRunner().invoke(solution_group, ["start"])
+    assert result.exit_code == 1
+    assert "already in use" in result.output
+    assert spawned == []  # no npm install happened


### PR DESCRIPTION
Last item from the 2026-07-09 solution-CLI review sweep.

`scaffold-app` freezes `<api_url>/api/sdk/download` into the app's `package.json` at scaffold time. Scaffold against an ephemeral debug-stack port (or offline, which falls back to `localhost:8000`) and `npm install` breaks days later with nothing connecting the error back to the frozen URL.

`start` now heals the URL before installing: if the `bifrost` dep is a `/api/sdk/download` URL pointing at a different instance than the bound one, it's rewritten and dependencies reinstall (even when `node_modules` exists — the stale tarball is what needs replacing). Only the scaffold-written shape is touched; user-pinned `file:`/registry specs are left alone.

Verified: 5224 unit tests, pyright/ruff clean; live drive — froze the dep to a dead port, ran `start`, watched it repoint + reinstall.

Fixes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)